### PR TITLE
lupdate: remove location tags to avoid excessive conflicts

### DIFF
--- a/Seamly2D.pro
+++ b/Seamly2D.pro
@@ -15,7 +15,7 @@ SUBDIRS = \
 out.depends = src
 
 qtPrepareTool(LUPDATE, lupdate)
-lupdate.commands = $$LUPDATE -noobsolete -locations relative $$shell_path($${PWD}/share/translations/translations.pro)
+lupdate.commands = $$LUPDATE -noobsolete -locations none $$shell_path($${PWD}/share/translations/translations.pro)
 lupdate.commands += && $$LUPDATE -noobsolete $$shell_path($${PWD}/share/translations/measurements.pro)
 
 QMAKE_EXTRA_TARGETS += lupdate

--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>O programu Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Stránky: %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Nelze otevřít váš výchozí prohlížeč</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Sestaveno %3 v %2 {1 ?}</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>Přidat předmět</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Chyba při zpracování souboru. Program bude ukončen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Chyba. Špatný identifikátor. Program bude ukončen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Chyba. Nelze převést hodnotu. Program bude ukončen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Chyba. Prázdný parametr. Program bude ukončen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Chyba. Špatný identifikátor. Program bude ukončen.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Něco je špatně!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Chyba při zpracování souboru. Program bude ukončen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Chyba. Špatný identifikátor. Program bude ukončen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Chyba. Nelze převést hodnotu. Program bude ukončen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Chyba. Prázdný parametr. Program bude ukončen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Chyba. Špatný identifikátor. Program bude ukončen.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Něco je špatně!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Revize sestavení: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Nelze otevřít váš výchozí prohlížeč</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Sestaveno %3 v %2 {1 ?}</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Stránky: %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Vybrat druhý bod čáry</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Poloměr nemůže být záporný</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Úhly jsou si rovny</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Středový bod:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Poloměr nemůže být záporný</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation type="unfinished">Středový bod:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Vybrat druhý bod úhlu</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Vybrat třetí bod úhlu</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation type="unfinished">Seznam bodů</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Cesta:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Vybrat bod osy</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation type="unfinished">Středový bod:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Poloměr nemůže být záporný</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished">Úhly jsou si rovny</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Vybrat první bod čáry</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Vybrat druhý bod čáry</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished">Cesta</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Přídavek na šev</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Šířka:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished">Výchozí</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Převrátit</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Nepodařilo se připravit data pro vytvoření rozvržení</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Vybrat druhý bod</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Čára_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>První čára</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Druhá čára</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Vybrat druhý bod první čáry</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Vybrat první bod druhé čáry</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Vybrat druhý bod druhé čáry</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>První bod čáry</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Vybrat druhý bod čáry</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Vybrat bod osy</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Bod osy</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Druhý bod čáry</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Míry</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Středový bod</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Jednotky:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Centimetry</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Palce</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Vybrat druhý bod čáry</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Popis střihu</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Výšky a velikosti</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Všechny výšky (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Všechny velikosti (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Výška:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation type="unfinished">bez názvu</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation type="unfinished">Cesta:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Střih</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Vybrat bod středu oblouku</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Vybrat druhý bod čáry</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Střih</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Předvolby</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Nastavení</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Vybrat první bod čáry</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Vybrat druhý bod čáry</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Souřadnice na listu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Souřadnice</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Základní bod</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>První bod</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Druhý bod</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Vybrat poslední bod čáry</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Seznam bodů</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Vybrat bod cesty křivky</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Cesta:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Prázdné pole</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Hodnota nemůže být 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Chyba zpracování: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>První bod</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Druhý bod</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Vybrat druhý bod osy</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Vybrat první bod</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Vybrat druhý bod</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Poškozený vzorec</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Zpět</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Opravit vzorec</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>Z&amp;rušit</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">Vypočítaná hodnota</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Vzorec</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Detaily</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Čára</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Úhel</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Křivka</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Oblouk</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Poloměr</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Prázdné pole</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Chyba zpracování: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Nástroj</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Upravit vzorec</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Míry</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Vložit proměnnou do vzorce</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Skrýt prázdné míry</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Délka čáry</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Délka křivky</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Úhel čáry</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished">Upravit</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished">Nepodařilo se uložit soubor</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">Chyba souboru.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Velikost</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Výška</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Cesta:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - Základní bod</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished">Křivka_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Oblouk_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished">Upravit</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">Historie</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Základní bod</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished">Křivka_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Oblouk_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Popis</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Šířka:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Výška:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished">Potvrdit smazání</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Opravdu chcete smazat?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Převrátit</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Program je poskytován TAK JAK JE bez JAKÉKOLIV ZÁRUKY JAKÉHOKOLIV DRUHU, VČETNĚ ZÁRUKY VZHLEDU, PRODEJNOSTI A VHODNOSTI PRO DANÝ ÚČEL.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation>Středový bod:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Poloměr nemůže být záporný</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukázat celý výpočet v okně se zprávami&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Poloměr nemůže být záporný</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Předlohy:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Šířka:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Výška:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Otočit obrobek</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Otočit o</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>stupňů</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Tři skupiny: velká, prostřední, malá</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Dvě skupiny, malá, velká</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centimetry</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Palce</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Pixely</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6623,84 +5191,67 @@ Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6708,32 +5259,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6741,2660 +5286,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Nástroje na vytváření bodů.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Bod</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Nástroje na vytváření čar.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Čára</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Nástroje na vytváření křivek.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Křivka</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Nástroje na vytváření oblouků.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Oblouk</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;Soubor</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Nápověda</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Míry</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nový</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Vytvořit nový střih</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Otevřít</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Otevřít</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Otevřít soubor se střihem</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Uložit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Uložit střih</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Uložit j&amp;ako...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Uložit dosud neuložený střih</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Detaily</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Nástroje ukazovátka</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Historie</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>O &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;O programu Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>&amp;Ukončit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Předvolby</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Nahlásit chybu</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Zobrazit nápovědu na internetu</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>O Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Uložit jako</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Nepodařilo se uložit soubor</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Otevřít soubor</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Chyba při zpracování souboru.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Chyba. Nelze převést hodnotu.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Chyba. Prázdný parametr.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Chyba. Špatný identifikátor.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Chyba při zpracování souboru (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Chybný identifikátor.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>Soubor uložen</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>Bez názvu.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>Střih byl změněn.
 Chcete uložit své změny?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Zpět</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Znovu</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>Tento soubor je již otevřen v jiném okně.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Nesprávné jednotky.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>Soubor nahrán</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Seamly2D nebyla vypnuta správně. Chcete znovu otevřít soubory (%1), které jste měli otevřeny?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Znovu otevřít soubory.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Rozvržení</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation type="unfinished">Výška:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation type="unfinished">Individuální míry</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Soubory se střihy</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished">Vypočítaná hodnota</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished">Vzorec</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished">Upravit</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">O programu Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">bez názvu</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>střih</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished">Výchozí</translation>
     </message>
@@ -9402,86 +7288,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Vytvoření souboru &apos;%1&apos; se nezdařilo! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Vážná chyba!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Nepodařilo se připravit data pro vytvoření rozvržení</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Střih</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9489,148 +7355,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished">Soubor</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Nový</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Uložit</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Uložit jako</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished">Nápověda</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9638,123 +7474,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
@@ -9763,18 +7578,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9782,37 +7589,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Jednotky:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9820,12 +7620,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9833,7 +7631,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9841,7 +7638,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9849,7 +7645,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9857,7 +7652,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9865,7 +7659,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9873,7 +7666,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9881,52 +7673,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Individuální</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Centimetry</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Palce</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9934,87 +7716,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10022,887 +7787,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished">Výchozí</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Šířka:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished">Výška:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Převrátit</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Volby</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Chyba zpracování: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Cesty</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10910,218 +8422,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11129,27 +8589,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11157,77 +8612,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11235,139 +8675,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11375,62 +8770,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
@@ -11438,316 +8821,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished">Interval:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished">Jazyk</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimetry</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished">Palce</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished">Zpět</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11755,582 +9072,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Bod</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Čára</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Křivka</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Oblouk</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Detaily</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished">Rozvržení</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished">Obrazový výstup</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Šířka:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Cesta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation type="unfinished">Výchozí</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished">Upravit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished">Otevřít adresář</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12338,272 +9487,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Přídavek na šev</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Šířka:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Cesty</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Šířka</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Výška</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12611,7 +9690,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>Postaveno na Qt %1 (%2, %3 bit)</translation>
     </message>
@@ -12619,155 +9697,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Začněte vytvořením nového dílu střihu.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>palec</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Vlastnost</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished">Nelze převést parametr toUInt</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished">Nelze převést parametr toBool</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished">Obdržen prázdný parametr</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished">Nelze převést parametr toDouble</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished">Obdržen chybný identifikátor parametru. Vyžaduje pouze identifikátor &gt; 0.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12775,15 +9822,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
@@ -12792,217 +9835,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Nalezen neočekávaný řetězec &quot;$TOK$&quot; na pozici $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Vnitřní chyba</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Neplatný název funkce, proměnné nebo konstanty: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Neplatný identifikátor binárního operátoru: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Neplatný identifikátor zaváděcího operátoru: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Neplatný identifikátor ukončujícího operátoru: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Neplatný ukazatel na funkci zpětného volání.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>Výraz je prázdný.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Neplatný ukazatel na proměnnou.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Nalezen neočekávaný operátor &quot;$TOK$&quot; na pozici $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Neočekávaný konec výrazu v poloze $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Neočekávaný oddělovač argumentů v poloze $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Neočekávaná závorka &quot;$TOK$&quot; v poloze $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Neočekávaná funkce &quot;$TOK$&quot; v poloze $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Nalezena neočekávaná hodnota &quot;$TOK$&quot; v poloze $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Nalezena neočekávaná proměnná &quot;$TOK$&quot; v poloze $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Argumenty funkce použity bez funkce (pozice: $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Chybějící závorka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Příliš mnoho parametrů funkce &quot;$TOK$&quot; ve výrazu v poloze $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Příliš málo parametrů funkce &quot;$TOK$&quot; ve výrazu v poloze $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Dělení nulou</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Chyba domény</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Střet názvu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>Neplatná hodnota pro prioritu operátoru (musí být větší nebo rovný nule).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>uživatelem stanovený binární operátor &quot;$TOK$&quot; je ve střetu s vestavěným operátorem.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Neočekávaný řetězec textu nalezen v poloze $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Neukončený řetězec začínající v poloze $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>Řetězcová funkce volána s argumentem, který není řetězec.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>Řetězcová hodnota použita tam, kde je očekávaný číselný argument.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Žádné vhodné přetížení pro operátor &quot;$TOK$&quot; v poloze $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>Výsledek funkce je řetězec.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Chyba při zpracování.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>Desetinný oddělovač je shodný s oddělovačem argumentů funkcí.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Operátoru &quot;$TOK$&quot; musí předcházet ukončující závorka.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>V operátoru if-then-else chybí část else</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Chybně umístěná dvojtečka v poloze $POS$</translation>
@@ -13011,7 +10018,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13019,7 +10025,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13027,12 +10032,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13040,7 +10043,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13048,7 +10050,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13056,7 +10057,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13064,88 +10064,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Jazyk</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Výška:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13153,52 +10135,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Cesta</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished">Výchozí</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished">Upravit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished">Otevřít adresář</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13206,102 +10178,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished">Jednotky:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimetry</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Palce</translation>
     </message>
@@ -13309,92 +10260,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished">Jednotky:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimetry</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Palce</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13402,12 +10334,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13415,1071 +10345,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished">Soubor</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Nový</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished">Otevřít</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Uložit</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Uložit jako</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished">Upravit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished">Zpět</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Míry</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Bod</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Čára</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Detaily</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished">Rozvržení</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">Historie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished">Nápověda</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14487,12 +11200,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14500,42 +11211,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14543,7 +11246,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14551,7 +11253,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14559,818 +11260,625 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Vzorec</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Základní hodnota</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>Ve velikostech</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>Ve výškách</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Detaily</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Název:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Cesta:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Křestní jméno:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Příjmení:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>Soubor</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Míry</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>O &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Předvolby</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>Tento soubor je již otevřen v jiném okně.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Chyba souboru.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Nepodařilo se uložit soubor</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Uložit jako</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Chyba zpracování: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Individuální míry</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>bez názvu</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Prázdné pole</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Otevřít soubor</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>muž</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>žena</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>O Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation type="unfinished">Výška:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation>Soubory se střihy</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15378,7 +11886,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15386,22 +11893,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15409,22 +11912,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15432,47 +11931,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">První bod</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Druhý bod</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Čára_</translation>
     </message>
@@ -15480,47 +11970,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Nástroj Spojení</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Vyberte druhý bod</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Vyberte jedinečný bod</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15528,7 +12009,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15536,17 +12016,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Příště se již neptat</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Příště se již nept&amp;at</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>Příště již nezobrazovat</translation>
     </message>
@@ -15554,57 +12031,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Nebylo možné získat informace o verzi.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>Příliš mnoho značek &lt;%1&gt; v souboru.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Verze &quot;%1&quot; neplatná.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Verze &quot;0.0.0&quot; neplatná.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Neplatná verze. Nejnižší podporovaná verze je %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Neplatná verze. Nejvyšší podporovaná verze je %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Chyba. Žádný jedinečný identifikátor.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>Nebylo možné změnit verzi.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation type="unfinished">Neočekávaná verze &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15612,7 +12078,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15620,22 +12085,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15643,13 +12104,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
@@ -15657,23 +12115,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>Nelze najít nástroj v tabulce.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15681,7 +12134,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15689,12 +12141,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
@@ -15702,283 +12152,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Potvrdit smazání</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Opravdu chcete smazat?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished">Upravit nesprávný vzorec</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15986,302 +12379,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Úhel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Program na tvorbu střihů.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Soubor se střihem.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16289,43 +12622,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16333,55 +12657,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>Nelze najít předmět</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation>Nelze najít předmět</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation>Nelze najít předmět. Neodpovídající typ.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16389,12 +12700,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished">Nedostatek bodů na vytvoření křivky.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished">Tato křivka neexistuje.</translation>
     </message>
@@ -16402,52 +12711,42 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>Nelze otevřít soubor %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Nelze otevřít soubor se schématem %1:
 %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation>Chyba při ověřování souboru %3 na řádku %1, ve sloupci %2</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation>Chyba při zpracování souboru %3 na řádku %1, ve sloupci %2</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation>Nepodařilo se získat uzel</translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>Tento identifikátor není jedinečný.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16455,27 +12754,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16483,7 +12777,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16491,11 +12784,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
@@ -16503,7 +12791,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16511,7 +12798,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16519,7 +12805,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16527,12 +12812,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>Pravda</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>Nepravda</translation>
     </message>
@@ -16540,12 +12823,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Adresář</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Otevřít soubor</translation>
     </message>
@@ -16553,335 +12834,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Chyba při zpracování souboru.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Chyba. Nelze převést hodnotu.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Chyba. Prázdný parametr.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Chyba. Špatný identifikátor.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Chyba při zpracování souboru (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Chyba při vytváření nebo aktualizaci jediného bodu</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu na konci čáry</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu podél čáry</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu ramene</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu kolmice</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu osy úhlu</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu dotyku</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation>Chyba při vytváření nebo aktualizaci modelovacího bodu</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Chyba při vytváření nebo aktualizaci výšky</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Chyba při vytváření nebo aktualizaci trojúhelníku</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu vyjmutí křivky</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu cesty vyjmutí křivky</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu vyjmutí oblouku</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu průsečíku křivky a osy</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation>Chyba při vytváření nebo aktualizaci bodu průsečíku křivky a osy</translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Chyba při vytváření nebo aktualizaci čáry</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Chyba při vytváření nebo aktualizaci jednoduché křivky</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Chyba při vytváření nebo aktualizaci cesty křivky</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation>Chyba při vytváření nebo aktualizaci modelovací jednoduché křivky</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation>Chyba při vytváření nebo aktualizaci cesty modelovací křivky</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Chyba při vytváření nebo aktualizaci jednoduchého oblouku</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation>Chyba při vytváření nebo aktualizaci modelovacího oblouku</translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16889,17 +13081,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16907,12 +13096,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16920,14 +13107,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>Nedostatek bodů na vytvoření křivky.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>Tato křivka neexistuje.</translation>
     </message>
@@ -16935,17 +13118,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Úhel</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
@@ -16953,27 +13133,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16981,37 +13156,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17019,7 +13187,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
@@ -17027,12 +13194,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17040,32 +13205,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Oblouk</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17073,18 +13232,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Křivka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17092,18 +13247,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Křivka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17111,7 +13262,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
@@ -17119,28 +13269,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17148,17 +13292,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Úhel</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
@@ -17166,12 +13307,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Úhel</translation>
     </message>
@@ -17179,7 +13318,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
@@ -17187,27 +13325,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Úhel</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17215,17 +13348,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Úhel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
@@ -17233,7 +13363,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17241,12 +13370,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">První bod čáry</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Druhý bod čáry</translation>
     </message>
@@ -17254,27 +13381,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Středový bod</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Úhel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17282,714 +13404,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Základní bod</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation>Středový bod:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Souřadnice</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Čára</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">První čára</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Druhá čára</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Origin point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Oblouk_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished">Křivka_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Čára_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Středový bod</translation>
     </message>
@@ -17997,12 +13803,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18010,17 +13814,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Úhel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
@@ -18028,12 +13829,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18041,12 +13840,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18054,12 +13851,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18067,17 +13862,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Délka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Úhel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
@@ -18085,1552 +13877,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>palce</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished">CestaKřivky</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished">Úhel1CestaKřivky</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished">Úhel2CestaKřivky</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Čára_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Úhelčáry_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Oblouk_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Křivka_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19639,17 +15174,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19657,7 +15189,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19665,7 +15196,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19673,7 +15203,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19681,12 +15210,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19694,7 +15221,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19702,7 +15228,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19710,17 +15235,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Cesta křivky&lt;/b&gt;: vyberte tři nebo více bodů</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19728,47 +15250,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19776,47 +15289,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>Über Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Webseite: %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Standardbrowser kann nicht geöffnet werden</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation>Von links nach rechts</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation>Von rechts nach links</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Erstellt am %1 um %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation>Über</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation>Baudaten in die Zwischenablage kopieren</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation>Seamly 2D</translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation>Erstellungsdatum:</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation>Qt-Version:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation>CPU:</translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation>Compiler:</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation>Revision:</translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation>Version:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation>Architektur</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation>OS:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation>OS-Version:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation>Standort</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation>Land:</translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation>Dezimalpunkt:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation>Skriptname:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation>System-Codec:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation>Sprache:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation>Textrichtung:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation>Positives Vorzeichen:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation>Negatives Vorzeichen:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation>Anmeldung</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation>Argumente:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation>Mitwirkende</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Nach Updates suchen</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation>Installationsprogramm runterladen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation>unbekannt</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation>Entwurfsblock hinzufügen %1</translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>Gruppe hinzufügen</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation>Objekt zur Gruppe hinzufügen</translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation>Schnittteil hinzufügen</translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>Objekt hinzufügen</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation>Zur Gruppe hinzufügen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation>Ankerpunkt</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation>Ankerpunkt Werkzeug</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation>Punkt:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation>Schnittteil:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Fehler beim Verarbeiten der Datei. Das Programm wird geschlossen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Fehler - unbekannte ID. Das Programm wird geschlossen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Fehler - Wert kann nicht konvertiert werden. Das Programm wird geschlossen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Fehler - leerer Parameter. Das Programm wird geschlossen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Fehler - falsche ID. Das Programm wird geschlossen.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Etwas ist schiefgegangen!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Auswertungsfehler: %1. Programm wird beendet.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Ausnahme ausgelöst: %1. Programm wird beendet.</translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Fehler beim Parsen der Datei. Das Programm wird beendet.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Fehler - ungültige ID. Das Programm wird beendet.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Fehler - Wert kann nicht konvertiert werden. Das Programm wird beendet.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Fehler - leerer Parameter. Das Programm wird beendet.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Fehler - falsche ID. Das Programm wird beendet.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Etwas ist schiefgegangen!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Parser Fehler: %1. Programm wird beendet.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Ausnahme ausgelöst: %1. Programm wird beendet.</translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation>Seamly2Ds Maßsatzeditor.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation>Die Maßsatzdatei.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation>Die Basiskörperhöhe</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation>Die Basisgröße</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation>Schnittmusterdatei Einheit festlegen: cm, mm, Zoll.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation>Die Schnittmuster Einheit</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation>Ungültige Basisgröße. Muss cm, mm oder Zoll sein .</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation>Es&apos; kann nicht begonnen werden, auf eingehende Verbindungen über den Namen zu hören&apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation>Der Test Modus unterstützt nicht das Öffnen mehrerer Dateien.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation>Bitte stellen Sie eine Eingabedatei bereit.</translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation>Mit der Basisgröße öffnen. Gültige Werte: %1cm.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation>Ungültiges Parameter für die Basiskörperhöhe. Muss %1cm sein.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation>Ungültiges Parameter für die Basisgröße. Muss in %1cm sein .</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation>Mit der Basiskörperhöhe öffnen. Gültige Werte: %1cm.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation>Verwenden zum Einheiten testen. Führen Sie das Programm aus und öffnen Sie eine Datei, ohne das Hauptfenster anzuzeigen.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Deaktivieren Sie die Skalierung mit hoher Auflösung. Rufen Sie diese Option auf, wenn es Probleme mit der Skalierung gibt (standardmäßig ist die Skalierung aktiviert). Alternativ können die %1 Umgebungsvariablen genutzt werden.</translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation>Taschenrechner</translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation>±</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation>Rücktaste</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation>Alle löschen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation>MC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation>MR</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation>MS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation>M+</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation>÷</translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation>×</translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation>Sqrt</translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation>x²</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation>1/x</translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation>=</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation>Taschenrechner</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation>####</translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation>Dezimaltabelle</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>Gruppe löschen</translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>Werkzeug löschen</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation>Entwurfsblock löschen %1</translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>Löschwerkzeug</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation>Über SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation>SeamlyMe Version</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation>Build Revision: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation>Dieses Programm ist Teil des Seamly2D Projekts.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation>Installationsprogramm runterladen</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation>Nach Updates suchen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation>Ihr Standardbrowser kann nicht geöffnet werden</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation>Erstellt am %1 um %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation>Webseite: %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation>unbekannt</translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Zweiten Punkt der Linie auswählen</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Länge bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>Erster Punkt der Linie</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Zweiter Punkt der Linie</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation>Punkt - auf einer Linie</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -781,136 +628,102 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius kann nicht negativ sein</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Winkel sind identisch</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Radius bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Ersten Winkel bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Zweiten Winkel bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>Erster Winkel:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Zweiter Winkel:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Mittelpunkt:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Mittelpunkt des Bogens auswählen</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation>Bogen - Radius und Winkel</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+613"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+484"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Berechnung des ersten Winkels&lt;/span&gt;&lt;br/&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position .&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Berechnung des Winkels&lt;/span&gt;&lt;br/&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position .&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
@@ -919,127 +732,96 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigenn&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Radius bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Ersten Winkel bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Bogenlänge bearbeiten</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius kann nicht negativ sein</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>Länge kann nicht gleich 0 sein</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>Erster Winkel:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Mittelpunkt:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation>Bogen - Radius und Länge</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width= 370&gt;&lt;tr&gt;&lt;td align =left width=300&gt;&lt;b&gt;Winkelberechnung&lt;/b&gt;&lt;br&gt;Winkel sind in Grad angegeben, d.h. ein kompletter Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position.&lt;/td&gt;&lt;td align = rechts valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -1047,107 +829,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Zweiten Punkt des Winkels auswählen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Dritten Punkt des Winkels auswählen</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Länge bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Dritter Punkt:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation>Punkt - auf einer Winkelhalbierenden</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -1155,77 +916,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Dritter Punkt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Vierter Punkt:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Zweiten Punkt der Kurve auswählen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Dritten Punkt der Kurve auswählen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Vierten Punkt der Kurve auswählen</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>Ungültige Spline</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation>Kurve - fixiert</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
@@ -1233,57 +979,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Punkt:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>Liste der Punkte</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation>Ungültiger Spline Pfad</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation>Spline - fixiert</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation>Verzeichnis:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
@@ -1291,98 +1026,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Achsenpunkt wählen</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Winkel bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Achsenpunkt:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Kurve:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation>Schnittpunkt - Kurve und Winkel</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Winkelberechnung&lt;/b&gt;&lt;br&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -1390,67 +1106,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Länge bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Bogen:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation>Punkt - auf Bogen</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -1458,67 +1161,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Länge bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Kurve:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation>Punkt - auf einer Kurve</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -1526,67 +1216,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Länge bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Kurve:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation>Punkt - auf Spline</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -1594,22 +1271,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation>Etiketten Datum-Zeit Editor</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation>Format:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation>Gib ein Format ein</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;leer&gt;</translation>
     </message>
@@ -1617,170 +1290,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation>Radius1:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation>Radius2:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation>Erster Winkel:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation>Zweiter Winkel:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation>Drehwinkel:</translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation>Mittelpunkt:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation>Mittelpunkt des Bogens auswählen</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-4"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Winkel sind gleich</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation>Radius 1 bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation>Radius 2 bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Ersten Winkel bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Zweiten Winkel bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation>Drehwinkel bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation>Bogen - elliptisch</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-307"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+874"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Berechnung des ersten Winkels&lt;/span&gt;&lt;br/&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position .&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Berechnung des zweiten Winkels&lt;/span&gt;&lt;br/&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersin. Null Grad ist in der 3 Uhr Position .&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Berechnung des Drehwinkels&lt;/span&gt;&lt;br/&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position .&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="-121"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius kann nicht negativ sein</translation>
     </message>
@@ -1788,106 +1413,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Winkel bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Länge bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Startpunkt:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation>Punkt - Länge und Winkel</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Winkelberechnung&lt;/b&gt;&lt;br&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -1895,47 +1497,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Exportoptionen</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>Mit Überschrift</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation>Codec:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Trenner</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>Komma</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>Semikolon</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Leertaste</translation>
     </message>
@@ -1943,72 +1536,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Ersten Punkt der Linie auswählen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Zweiten Punkt der Linie auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Startpunkt:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation>Punkt - schneidet Linie und Senkrechte</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Eindeutiger Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wählen Sie einen eindeutigen Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -2016,356 +1595,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation>Werkzeug für internes Verzeichnis</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation>Verzeichnis</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation>Unbenannter Pfad</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation>Bezeichnung für Dein Verzeichnis erstellen</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation>Teil:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation>Reihe an den Anfang der Liste verschieben</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation>Reihe eine Reihe nach oben verschieben</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation>Reihe eine Reihe nach unten verschieben</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation>Reihe an das Ende der Liste verschieben</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation>Der Pfad ist eine Schnittlinie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation>Auf dem Zuschnitt anzeigen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation>Fertig!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation>Nahtzugabe</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation>Breite:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation>Knoten</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation>Knoten:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation>Vorher:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation>Zur Standardweite zurück</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation>Nachher:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation>Markierungen</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation>Markierung:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation>Schlitz</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation>T Markierung</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation>U Markierung</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation>V innen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation>V aussen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation>Burg</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation>Unterart</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation>Geradeaus</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation>Halbierende</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation>Auswählen, um den Eckpunkt als Markierung festzulegen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation>Schnittpunkt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation>Markierungswinkel auf Standard zurücksetzen.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation>Zählen:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation>Markierung auf Standard zurücksetzen.</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation>Diese Option hat nur dann eine Auswirkung wenn die zweite Markierung auf der Nahtlinie in der allgemeinen Einstellung aktiviert ist. Die Option hilft die zweite Markierung nur für diese Markierung zu deaktivieren.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation>Zweite Markierung auf der Nahtlinie anzeigen</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation>Länge der Markierung auf Standard zurücksetzen.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation> Breite:</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation>Hauptpfad Objekte auswählen, Mit &lt;b&gt;SHIFT&lt;/b&gt; die Kurvenrichtung umkehren, mit &lt;b&gt;ENTER&lt;/b&gt; Pfaderstellung abschliessen </translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation>Umkehren</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation>Aktuelle Nahtzugabe</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation>Nahtzugabenbreite bearbeiten</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation>Nahtzugabenbreite vorher bearbeiten</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation>Nahtzugabenbreite nachher bearbeiten</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation>Internes Verzeichnis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation>Individuelle Nahtzugabe</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation>Du brauchst mehr Punkte!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation>Startpunkt der&lt;b&gt;individuellen Nahtzugabe/b&gt; kann nicht gleichzeitig der Endpunkt sein!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation>Du hast doppelte Punkte!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation>Jeder Punkt des &lt;b&gt;individuelle Nahtzugaben&lt;/b&gt; Verzeichnis muss eindeutig sein!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation>Die Detailliste ist leer!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation>Bitte ein Detail zum Einfügen in die Liste auswählen!</translation>
     </message>
@@ -2373,28 +1870,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Daten für die Erstellung des Layouts konnten nicht vorbereitet werden</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Ein Layout erstellen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation>Angeordnete Schnittteile: %1 von %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Suche beste Position für Schnittteile. Bitte warten.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation>Ein oder mehrere Schnittteile sind größer als das ausgewählte Papierformat. Bitte ein größeres Papierformat wählen.</translation>
     </message>
@@ -2402,58 +1893,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Zweiten Punkt wählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation>Linie - zwischen Punkten</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation>Linie_</translation>
     </message>
@@ -2461,64 +1940,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Erste Linie</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Zweite Linie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Zweiten Punkt der ersten Linie auswählen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Ersten Punkt der zweiten Linie auswählen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Zweiten Punkt der zweiten Linie auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation>Punkt - schneidet Linien</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -2526,124 +1991,100 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Erster Punkt der Linie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Zweiten Punkt der Linie auswählen</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Achsenpunkt auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Achsenpunkt</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Zweiter Punkt der Linie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Winkel bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Achsenpunkt:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation>Schnittpunkt - Linie und Achse</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wählen Sie einen eindeutigen Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Winkelberechnung&lt;/b&gt;&lt;br&gt;Winkel werden in Grad angegeben, d.h. ein vollständiger Kreis entspricht 360 Grad, positive Werte bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -2651,22 +2092,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Maße</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation>ME Database - füge bekannte Maße hinzu</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation>Finden:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation>Suche</translation>
     </message>
@@ -2674,47 +2111,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation>Spiegeln an einer Achse</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation>Achsenpunkt:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation>Achsentyp:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation>Achsendrehpunkt wählen</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation>Einen Achsendrehpunkt wählen, der nicht zur Liste der Objekte gehört</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation>Vertikale Achse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation>Horizontale Achse</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
@@ -2722,47 +2150,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation>Spiegeln an einer Linie</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation>Punkt 1 der Linie:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation>Punkt 2 der Linie:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation>Wähle ersten Punkt der Spiegellinie</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation>Wähle einen ersten Punkt der Spiegellinie, der nicht zur Objektliste gehört</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation>Wähle zweiten Punkt der Spiegellinie</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation>Wähle einen zweiten Punkt der Spiegellinie, der nicht zur Objektliste gehört</translation>
     </message>
@@ -2770,93 +2189,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation>Winkel bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Länge bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation>Ausgangspunkt:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation>Drehung:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Mittelpunkt</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation>Drehung bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Winkelberechnung&lt;/b&gt;&lt;br&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotationswinkelberechnung&lt;/span&gt;&lt;br/&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -2864,42 +2261,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Einheiten:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Zentimeter</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Zoll</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Eindeutige Schnittteil Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Wähle eine eindeutige Bezeichnung für das Schnittteil.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>Neues Schnittmuster</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation>Millimeter</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation>Entwurfsblock Bezeichnung:</translation>
     </message>
@@ -2907,107 +2296,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Zweiten Punkt der Linie auswählen</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Länge bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation>Punkt - auf einer Senkrechten</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation>Drehung:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotationswinkel&lt;/span&gt;&lt;br/&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position .&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -3015,210 +2383,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Schnittmusterbeschreibung</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Körperhöhen und Größen</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Alle Körperhöhen (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Alle Größen (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Standardkörperhöhe und -größe</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Benutzerdefiniert</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Körperhöhe:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Größe:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Sicherheit</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Schreibgeschützt öffnen</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation>Kontextmenü zum Bearbeiten aufrufen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>Kein Bild</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Bild löschen</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Bild ändern</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Bild in Datei speichern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Bild anzeigen</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation>Bild für Schnittmuster</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Bilder</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Datei speichern</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>unbenannt</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Verzeichnis:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Im Explorer anzeigen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;leer&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>Die Datei wurde noch nicht gespeichert.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Im Finder anzeigen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Name des Schnittmusters:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Nummer des Schnittmusters:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Name der Firma/des Designers:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Name des Kunden:</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation>Vom Mehrgrößen Maßsatz</translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Schnittmuster</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation>Für technische Anmerkungen</translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation>Etikettendaten</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation>Etikettenvorlage:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit template</source>
         <translation>Vorlage bearbeiten</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation>Datumformat:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation>Zeitformat:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation>Etikettendaten sichern.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation>Etiketten Daten wurden geändert. Sollen die Änderungen vor der Etikettenvorlagen Bearbeitung gespeichert werden ?</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation>Schnittmuster Einstellungen</translation>
     </message>
     <message>
-        <location line="+1195"/>
         <source>Edit pattern label</source>
         <translation>Schnittmuster Etikett bearbeiten</translation>
     </message>
@@ -3226,47 +2550,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Wähle einen Bogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Tangentenpunkt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Bogen:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Übernehmen:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Punkt - schneidet Bogen und Tangente</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -3274,87 +2589,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Mittelpunkt des Bogens auswählen</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Zweiten Punkt der Linie auswählen</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Radius bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation>Mittelpunkt des Bogens:</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation>Punkt - schneidet Bogen und Linie</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation>Erster Linienpunkt:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation>Zweiter Linienpunkt</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -3362,47 +2660,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation>Zweiten Bogen auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>Erster Bogen:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Zweiter Bogen:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Übernehmen:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation>Punkt - schneidet Bögen</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -3410,52 +2699,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>Erste Kurve:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Zweite Kurve:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Zweite Kurve auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation>Punkt - schneidet Kurven</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation>Vertikale Aufnahme:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation>Horizontale Aufnahme:</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -3463,27 +2742,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Schnittmuster</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation>Anwendungsvoreinstellungen</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation>Generell</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation>Dateipfad</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation>Grafiken</translation>
     </message>
@@ -3491,62 +2765,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Drehung</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation>Winkel bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation>Drehpunkt:</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation>Achsendrehpunkt wählen</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation>Achsendrehpunkt wählen, der nicht zur Liste der Objekte gehört</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Winkelberechnung&lt;/b&gt;&lt;br&gt;Winkel sind in Grad angegeben, d.h. ein voller Kreis entspricht 360 Grad, positive Werte eines Winkels bedeuten gegen den Uhrzeigersinn, negative Werte bedeuten im Uhrzeigersinn. Null Grad ist in der 3 Uhr Position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
@@ -3555,17 +2817,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation>Vorlieben</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation>Konfiguration</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation>Dateipfade</translation>
     </message>
@@ -3573,107 +2832,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Ersten Punkt der Linie auswählen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Zweiten Punkt der Linie auswählen</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Länge bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Dritter Punkt:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation>Punkt - Länge zur Linie</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -3681,47 +2919,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Koordinaten auf dem Blatt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Koordinaten</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation>Basispunkt</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation>X-Koordinate:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation>Y-Koordinate:</translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -3729,148 +2958,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Erster Punkt</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Zweiter Punkt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Letzten Punkt der Kurve auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>Ungültige Spline</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation>Winkel des ersten Kontrollpunktes bearbeiten</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation>Winkel des zweiten Kontrollpunktes bearbeiten</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation>Länge des ersten Kontrollpunktes bearbeiten</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation>Länge des zweiten Kontrollpunktes bearbeiten</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation>Länge kann nicht negativ sein</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation>Kurve - interaktiv</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
@@ -3878,163 +3065,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Liste von Punkten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Punkt für den Kurvenpfad auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Punkt:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation>Erster Kontrollpunkt</translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation>Zweiter Kontrollpunkt</translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation>Ungültiger Spline Pfad</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation>Winkel des ersten Kontrollpunktes bearbeiten</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation>Winkel des zweiten Kontrollpunktes bearbeiten</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation>Länge des ersten Kontrollpunktes bearbeiten</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation>Länge des zweiten Kontrollpunktes bearbeiten</translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation>Länge kann nicht negativ sein</translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation>Nicht verwendet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation>Spline - interaktiv</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation>Verzeichnis:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation>Ergebniswert</translation>
     </message>
@@ -4042,108 +3184,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Leeres Eingabefeld</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Wert kann nicht 0 sein</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Auswertungsfehler: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Erster Punkt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Zweiter Punkt</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation>Höchster Punkt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation>Tiefster Punkt</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation>Punkt ganz links</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation>Punkt ganz rechts</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation>nach Länge</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation>nach Schnittpunkten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation>nach Symmetrie der ersten Ecke</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation>nach Symmetrie der zweiten Ecke</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation>nach rechtem Winkel der ersten Ecke</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation>nach rechtem Winkel der zweiten Ecke</translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Ungültiges Ergebnis: Der Wert ist unendlich oder NaN, Bitte die Berechnung prüfen.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation>Wert kann nicht kleiner als 0 sein</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation>Ergebniswert</translation>
     </message>
@@ -4151,62 +3263,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Zweiten Punkt der Achse auswählen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Ersten Punkt wählen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Zweiten Punkt wählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation>Punkt - Schneidet Achse und Dreieck</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation>Erster Achsenpunkt:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation>Zweiter Achsenpunkt:</translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -4214,79 +3314,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation>Zweiten Ausgangspunkt auswählen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation>Ersten Abnäherpunkt auswählen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation>Zweiten Abnäherpunkt auswählen</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation>Dritten Abnäherpunkt auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation>Erster Ausgangspunkt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation>Zweiter Ausgangspunkt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation>Erster Abnäherpunkt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation>Zweiter Abnäherpunkt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation>Dritter Abnäherpunkt:</translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation>Abnäherlänge ausgleichen</translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation>Punktbezeichnung 1:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation>Punktbezeichnung 2:</translation>
     </message>
@@ -4294,27 +3377,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Defekte Formel</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Rückgängig</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Formel festlegen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Abbrechen</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Fehler beim Berechnen der Formel. Du kannst versuchen, den letzten Schritt rückgängig zu machen, oder die defekte Formel festlegen.</translation>
     </message>
@@ -4322,214 +3400,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation>Variablen</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation>Filter:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation>Liste nach Stichwort filtern</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation>Kundenvariablen</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation>Der berechnete Wert</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation>Formel</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation>Maß nach oben bewegen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Maß nach unten bewegen</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation>Benutzerdefinierte Variable hinzufügen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation>Benutzerdefinierte Variable entfernen</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation>Eindeutige Variablenbezeichnung</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation>Berechneter Wert:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation>Formel:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation>Beschreibung:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation>Aktualisiere ein Schnittmuster mit allen Änderungen die Du gemacht hast</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation>Linienlängen</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation>Linienwinkel</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation>Kurvenlängen</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation>Kurvenwinkel</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation>Kontrollpunktlängen</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation>Bogenradien</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation>Bogen</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation>Radius</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation>Leeres Eingabefeld.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation>Leeres Eingabefeld</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Ungültiges Ergebnis: Der Wert ist unendlich oder NaN, Bitte Deine Berechnung prüfen.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Auswertungsfehler: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation>Variable bearbeiten</translation>
     </message>
@@ -4537,17 +3563,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation>Werkzeug</translation>
     </message>
@@ -4555,148 +3578,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation>Formel bearbeiten</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation>Maße</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation>Kundenvariablen</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation>Linienlängen</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation>Linienwinkel</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation>Kurvenlängen</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation>Kurvenwinkel</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation> Kontrollpunktlängen</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation>Bogenradien</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation>Funktionen</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation>Formel:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation>Formel löschen</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation>Auf die Originalformel zurücksetzen</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation>Variable in Formel einfügen</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation>Maßvariablen die keinen Wert haben werden ausgeblendet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation>Leere Maße ausblenden</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation>Vollständige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation>Variablenliste nach Stichwort filtern</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation>Liste nach Stichwort filtern</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation>Maße</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation>Kundenvariable</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation>Linienlänge</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation>Kurvenlänge</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation>Linienwinkel</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation>Bogenradius</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation>Kurvenwinkel</translation>
     </message>
@@ -4704,37 +3697,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation>Gruppe hinzufügen</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation>Eindeutige Bezeichnung des Schnittteils</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation>Eindeutige Gruppenbezeichnung</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
@@ -4742,296 +3728,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation>Etikettvorlage bearbeiten</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation>Lösche das aktuelle und beginne ein neues Etikett</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation>Aus den Etikettenvorlagen importieren</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation>Etikett als Vorlage exportieren</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation>Fett</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation>Italic</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation>Richtet sich an der linken Ecke aus</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation>Zentriert horizontal im verfügbaren Platz</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation>Richtet sich an der rechten Ecke aus</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation>Zusätzliche Schriftgröße. Benutzen um eine Linie größer zu machen.</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation>Text:</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation>Textzeile</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation>Platzhalter einfügen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation>Einfügen...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation>Vorschau</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;leer&gt;</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation>Erstelle eine neue Vorlage</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation>Beim Erstellen einer neuen Vorlage überschreibt die aktuelle, möchtest Du fortfahren?</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation>Etikettvorlage</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation>Ettikettvorlage exportieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation>Vorlage</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation>Datei konnte nicht gespeichert werden</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation>Vorlage importieren</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation>Beim Import der Vorlage wird die aktuelle überschrieben, möchtest Du fortfahren?</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation>Dateifehler.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation>Zeit</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation>Name des Schnittmusters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation>Nummer des Schnittmusters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation>Firmen- oder Designername</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation>Name des Kunden</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation>Schnittmustererweiterung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation>Schnittmusterdateiname</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation>Maßsatz Dateiname</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation>Körperhöhe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation>Maßsatz Erweiterung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation>Schnittteil Buchstabe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation>Schnittteil Anmerkung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation>Schnittteil Ausrichtung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation>Schnittteil Drehung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation>Schnittteil Neigung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation>Schnittteil Bruch Position</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation>Bezeichnung des Schnittteils</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation>Menge</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation>Material: Stoff</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation>Stoff</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation>Material: Futter</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation>Futter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation>Material: Verstärkung</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation>Verstärkung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation>Material: Einlage</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation>Einlage</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation>Wort: Schnitt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation>Schnitt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation>Wort: im Bruch</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation>im Bruch</translation>
     </message>
@@ -5039,12 +3965,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation>(flache) Dateien</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation>Dateien</translation>
     </message>
@@ -5052,163 +3976,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation>Layout exportieren</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation>Binärform</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation>Text als Verzeichnis</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation>Verzeichnis:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation>Zielordner</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation>Pfad zum Zielordner</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation>Pfad zum Zielordner auswählen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation>Durchsuchen...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation>Dateiformat:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation>Dateiname:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation>Datei Basisname</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation>Qualität (0-100):</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation>Ränder</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation>Rechts:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation>Links:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation>Oben:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation>Unten:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation>Papierformat</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation>Vorlagen: </translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation>Orientierung: </translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation>Die Ausgangsdateibezeichnung entspricht keiner regulären Formulierung.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation>Ordner auswählen</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation>Versucht die ausserhalb des Formatbereichs liegenden Zahlen zu benutzen.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation>Ausgewähltes nicht vorhandenes Format.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation>Das Zielverzeichnis existiert nicht oder kann nicht gelesen werden.</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation>%1 besteht bereits.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation>%1 Datei mit Basisnamen %2 besteht bereits.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation>Möchtest Du diese ersetzen?</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation>Export bestätigen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation>Dateien exportieren:</translation>
     </message>
@@ -5216,7 +4107,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+230"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
@@ -5225,45 +4115,36 @@ Possibly the file is already being downloaded.</source>
 Möglicherweise wird die Datei bereits heruntergeladen.</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Feed download failed: %1.</source>
         <translation>Feed download ist fehlgeschlagen: %1.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-183"/>
         <source>File download failed: %1.</source>
         <translation>Dateidownload ist fehlgeschlagen: %1.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation>Download hat begonnen, der Installer öffnet sich, sobald der Download abgeschlossen ist</translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation>Es sind keine neuen Releases verfügbar.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation>Ein neuer Release %1 ist verfügbar.
 Möchtest Du diesen downloaden?</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Unable to open file
 %1
 for writing</source>
@@ -5273,369 +4154,286 @@ for writing</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation>Gruppenmanager</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation>Alle Gruppen anzeigen</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation>Alle Gruppen verbergen</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation>Alle Gruppen sperren</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation>Alle Gruppen entsperren</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation>Eine neue Gruppe der Liste zufügen</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation>Entferne die aktive Gruppe von der Liste</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation>Bearbeite die Gruppeneigenschaften</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation>Gruppen</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation>Gruppenliste</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation>Gruppen Objekt Liste</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation>Objekte</translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation>Doppelklicken zoomt zum Objekt.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation>Der Name existiert</translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation>Die Aktion kann nicht abgeschlossen werden weil die Gruppenbezeichnung bereits existiert.</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation>Gruppe bearbeiten</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation>Zeige welche Gruppen in der Liste sichtbar sind</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation>Zeige welche Gruppen in der Liste gesperrt sind</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation>Zeige welche Gruppen Objekte enthalten</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation>Unbekanntes Objekt</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation>%1 - Startpunkt</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation>%1 - Punkt Länge und Winkel</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation>Linie %1_%2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation>%1 - Punkt auf einer Linie</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation>%1 - Punkt Länge zur Linie</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation>%1 - Punkt auf einer Senkrechten</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation>%1 - Punkt auf einer Winkelhalbierenden</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation>%1 - Punkt schneidet Linien</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation>%1 - Kurve interaktiv</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation>%1 - Kurve fixiert</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation>%1 - Bogen Radius &amp; Winkel</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation>Bogen_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation>%1 - Bogen Radius &amp; Länge</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation>%1 - Spline interaktiv</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation>SplVerzeichnis_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation>%1 - Spline fixiert</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation>%1 - Punkt - schneidet Bogen &amp; Linie</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation>%1 - Punkt schneidet Linie &amp; Senkrechte</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation>%1 - Punkt schneidet Achse &amp; Dreieck</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation>%1 - Punkt schneidet XY</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation>%1 - Punkt auf Bogen</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation>%1 - Punkt auf Kurve</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation>%1 - Punkt auf Spline</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation>%1 - Punkt schneidet Linie &amp; Achse</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation>%1 - Punkt schneidet Kurve &amp; Achse</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation>%1 - Punkt schneidet Bögen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation>%1 - Punkt schneidet Kreise</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation>%1 - Punkt schneidet Kurven</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation>%1 - Punkt schneidet Kreis &amp; Tangente</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation>%1 - Punkt schneidet Bogen &amp; Tangente</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation>%1 - endgültiger Abnäher %2_%3_%4</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation>%1 - Bogen elliptisch</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation>ElBogen_</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation>%1 - Drehung</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation>%1 - Bewegen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation>%1 - Spiegeln an einer Linie</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation>%1 - Spiegeln an einer Achse</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation>Gruppenobjekt bewegen</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation>Gruppenobjekt entfernen</translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation>Gruppenfarbe</translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation>Gruppenbezeichnung</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation>Sichtbar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation>Gruppe ist sichtbar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation>Gesperrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation>Gruppe ist gesperrt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation>Gruppe hat Objekte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation>Farbe</translation>
     </message>
@@ -5643,265 +4441,186 @@ for writing</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation>Chronik</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation>Finden:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation>Text suchen</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation>Id</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+1"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-328"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation>Basispunkt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation>Linie_%1_%2</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation>Linie von %1 nach %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation>Punkt auf Linie %1_%2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation>Punkt Länge zur Linie</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation>Punkt auf einer Senkrechten %1_%2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation>Punkt auf einer Winkelhalbierenden %1_%2_%3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation>Punkt schneidet Linien %1_%2und %3_%4</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation>Kurve interaktiv</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation>Kurve fixiert</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation>Bogen_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation>Bogen Radius &amp; Winkel</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation>Bogen Radius &amp; Länge %1</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation>SplVerzeichnis_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation>Spline interaktiv</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation>Spline fixiert</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation>Punkt schneidet Bogen mit Mittelpunkt %1 &amp; Linie %2_%3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation>Punkt schneidet Linie %1_%2 &amp; Senkrechten %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation>Punkt schneidet Achse  %1_%2 &amp; Dreieckspunkte %3 und %4</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation>Punkt schneidet XY der Punkte %1 und %2</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation>Punkt auf einem Bogen</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation>Punkt auf einer Kurve</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation>Punkt auf einer Spline</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation>%Punkt schneidet Linie  &amp; %1_%2 und  Achse durch Punkt%3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation>Punkt schneidet Kurve &amp; Achse durch Punkt %1</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation>Punkt schneidet Bögen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation>%1 - Punkt schneidet Kreise</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation>Punkt schneidet Kurven</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation>Punkt schneidet Kreis &amp; Tangente</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation>Punkt schneidet Bogen &amp; Tangente</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation>Endgültige Abnäherlänge  %1_%2_%3</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation>ElBogen_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation>Bogen elliptisch mit Länge %1</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation>Drehung um Punkt %1. Suffix %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation>Spiegeln an einer Linie %1_%2. Suffix %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation>Spiegeln an einer Achse durch %1 Punkt. Suffix %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation>Bewegen - drehen um Punkt %1. Suffix %2</translation>
     </message>
     <message>
-        <location line="-277"/>
         <source>Point Length and Angle from point %1</source>
         <translation>Punkt Länge und Winkel von Punkt %1</translation>
     </message>
@@ -5909,127 +4628,98 @@ for writing</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation>Bild-Eigenschaften</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation>Id:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation>Id</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation>Bild sperren:</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation>Umschalten zwischen px- und Muster-Einheiten</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation>PX</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation>Einheit:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation>X Position:</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation>Y Position:</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation>Seitenverhältnis sperren</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation>Aspekt sperren:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation>Breite:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation>Höhe:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation>X Skala:</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation>Y Skala:</translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation>Drehung:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation>Opazität:</translation>
     </message>
@@ -6037,110 +4727,85 @@ for writing</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation>Sperre</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation>Bestellung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation>Nach oben bringen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation>Nachrücken</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation>Nach unten gehen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation>Nach unten senden</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation>&lt;b&gt;Bild (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
         <translation> - &lt;b&gt;Seitenverhältnis gesperrt&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation>Bild importieren</translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation>Das Bild konnte nicht geladen werden.</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation>Das Bild konnte nicht gelesen werden.</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation>Die Datei könnte beschädigt sein...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation>Die Datei kann beschädigt oder leer sein...</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation>Löschvorgang bestätigen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Möchtest Du wirklich löschen?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation>Die Bilder werden nicht gespeichert</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6152,102 +4817,82 @@ Es empfiehlt sich, vor dem Schließen der Software einen Screenshot des Dialogs 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation>Schnittteil:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation>Knoten:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation>Zustand:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation>msg</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation>Umkehren</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation>Markierung</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation>Schlitz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation>T Markierung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation>U Markierung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation>V innen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation>V aussen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation>Burg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation>Keine Knoten ausgewählt. Cancel Drücken um fortzufahren</translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation> war automatisch umgekehrt.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation> muss evtl. manuell umgekehrt werden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation>Knoten einfügen</translation>
     </message>
@@ -6255,12 +4900,10 @@ Es empfiehlt sich, vor dem Schließen der Software einen Screenshot des Dialogs 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLICH DER GARANTIE FÜR DESIGN, GEBRAUCHSFÄHIGKEIT UND EIGNUNG FÜR EINEN BESTIMMTEN ZWECK zur Verfügung gestellt.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6288,87 +4931,70 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation>Auswählen:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation>Mittelpunkt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation>Tangentenpunkt:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation>Kreismittelpunkt wählen</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation>Radius bearbeiten</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius kann nicht negativ sein</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Punkt - schneidet Kreis und Tangente</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -6376,12 +5002,10 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation>Schnittpunkt Kreis und Tangente</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Schnittpunkt kann nicht gefunden werden %1 von &lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Bogen und Tangente&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Ausgangspunkt als Platzhalter benutzen bis Schnittteil korrigiert ist.</translation>
     </message>
@@ -6389,110 +5013,82 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation>Auswählen:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation>Kreis 1</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation>Mitte:</translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;vollständige Berechnung im Hinweisfenster anzeigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation>Kreis 2</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation>Zweiten Kreismittelpunkt wählen</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation>Ersten Kreisradius bearbeiten</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation>Zweiten Kreisradius bearbeiten</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius kann nicht negativ sein</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation>Punkt - schneidet Kreise</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -6500,12 +5096,10 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Schnittpunkt kann nicht gefunden werden %1 der Kurven&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Ausgangspunkt als Platzhalter benutzen bis Schnittteil korrigiert ist.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation>Punkt schneidet Kreise</translation>
     </message>
@@ -6513,52 +5107,42 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Vorlagen:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Breite:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Höhe:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Schnittteil drehen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Drehen um</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>grad</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Drei Gruppen: groß, mittel, klein</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Zwei Gruppen: groß, klein</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>Absteigender Bereich</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
@@ -6567,74 +5151,58 @@ Apply settings anyway?</source>
 Einstellungen trotzdem anwenden?</translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Zentimeter</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Zoll</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Pixel</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Automatisches Zuschneiden der ungenutzten Länge</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Seiten zusammenfassen (wenn möglich)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation>Spaltweite:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Blattlänge speichern</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Papierformat</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Links:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Rechts:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Oben:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Unten:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Falsche Felder.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6645,84 +5213,67 @@ Einstellungen trotzdem anwenden?</translation>
 	Absteigende Fläche = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation>Layoutoptionen</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation>Verschiebungs-/Ausgleichslänge:</translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation>Regel zur Auswahl des nächsten Schnittteils</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation>In Streifen aufteilen</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation>Multiplikator</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation>Multiplikator für die Länge des größten Schnittteils im Layout festlegen.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation>Durch die Aktivierung für Blätter mit großer Höhe wird die Erstellung beschleunigt.</translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Drucker:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation>Keiner</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation>Text</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation>Text wird in Verzeichnisse umgewandelt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation>Text als Verzeichnis exportieren</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation>Ränder</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation>Ränder ignorieren</translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation>Layoutdruck Einstellungen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation>Millimeter</translation>
     </message>
@@ -6730,32 +5281,26 @@ Einstellungen trotzdem anwenden?</translation>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation>Kein Stift</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation>Durchgezogene Linie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation>Bindestrich</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation>Strichpunkt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation>Strich Punkt Punkt</translation>
     </message>
@@ -6763,2661 +5308,2002 @@ Einstellungen trotzdem anwenden?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Werkzeuge zum Erstellen von Punkten.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Werkzeuge zur Linienerzeugung.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Werkzeuge zur Kurvenerzeugung.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Werkzeuge zur Bogenerzeugung.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Bogen</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;Datei</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Hilfe</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Maße</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Neu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Neues Schnittmuster erstellen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Öffnen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Datei mit Schnittmuster öffnen</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Speichern</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Schnittmuster speichern</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Speichern &amp;als...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Noch nicht gespeichertes Schnittmuster speichern</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Zeigewerkzeuge</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Chronik</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>Über &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;Über Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>Be&amp;enden</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Programmfehler melden</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Onlinehilfe anzeigen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>Über Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Speichern als</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Datei konnte nicht gespeichert werden</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Datei öffnen</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Fehler beim Auswerten der Datei.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Fehler: Wert kann nicht konvertiert werden.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Fehler: Leerer Parameter.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Fehler: Falsche ID.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Fehler beim Auswerten der Datei  (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Ungültige ID.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>Datei gespeichert</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>unbenannt.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>Das Schnittmuster wurde geändert.
 Sollen die Änderungen gespeichert werden?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Rückgängig</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Wiederholen</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>Diese Datei ist bereits in einem anderen Fenster geöffnet.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Falsche Einheiten.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>Datei geladen</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Seamly2D wurde nicht korrekt beendet. Zuletzt geöffnete Dateien (%1) laden?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Dateien erneut öffnen.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Layout</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation>Drucken</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation>PDF Kachelblätter drucken</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation>Teilen und drucken eines Layouts in kleinere Seiten (für normale Drucker)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation>Druckvorschau</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation>Druckvorschau mit Originallayout</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation>Exportieren als...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation>Layoutmodus</translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation>Ungespeicherte Änderungen</translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation>Maße geladen</translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation>Du kannst kein leeres Layout exportieren.</translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation>Die Maßdatei enthält ungültige bekannte Maße.</translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation>Maßdatei hat ein unbekanntes Format.</translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation>Die Maßdatei Arten stimmen nicht überein.</translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation>Maße konnten nicht synchronisiert werden.</translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation>Maße konnten nicht aktualisiert werden.</translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation>Die Maßdatei &apos;%1&apos; konnte nicht gefunden werden.</translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation>Lädt Maßdatei</translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation>Die Größeneinheit &apos;%1&apos; wird für diese Schnittmusterdatei nicht unterstützt.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation>Größe konnte nicht bestimmt werden. Datei nicht geöffnet.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation>Die Methode %1 hat keine Auswirkung im GUI-Modus</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation>Nicht unterstützer Körperhöhen Wert &apos;%1&apos; für diese Schnittmusterdatei.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation>Körperhöhe konnte nicht bestimmt werden. Datei nicht geöffnet.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation>Bitte stelle eine Eingabedatei zur Verfügung.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation>Ein originales Layout drucken</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation>Vorschau der PDF Kachelblätter</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation>Druckvorschau gekacheltes Layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation>Geladene Maße gelöscht</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation>Maße konnten nicht gelöscht werden, einige werden im Schnittteil verwendet.</translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>Neues Schnittmuster</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation>Schnittmuster öffnen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation>Maße erstellen/bearbeiten</translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>Speichern...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Nicht Speichern</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Datei sperren</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Diese Datei ist bereits in einem anderen Fenster geöffnet. Diese Nachricht ignorieren, wenn Sie fortfahren wollen (nicht empfohlen, kann zu Datenverlust führen).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Die Sperrdatei konnte aufgrund fehlender Berechtigungen nicht erstellt werden. Diese Nachricht ignorieren, wenn Sie fortfahren wollen (nicht empfohlen, kann zu Datenverlust führen).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Ein unbekannter Fehler ist aufgetreten, zum Beispiel hat eine volle Festplatten Partition verhindert, dass die Sperrdatei geschrieben werden konnte. Diese Nachricht ignorieren, wenn Sie fortfahren wollen (nicht empfohlen, kann zu Datenverlust führen).</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Die Sperrdatei konnte aufgrund fehlender Berechtigungen nicht erstellt werden.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Ein unbekannter Fehler ist aufgetreten, zum Beispiel hat eine volle Festplatten Partition verhindert, dass die Sperrdatei geschrieben werden konnte.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation>Arbeitsabläufe</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation>Schnittmuster schließen</translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation>Werkzeug Anzeiger</translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation>Original zoom</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Körperhöhe:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Größe:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation>Die Maßdateien &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; konnten nicht gefunden werden. Möchtest Du den Speicherort aktualisieren?</translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation>Die Maße wurden geändert. Sollen die Maße jetzt synchronisiert werden?</translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Gradierung unterstützt Zoll nicht</translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation>Maße wurden synchronisiert</translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation>Das Dokument hat keine Schreibberechtigung.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Kann keine Berechtigung für %1 als schreibbar setzen.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Die Datei kann nicht gesichert werden.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation>Die Datei kann nicht gesichert werden</translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation>Nur lesen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation>Individuell laden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation>individuelle Maße laden</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation>Mehrgröße laden</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation>Mehrgrößen Maße laden</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation>Öffne SeamlyMe</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation>Aktuelle bearbeiten</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation>Verknüpft mit den Schnittmustermaßen bearbeiten</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation>Sync</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation>Verknüpft mit den Mustermaßen nach Änderung synchronisieren</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation>Aktuelle löschen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation>Maße löschen, wenn sie nicht in einer Schnittmusterdatei benutzt werden</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation>Individuelle Maße</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation>Mehrgrößen Maße</translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Schnittmusterdateien</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation>Wiki</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation>Forum</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation>Der berechnete Wert</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation>Formel</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation>Layoutmodus kann noch nicht genutzt werden.</translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation>Die Anwendung unterstütz&apos; keine Mehrgrößentabellen in Zoll.</translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation>Größe kann nicht eingestellt werden. Mindestens eine Mehrgrößenmaßdatei ist notwendig.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation>Körperhöhe kann nicht eingestellt werden. Mindestens eine Mehrgrößenmaßdatei muß vorhanden sein.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation>Vorschau</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation>Ansicht</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation>Punktbezeichnungen</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation>&amp;Werkzeuge</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation>&amp;Abläufe</translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation>Stück</translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation>Dienstprogramme</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation>Datei Symbolleiste</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation>Modus Symbolleiste</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation>Vorlagen Symbolleiste</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation>Symbolleiste bearbeiten</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation>Eigenschaften Editor</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation>Seiten Layout</translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation>Gruppen Manager</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation>Zoom Symbolleiste</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation>Werkzeuge Symbolleiste</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation>Punkte Symbolleiste</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation>Linien Symbolleiste</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation>Kurven Symbolleiste</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation>Bögen Symbolleiste</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation>Operationen Symbolleiste</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation>Schnittteil Symbolleiste</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation>Details Symbolleiste</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation>Layout Symbolleiste</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation>Punktbezeichnung Symbolleiste</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation>Werkzeugpalette</translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation>Linie zwischen 2 Punkten (Alt+L)</translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation>Werkzeuge um Operationen an Objektion durchzuführen</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation>Ausgewählte Objekte drehen (R)</translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation>Entwurfsblöcke (E, D) exportieren</translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation>Werkzeuge um Schnittteile hinzuzufügen.</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation>Detail hinzufügen</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation>Werkzeuge um Details zu Schnittteilen hinzuzufügen</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation>2 Teile zusammenführen (U)</translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation>Ansicht Symbolleiste</translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation>Entwurf</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modus  zur Arbeit mit Entwurfsblöcken. Diese Entwursblöcke sind die Basis um in die nächste Phase zu gehen. &amp;quot;Teil Modus&amp;quot;. Bevor Du die diesen Teil Modus &amp;quot;aktivieren kannst&amp;quot; Musst Du mindestens ein Teil erstellt haben.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modus Mit Schnittteilen arbeiten. Bevor Du den Teile Modus aktivieren kannst, musst &amp;quot; Du mindestens ein Schnittteil im Stadium &amp;quot;Entwurfsmodus&amp;quot; erstellt haben&amp;quot;. Schnittteile die in dieser Phase erstellt wurden, werden zur Layouterstellung benutzt.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation>Neuer Entwurfsblock</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation>Neuen Entwurfsblock hinzufügen (Ctrl+Shift+N)</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation>Entwurfsblock umbenennen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation>Die Bezeichnung des Entwurfsblocks ändern</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation>Variablentabelle</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modus um ein Layout aus Schnittteilen zu erstellen. Dieser Modus ist verfügbar wenn mindestens ein Schnittteil im Schnitzel Modus erstellt worden ist.&amp;quot;Teil Modus&amp;quot;. Das Layout kann in Dein bevorzugtes Dateiformat exportiert und gespeichert werden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation>Drehung</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation>Spiegeln an einer Linie</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation>M, L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation>Spiegeln an einer Achse</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation>M, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation>Abnäherlängen ausgleichen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation>T, D,</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation>Mittelpunkt</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation>P, S</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation>Schneidet XY</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation>X, Y</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation>I, L</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation>Alt+C</translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation>A, X</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation>I, A</translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation>I, C</translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation>C, T</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation>A, T</translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation>A, L</translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation>Werkzeuge zum Einfügen oder Ändern von Bildern.</translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation>Punkt auf Kurve (O, C)</translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation>Über Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation>Programm beenden</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation>Anwendungseinstellungen...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation>Schnittteil Einstellungen...</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation>Heranzoomen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation>Heran</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation>Heranzoomen (Strg++)</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation>Herauszoomen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation>Heraus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation>Herauszoomen (Strg+-)</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation>Alles passend</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation>Passen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation>Zoom um alle zu sehen (Strg+=)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation>Programmfehler melden...</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation>Verknüpfungen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation>Letztes Werkzeug</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation>Kurven Kontrollpunkte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation>Kontrollpunkte und Kurvenrichtung umschalten (V, C)</translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation>Mehrgrößen laden</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation>Öffne SeamlyMe Maße app(Ctrl+M)</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation>Variablen nach CSV exportieren</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation>Ausgewählt</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation>Etikettenvorlagen Editor...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation>Vorherige</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation>Zoom zum Vorherigen (Strg+Links)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation>Strg+Links</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation>Gebiet</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation>Strg+A</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation>Pan</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation>Z, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation>Zoom 1:1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation>Zoom auf 100 Prozent (Strg+0)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation>Strg+0</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation>Punkt Werkzeuge</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation>Linien Werkzeuge</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation>Alt+L</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation>Kurven Werkzeuge</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation>Bogen Werkzeuge</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation>Operations Werkzeuge</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation>Layout Werkzeuge</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation>Schnittteil Werkzeuge</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation>Neues Schnittteil</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation>N;P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation>Neues Drucklayout</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation>N;L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation>Layout exportieren</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation>E, L</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation>Anker Punkt</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation>A, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation>Internes Verzeichnis</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation>I;P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation>Füge Knoten ein</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation>I;N</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation>Füge Teile zusammen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation>Schnittteile exportieren</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation>E;P</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation>Detail Werkzeuge</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation>Punktbezeichnung Text</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation>V, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation>Textgröße erhöhen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation>Textgröße erhöhen (Strg+])</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation>Strg+]</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation>Textgröße verringern</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation>Textgröße verringern (Strg+[)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation>Strg+[</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation>Benutze Werkzeugfarbe</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation>Benutze Werkzeugfarbe (T)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation>V, T</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation>Achsenursprung </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation>Achsenursprung umschalten (V, A)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation>V,A</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation>Wireframe Modus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation>Wireframe Modus umschalten (V,W)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation>V, W</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation>Fadenläufe</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation>Fadenlauf umschalten (V, G)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation>V,G</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation>Etiketten</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation>Etiketten umschalten (V, L)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation>V, L</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation>Taschenrechner</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation>Strg+Umschalt+C</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation>Dezimatabelle</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation>Strg+Umschalt+D</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation>Exportiere Entwurfsblöcke</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation>E;D</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation>Nahtzugabe</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation>V, S</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation>Dokument Info...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation>Dokument Info</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation>Dokument Info anzeigen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation>Strg+I</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation>Maßdatei beinhaltet nicht alle erforderlichen Maße.</translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation>&lt;b&gt;Werkzeug::Operationen - Gruppe erstellen:&lt;/b&gt; Wähle ein oder mehrere Opbjekte aus - Halten b&gt;%1&lt;/b&gt;für Mehrfachauswahl, mit &lt;&gt;ENTER &lt;/b&gt; die Gruppenerstellung abschließen </translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Werkzeug::Operationen - Spiegeln an einer Linie:&lt;/b&gt; wähle ein oder mehrere Objekte aus - Halten &lt;b&gt;%1&lt;/b&gt; für Mehrfachauswahl, mit &lt;b&gt;ENTER&lt;/b&gt; die Auswahl bestätigen</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Werkzeug::Operationen - Spiegeln an einer Achse:&lt;/b&gt; wähle ein oder mehrere Objekte aus - Halten &lt;b&gt;%1&lt;/b&gt; für Mehrfachauswahl, mit &lt;b&gt;ENTER&lt;/b&gt; die Auswahl bestätigen</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Werkzeug::Operationen - Bewegen:&lt;/b&gt; Wähle ein oder mehrere Objekte aus - Halten &lt;b&gt;%1&lt;/b&gt; für Mehrfachauswahl, mit &lt;b&gt;ENTER&lt;/b&gt; die Auswahl bestätigen</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation>&lt;b&gt;Werkzeug::Operationenen Abnäher korrigieren:&lt;/b&gt; wähle den ersten Basispunkt</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation>Das Bild konnte nicht geladen werden.</translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation>Entwurfsblock:</translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation>Drehen</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation>Ankerpunkt hinzufügen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation>Unterverzeichnis erstellen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation>Knoten in das Verzeichnis aufnehmen</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation>Vereinigungswerkzeug</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation>Schnittteile exportieren</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation>Bild importieren</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation>Schnittteil Modus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation>Schnitteilmodus kann noch nicht genutzt werden, Erstelle mindestens ein Schnittteil.</translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation>Schnittteile</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation>Layoutmodus kann noch nicht genutzt werden, Erstelle mindestens ein Schnittteil.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation>Layoutmodus kann nicht genutzt werden, mindestens ein Schnittteil ins Layout aufnehmen.</translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation>Entwurfsblock.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation>Bezeichnung existiert</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation>Die Aktion kann nicht abgeschlossen werden, da der Name des Entwurfsblocks bereits existiert.</translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation>Es gibt kein Schnittteil zum exportieren, mindestens ein Schnittteil ins Layout übernehmen.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation>Schnittteile exportieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation>Schnittteile können nicht exportiert werden.</translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation>&lt;b&gt;Werkzeug: Schnittteil - Neues Schnittteil hinzufügen&lt;/b&gt; Hauptpfad der Objekte im Uhrzeigersinn auswählen.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation>&lt;b&gt;Werkzeug: Schnittteil - Ankerpunkt hinzufügen :&lt;/b&gt; wähle einen Ankerpunkt</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation>&lt;b&gt;Werkzeug: Schnittteil - Unterverzeichnis:&lt;/b&gt; Zum Auswählen der Verzeichnissobjekte , benutze , &lt;b&gt;SHIFT&lt;/b&gt; um die Richtung der Kurven umzukehren</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Werkzeug::Schnitteil-Knoten einfügen:&lt;/b&gt; wähle ein oder mehrere Objekte aus, Halten &lt;b&gt;%1&lt;/b&gt; für Mehrfachauswahl,&lt;b&gt;ENTER &gt;um Auswahl zu bestätigen</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation>&lt;b&gt;Werkzeug: Details Vereinigung /b&gt; wähle ein Schnittteil</translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation>Entwurfsblock %1</translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation>Entwurfsblock %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation>Punkt - Auf Winkelhalbierender (O, B)</translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation>Punkt - Länge zur Linie (P, S)</translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation>Punkt - Schneidet Bogen und Linie (A, U)</translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation>Point - Schneidet Achse und Dreieck (X, T)</translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation>Punkt - Schneidet XY</translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation>Point - Schneidet Linie und Senkrechte (L, P)</translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation>Punkt - Schneidet Linie und Achse (L, X)</translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation>Punkt - Auf einer Senkrechten (O, P)</translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation>Punkt - Länge und Winkel (L, A)</translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation>Punkt - Auf einer Linie (O, L)</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation>Punkt - Mittelpunkt auf einer Linie (Umschalt+O, Umschalt+L)</translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation>Punkt - Schneidet Linien (I, L)</translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation>Kurve - Interaktiv (Alt+C)</translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation>Spline - Interaktiv (Alt+S)</translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation>Kurve - Fixiert (Alt+Umschalt+C)</translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation>Spline - Fixiert (Alt+Umschalt+S)</translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation>Punkt - Auf einer Spline ( O, S)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation>Punkt - Schneidet Kurven (I, C)</translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation>Punkt - Schneidet Kurve und Achse (C, X)</translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation>Punkt - Auf einer Kurve (O, C)</translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation>Bogen - Radius uns Winkel (Alt+A)</translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation>Punkt - Auf Bogen (O, A)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation>Punkt - Schneidet Bogen und Achse (A, K)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation>Punkt - Schneidet Bögen ((I, A)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation>Punkt - Schneidet Kreise  (Umschalt+I, Umschalt+C)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation>Punkt - Schneidet Kreis und Tangente (C, T)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation>Punkt - Schneidet Bogen und Tangente (A, T)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation>Bogen - Radius und Länge (Alt+Umschalt+A)</translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation>Bogen - Elliptisch (Alt+E)</translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation>Objekte an einer Linie spiegeln (M, L)</translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation>Objekte an einer Achse spiegeln (M, A)</translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation>Objekte bewegen (Alt-M)</translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation>Abnäherlängen ausgleichen (T;D)</translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation>Neues Schnittteil hinzufügen (N, P)</translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation>Ankerpunkt hinzufügen (A, P)</translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation>Füge Knoten ein (I, N)</translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation>Unterverzeichnis hinzufügen  (I, P)</translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation>Bild importieren</translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation>Schnittteile exportieren (E, P)</translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation>Neues Drucklayout (N, L)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation>Layout exportieren (E, L)</translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation>Enthält Informationen über benutzerdefinierte und interne Variablen</translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation>Alt+M</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation>Elliptisch</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation>Bogen - Elliptisch</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation>Alt+E</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation>Mittelpunkt auf Linie</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation>Umschalt+O, Umschalt+L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation>Auf Linie</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation>O, L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation>Länge und Winkel</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation>L, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation>Auf Senkrechter</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation>O, P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation>Auf Winkelhalbierender</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation>O, B</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation>Länge zur Linie</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation>Schneidet Bogen und Linie</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation>Schneidet Achse und Dreieck</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation>X, T</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation>Schneidet Linie und Senkrechte</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation>Schneidet Linie und Achse</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation>L, X</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation>Schneidet Linien</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation>Kurve - interaktiv</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation>Punkt auf Kurve</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation>O, C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation>Kurve- Fixiert</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation>Alt+Umschalt+C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation>Spline - Interaktiv</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation>Punkt auf Spline</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation>Punkt auf Spline (O, S)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation>O, S</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation>Spline - Fixiert</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation>Alt+Umschalt+S</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation>Schneidet Kurven</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation>Schneidet Kurve und Achse</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation>C, X</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation>Radius und Winkel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation>Bogen - Radius und Winkel</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation>Punkt auf Bogen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation>Punkt auf Bogen (O, A)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation>O, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation>Schneidet Bogen und Achse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation>Schneidet Bogen und Achse A, X)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation>Schneidet Bögen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation>Schneidet Bögen (I, A)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation>Schneidet Kreise</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation>Schneidet Kreise (Umschalt+I, Umschalt+C)</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation>Umschalt+I, Umschalt+C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation>Schneidet Kreis und Tangente</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation>Schneidet Kreis und Tangente (C, T)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation>Schneidet Bogen und Tangente</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation>Schneidet Bogen und Tangente A, T)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation>Radius und Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation>Bogen - Radius und Länge</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation>Alt+Umschalt+A</translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation>Letztes benutztes Werkzeug aktivieren Strg+Umschalt+L)</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation>Zoom zur Auswahl (Ctrl+Rechts)</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation>Zoom zum  ausgewählten Bereich  (Ctrl+A)</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation>Pan Arbeitsbereich (Z, P)</translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation>Erstelle ein neues Drucklayout (N, L)</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation>Punktnamen-Text umschalten (V, P)</translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation>Bilder-Tools</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation>Ausrichten</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation>Sperre</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation>Zoom zum Punkt (Strg + Alt + P)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation>Strg+Alt+P</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation>Alt+I</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation>Bitte gib zusätzliche Maße an: %1</translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Mittelpunkt auf der Linie :&lt;/b&gt; Wähle den ersten Punkt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Länge und Winkel&lt;/b&gt;: Punkt auswählen</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation>&lt;b&gt;Werkzeug: Punkt -auf einer Linie&lt;/b&gt; Wähle den ersten Punkt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Auf einer Senkrechten:&lt;/b&gt; Wähle den ersten Punkt der Linie</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Auf einer Winkelhalbierenden:&lt;/b&gt; Wähle den ersten Punkt des Winkels</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation>&lt;b&gt;Werkzeug: Punkt  - Länge zur Linie:&lt;/b&gt; Wähle einen Punkt</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Schneidet Bogen und Linie:&lt;/b&gt; Wähle den ersten Punkt der Linie</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Schneidet Achse und Dreieck:&lt;/b&gt; Wähle den ersten Punkt der Achse</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation>&lt;b&gt;Wekzeug: Punkt - Schneidet XY&lt;/b&gt; Wähle einen Punkt für den X Wert (vertikal</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Schneidet Linie und Senkrechte:&lt;/b&gt; Wähle den Basispunkt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation>b&gt;Werkzeug: Punkt - Schneidet Linie und Achse:&lt;/b&gt; Wähle den ersten Punkt der Linie</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation>&lt;b&gt;Werkzeug: Linie  &lt;/b&gt;:Wähle den ersten Punkt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Schneidet Linien:&lt;/b&gt; Wähle den ersten Punkt der ersten Linie</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation>&lt;b&gt; Werkzeug: Kurve - Interaktiv b&gt; Wähle den Startpunkt der Kurve</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation>&lt;b&gt;Werkzeug: Spline - Interaktiv:&lt;/b&gt; Wähle den Startpunkt der Spline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation>&lt;b&gt; Werkzeug : Kurve  - Fixiert &lt;/b&gt; Wähle den ersten Punkt der Kurve</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation>&lt;b&gt;Werkzeug: Spline - Fixiert:&lt;/b&gt; Wähle den ersten Punkt der Spline</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - auf einer Kurve:&lt;/b&gt; Wähle den ersten Punkt der Kurve</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - auf Spline&lt;/b&gt; Wähle die Spline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Schneidet Kurven:&lt;/b&gt; Wähle die erste Kurve</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Schneidet Kurve und Achse:&lt;/b&gt; Wähle die Kurve</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation>&lt;b&gt; Werkzeug:Bogen - Radius und Winkel &lt;/b&gt; Wähle den Mittelpunkt des Bogens</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Auf einem Bogen :&lt;/b&gt; Wähle den Bogen</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Schneidet Bogen und Achse:&lt;/b&gt; Wähle den Bogen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation>&lt;b&gt;Werkzeug:Punkt - Schneidet Bögen:&lt;/b&gt; Wähle den ersten Bogen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Schneidet Kreise :&lt;/b&gt; Wähle den ersten Kreismittelpunkt</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Schneidet Kreis und Tangente&lt;/b&gt; Wähle einen  Punkt auf der Tangente</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation>&lt;b&gt;Werkzeug: Punkt - Schneidet Bogen und Tangente:&lt;/b&gt; Wähle einen Punkt auf der Tangente</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation>&lt;b&gt;Werkzeug: Bogen - Radius und Länge &lt;/b Wähle den Mittelpunkt des Bogens</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation>&lt;b&gt;Werkzeug:l::Bogen - Elliptisch:&lt;/b&gt; Wähle den Mittelpunkt des Ellipsenbogens</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation>Bilder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation>Bilddatei öffnen</translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation>Zoom zum Punkt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation>Punkt:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation>Schneidet Bogen und Linie</translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation>Schneidet Kurve &amp; Achse</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation>Objekte zur Gruppe hinzufügen (G)</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation>Objekte zur Gruppe hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation>Gruppen Objekt hinzufügen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation>Gruppe ist gesperrt. Entsperren um Objekte hinzuzufügen</translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation>Datei kann nicht gesichert werden.</translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation>Schnittmuster ist schreibgeschützt.</translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation>Sperren ist fehlgeschlagen. Datei mit diesem Namen ist in einem anderen Fenster geöffnet.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation>Strg+E</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation>unbenannt</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation>Sperren fehlgeschlagen. Diese Datei ist bereits in einem anderen Fenster geöffnet. Bei Anwendung von 2 Programmkopien kommt es zu Konflikten.</translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation>Stift-Symbolleiste</translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation>Symbolleisten</translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation>Dateiausnahme.</translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation>Ausnahme exportieren.</translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>Schnittmuster</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-821"/>
         <source>L, P</source>
         <translation>L, P</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2517"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Werkzeug::Operationen - Drehung:&lt;/b&gt; Wähle ein oder mehrere Opbjekte aus - Halten &lt;b&gt;%1&lt;/b&gt; für Mehrfachauswahl, mit &lt;b&gt;ENTER&lt;/b&gt; die Auswahl bestätigen</translation>
     </message>
     <message>
-        <location line="+972"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation>Basisname, der für neue Punkte verwendet wird.
 Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
@@ -9425,86 +7311,66 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Erstellen der Datei &apos;%1&apos; fehlgeschlagen! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Kritischer Fehler!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation>Druckfehler</translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation>Kann nicht fortfahren werden, da keine verfügbaren Drucker in Ihrem System vorhanden sind.</translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation>unbenannt</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation>Das Layout ist veraltet.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation>Das Layout wurde seit der letzten Schnitteiländerung nicht aktualisiert. Möchtest Du fortfahren?</translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Daten für die Erstellung des Layouts konnten nicht vorbereitet werden</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation>Drucker %1 kann nicht geöffnet werden</translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation>Für die Vorschau eines mehrseitigen Dokuments sollten alle Blätter die gleiche Größe haben.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation>Zum Drucken eines mehrseitigen Dokuments sollten alle Blätter die gleiche Größe haben.</translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation>Seiten werden beschnitten, da sie nicht mit der Papiergröße des Drucker übereinstimmen.</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation>Druckränder können nicht gesetzt werden</translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation>Ein Verzeichnis kann nicht erstellt werden</translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Schnittmuster</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation>Ein oder mehrere Schnittteile sind größer als das ausgewählte Papierformat. Wähle ein größeres.</translation>
     </message>
@@ -9512,148 +7378,118 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation>Kopiere die Verknüpfungen in die Zwischenablage</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation>Verknüpfungen als PDF exportieren</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation>Sende Verknüpfungen an den Drucker</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+78"/>
         <source>File</source>
         <translation>Datei</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation>Strg+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation>Individuelle Maße öffnen</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Export PDF</source>
         <translation>PDF exportieren</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Ctrl+O</source>
         <translation>Strg+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation>Mehrgrößen öffnen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation>Strg+Umschalt+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation>Drucken</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation>Strg+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation>Strg+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation>Speichern als</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation>Strg+Umschalt+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation>Als CSV exportieren</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation>Strg+E</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation>Verlassen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation>Strg+Q</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation>Tastaturkurzbefehle</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation>SeamlyMe Verknüpfungen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation>Vorheriges finden</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation>Strg+Umschalt+G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation>Nächstes finden</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation>Strg+G</translation>
     </message>
@@ -9661,123 +7497,102 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation>Alles einklappen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation>Alles ausklappen</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation>Alle überprüfen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation>Alles deaktivieren</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation>Direkte Höhe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation>Direkte Weite</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation>Vertiefung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation>Hand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation>Fuß</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation>Kopf</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation>Umfang und Bogen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation>Vertikal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation>Horizontal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation>Brust</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation>Balance</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation>Arm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation>Bein</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation>Schritt und Höhe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation>Herren &amp; Schneiderei</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation>Historische &amp; Spezialität</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation>Schnittmustermaße</translation>
@@ -9786,18 +7601,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation>Maß &apos;%1&apos; kann nicht gefunden werden</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation>Name des Maßes ist leer!</translation>
     </message>
@@ -9805,37 +7612,30 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation> XPos:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation>xpos</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation>YPos:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation>ypos</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation>Einheiten:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation>Einheiten</translation>
     </message>
@@ -9843,12 +7643,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation>Verschiebe das erste Abnäher Etikett</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation>Verschiebe das zweite Abnäher Etikett</translation>
     </message>
@@ -9856,7 +7654,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation>Gruppenelement verschieben</translation>
     </message>
@@ -9864,7 +7661,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation>Punkt Etikett verschieben</translation>
     </message>
@@ -9872,7 +7668,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation>Punkt Etikett verschieben</translation>
     </message>
@@ -9880,7 +7675,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation>Einzelnen Punkt verschieben</translation>
     </message>
@@ -9888,7 +7682,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation>Spline verschieben</translation>
     </message>
@@ -9896,7 +7689,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation>Spline Pfad verschieben</translation>
     </message>
@@ -9904,52 +7696,42 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>Neue Maßdatei</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Maßsatz Typ:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Einheit:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Basisgröße:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Basis Körperhöhe:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Individuell</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Zentimeter</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Zoll</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation>Mehrgröße</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation>Millimeter</translation>
     </message>
@@ -9957,87 +7739,70 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation>A0</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation>A1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation>A2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation>A3</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation>A4</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation>Brief</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation>Legal (US-Papiergröße)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation>Boulevardzeitung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation>ANSI C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation>ANSI D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation>ANSI E</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation>Rolle 24zoll / 60.96cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation>Rolle 30zoll / 76.20cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation>Rolle 36zoll / 91.44cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation>Rolle 42zoll / 106.68cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation>Rolle 44zoll / 111.76cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation>Benutzerdefiniert</translation>
     </message>
@@ -10045,887 +7810,634 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation>Schnittteil Werkzeug</translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation>Eigenschaften </translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation>Verzeichnisse </translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation>Nahtzugabe </translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation>Etiketten </translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation>Anker </translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation>Fadenlauf </translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation>Markierungen </translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation>Bezeichnung des Schnittteils:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation>Schnittteil</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation>Bezeichnung kann nicht leer sein</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation>Buchstabe:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation>Buchstabe des Schnittteils</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation>Menge:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation>Platzierung:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation>im Bruch</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation>Position des Bruchs:</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation>Undefiniert</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation>Auf/Ab</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation>Links/Rechts</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation>Orientierung:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation>Links</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation>Rechts</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation>Drehung:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation>Einfach</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation>Zweifach</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation>Vierfach</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation>Jeder</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation>Neigung:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation>Im Uhrzeigersinn X</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation>Gegen den Uhrzeigersinn X</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation>Anmerkungen:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation>Ein Textfeld um Kommentare einzufügen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation>Schnittteil darf im Layout nicht gespiegelt werden.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation>hex Wert</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation>Ausfüllen:</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation>Hauptverzeichnis</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation>Alle Objekte im Pfad sollen im Uhrzeigersinn folgen.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation>Reihe an den Anfang der Liste bewegen</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation>Reihe um eine Reihe nach oben bewegen</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation>Reihe um eine Reihe nach unten bewegen</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation>Reihe an das Ende der Liste bewegen</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation>Zustand:</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation>Fertig!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation>Unterverzeichnis</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation>Die Nahtzugabe ist Bestandteil des Hauptverzeichnisses</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation>Integriert</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation>Hauptverzeichnis ausblenden wenn Nahtzugabe aktiviert ist</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation>Breite:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation>Formelassistent</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation>Berechnung</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation>Knoten</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation>Knoten:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation>Vorher:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation>Zur Standardweite zurück</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation>Standard verwenden</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation>Nachher:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation>Kunde</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation>Anfangspunkt:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation>Endpunkt:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation>Einschließen als:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation>Schnittteil Etikett</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation>Schnittmuster Etikett bearbeiten</translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation>Vorlage bearbeiten</translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation>Schnittteil Etikett anzeigen</translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation>Höhe:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation>Ankerpunkt</translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation>Schnittteil Etikett</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation>Schnittteil Etikett anzeigen</translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation>Fadenlauf anzeigen</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation>Pfeile</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation>Markierung:</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation>Schlitz</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation>T Markierung</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation>U Markierung</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation>V innen </translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation>V aussen</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation>Burg</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation>Unterart</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation>Geradeaus</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation>Winkelhalbierende</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation>Auswählen um einen Eckpunkt als Markierung zu benennen</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation>Schnittpunkt</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation> Breite:</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation>  °</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation>Markierungslänge auf Standard zurücksetzen.</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation>Markierungsweite auf Standard zurücksetzen.</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation>Markierungswinkel auf Standard zurücksetzen.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation>Zählen:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation>Hauptpfad Objekte im Uhrzeigersinn auswählen, mit &lt;b&gt;SHIFT&lt;/b&gt; Kurvenrichtung umkehren,  oder &lt;b&gt;Strg&lt;/b&gt; um Kurvenrichtung beizubehalten. Mit &lt;b&gt;Enter&lt;/b&gt; Teilerstellung abschließen </translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation>OK drücken um ein Schnittteil zu erstellen</translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation>Umkehren</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation>Duplizieren</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation>Markierung</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation>TMarkierung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation>UMarkierung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation>VInnen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation>VAussen</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation>Ausgeschlossen</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation>Fehler: Das Schnittteilverzeichnis kann nicht gespeichert werden.</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation>Unendliches / undefiniertes Ergebnis</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation>Länge sollte positiv sein</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation>Auswertungsfehler: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation>Länge bearbeiten</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation>Winkel bearbeiten</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation>Höhe bearbeiten</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation>Breite bearbeiten</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation>Aktuelle Nahtzugabe</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation>Nahtzugabenbreite bearbeiten</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation>Nahtzugabenweite vorher bearbeiten</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation>Nahtzugabenweite nachher bearbeiten</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation>Fadenlauf</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation>Du brauchst mehr Punkte!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation>Du musst die Punkte im Uhrzeigersin auswählen!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation>Der erste Punkt kann nicht gleich dem letzten Punkt sein!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation>Du hast doppelte Punkte!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation>Jeder Punkt in dem Verzeichnis muss unterschiedlich sein!</translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation>Leer</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation>Hauptverzeichnis</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation>individuelle Nahtzugabe</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation>Beide</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation>Nur vorne</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation>Nur hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation>Markierung auf der Schnittlinie anzeigen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation>Markierung auf Schnittlinie anzeigen</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation>Markierung auf der Nahtlinie anzeigen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation>Markierung auf Nahtlinie anzeigen</translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation>Schnittlinie anzeigen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation>Nahtlinie ausblenden</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation>Nahtzugabe</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation>Verzeichnisse</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation>Etiketten</translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation>Farbe auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation>Drehen:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation>Verbieten</translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation>Mitte:</translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation>Oben links:</translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation>Unten rechts:</translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation>Oben:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation>Unten:</translation>
     </message>
@@ -10933,218 +8445,166 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation>Aktuelle Nahtzugabe</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation>Schnittteil Etikett bewegen</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation>Größe des Schnittteil Etiketts ändern</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation>Schnittteil Etikett drehen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation>Schnittteilinfo Etikett bewegen</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation>Größe des Schnittteilinfo Etiketts ändern</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation>Schnittteilinfo Etikett drehen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation>Fadenlauf bewegen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation>Größe des Fadenlaufs ändern</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation>Fadenlauf drehen</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation>Schnittteil sperren</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation>In das Layout aufnehmen</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation>Drehen ausschließen</translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation>Nach oben bewegen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation>Nach unten absenken</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation>Nahtlinie verbergen</translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation>Nahtzugabe anzeigen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation>Fadenlauf anzeigen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation>Schnittmuster Etikett anzeigen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation>Schnittteil Etikett anzeigen</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation>Umbenennen...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation>Drehen ausschließen geändert: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation>Aktiviert</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation>Deaktiviert</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation>Sichtbarkeit der Nahtlinie wurde geändert: </translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation>Verbergen</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation>Anzeigen</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation>Nahtzugabe anzeigen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation>Sichtbarkeit der Nahtzugabe wurde geändert: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation>Fadenlauf anzeigen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation>Fadenlauf Sichtbarkeit wurde geändert: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation>Schnittmuster Etikett anzeigen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation>Sichtbarkeit des Schnittmuster Etiketts wurde geändert: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation>Schnittteil Etikett anzeigen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation>Sichtbarkeit des Schnittteil Etiketts wurde geändert: </translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation>Bezeichnung des Schnittteils:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation>Schnittteil umbenennen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation>Schnittmuster umbenennen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation>Schnittteil wurde umbenannt in: </translation>
     </message>
@@ -11152,27 +8612,22 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation>Aktuelle Linienfarbe</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation>Aktueller Linientyp</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation>Aktuelle Linienstärke</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation>Aktuellen Stift auf Standad zurücksetzen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation>Aktuelle Stifteinstellung speichern</translation>
     </message>
@@ -11180,77 +8635,62 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation>Nicht füllen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation>Durchgezogen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation>Dichte 1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation>Dichte 2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation>Dichte 3</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation>Dichte 4</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation>Dichte 5</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation>Dichte 6</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation>Dichte 7</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation>Horizontale Linie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation>Vertikale Linie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation>Kreuz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation>Rückwärtsdiagonale</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation>Vorwärtsdiagonale</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation>Diagonales Kreuz</translation>
     </message>
@@ -11258,139 +8698,94 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation>Alle Schnittteile einschließen</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation>Alle Schnitteile ausschließen</translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation>Eingeschlossene Schnitteile umkehren</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation>Alle Schnittteile sperren</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation>Alle Schnittteile entsperren</translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation>gesperrte Schnittteile umkehren</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation>Einschluß des Schnittteils in das Layout umschalten</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation>Farbe auswählen</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation>Eigenschaften Schnittteils bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-317"/>
         <source>Toggle lock on pattern piece</source>
         <translation>Schloss des Schnittteils umschalten</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation>Doppelklick öffnet den Farbwähler</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation>Ein Doppelklick öffnet den Dialog für die Eigenschaften des Schnittteils</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Included</source>
         <translation>Eingeschlossene</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation>Schnittteils ist im Layout enthalten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation>Gesperrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation>Schnittteil ist gesperrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation>Farbe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation>Schnittteil Farbe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation>Stück</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation>Schnittteil Buchstabe</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation>Schnittteil Bezeichnung</translation>
     </message>
@@ -11398,62 +8793,50 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation>Punkt - Schneidet XY</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation>Punkt für Y-Wert (horizontal) auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation>Eindeutige Bezeichnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Wähle eine eindeutige Bezeichnung.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
@@ -11461,317 +8844,251 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation>Intervall:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>Sprache der Benutzeroberfläche:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation>Standard Maßeinheit:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>Die Standardmaßeinheit wurde geändert und wird als Standard für die nächsten von Dir erstellten Schnittmuster benutzt.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation>Zentimeter</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Zoll</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation>Bearbeitung</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation>Rückgängig</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation>Schritt zählen:</translation>
     </message>
     <message>
-        <location line="+251"/>
         <source>Pattern Editing Warnings</source>
         <translation>Schnittteilbearbeitung Warnungen</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation>Bestätige das Löschen des Objekts</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation>Bestätige Formatumschreibung</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation>Standardablauf Suffix</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation>Spiegeln an einer Achse Suffix:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation>Spiegeln an einer Linie Suffix:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation>Bewegen Suffix:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation>Drehen Suffix:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation>Dateiverwaltung</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation>Datensicherungen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation>Beim Konvertieren eine Sicherungsdatei erstellen</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation>Automatisches Speichern ausschalten</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation> min</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation>Jeden </translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation>Exportformat</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation>Modustyp in den Dateinamen aufnehmen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation>Zuletzt verwendet speichern</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation>Standard:</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation>Dezimaltrennzeichen:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation>_M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation>_MOV</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation>_R</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation>_ROT</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation>_MA</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation>_MBA</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation>_MB</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation>_MBL</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation>Millimeter</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation>Auswahl Ton</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation>Ton:</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source> (0 - no limit)</source>
         <translation> (0 - unbegrenzt)</translation>
     </message>
     <message>
-        <location line="-394"/>
         <source>Designer Info</source>
         <translation>Designerinfos</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation>Firma / Designerinfos</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation>Firma / Designer:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation>Kontakt:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>City:</source>
         <translation>Stadt:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation>Staat:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation>Postleitzahl:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation>Land:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation>Telefon:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation>Fax:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation>Email:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation>Website:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation>E-Mail-Überprüfung</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-184"/>
         <source>Address:</source>
         <translation>Anschrift:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-38"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation>Gebietsschema des Benutzers</translation>
     </message>
     <message>
-        <location line="-110"/>
         <source>Email format is not valid.</source>
         <translation>Das E-Mail-Format ist nicht gültig.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1031"/>
         <source>Startup</source>
         <translatorcomment>Startup</translatorcomment>
         <translation>Startup</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation>Willkommen</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation>Willkommensbildschirm nicht anzeigen</translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation>Punktbezeichnung Text:</translation>
     </message>
@@ -11779,582 +9096,414 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation>Aussehen</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation>Symbolleiste</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation>Textlabel erscheint unter dem Symbol (empfohlen für Anfänger)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation>Werkzeugleisten anzeigen</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation>Werkzeugpalette</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation>Bogen</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation>Arbeitsabläufe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation>Stück</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation>Layout</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation>Grafische Ausgabe</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation>Antialiasing verwenden</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation>Schriftarten</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation>Etikett</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation>Schriftart:</translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation>Größe:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation>6</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation>7</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation>8</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation>9</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation>10,5</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation>11</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation>12</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation>1313</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation>14</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation>15</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation>16</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation>18</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation>20</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation>22</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation>24</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation>26</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation>28</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation>32</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation>36</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation>40</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation>44</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation>48</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation>54</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation>60</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation>66</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation>72</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation>80</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation>96</translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation>Der schnelle braune Fuchs springt über den faulen Hund</translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation>Punktbezeichnungen</translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation>Graphische Benutzeroberfläche</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation>Farben</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation>Zoom Gummiband</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation>Positiv:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation>Steuerung:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation>Standard:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation>Schweben</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation>Zeichnung</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation>Ausgangsachse</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation>Primär:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation>Sekundär:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation>Tertiär:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation>Steuerung</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation>Bildlaufleisten</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation>Bildlaufleisten anzeigen</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation>Breite:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation> px</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation>Dauer:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation>Scroll-Animations Dauer</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation> ms</translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation>Update Intervall:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation>Zeit in Milisekunden zwischen jedem Animationsupdate</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation>Geschwindigkeit:</translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation>CTRL Modifikator benutzen</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation>Verhalten</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation>Einschränkungen</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation>Winkelschritt:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation> Grad</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation>Mit Doppelklick auf die Auswahl zoomen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation>Schwenk aktiv solange Leertaste gedrückt ist</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
         <translation>Qualität:</translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation>Verzeichnis das Seamly2D benutzt</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Verzeichnis</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation>Verzeichnis öffnen</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation>Meine individuellen Maße</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>Meine Mehrgrößen Maße</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation>Meine Bilder</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation>Meine Datensicherungen</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation>Meine Schnittmuster</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation>Meine Layouts</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation>Meine Vorlagen</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation>Meine Etiketten Vorlagen</translation>
     </message>
@@ -12362,272 +9511,202 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation>Drehen ausschließen</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation>Standardmäßig ist das Drehen für alle neu erstellten Werkstücke verboten</translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation>Standardmäßig wird der Hauptpfad ausgeblendet, wenn die Nahtzugabe aktiviert ist</translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation>Nahtzugaben</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation>Standardwert:</translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation>Datum:</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation>Formate bearbeiten</translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation>Zeit:</translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation>Schnittteil</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation>Markierungen</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation>Markierung sowohl auf der Nahtzugabe als auch auf der  Nahtlinie anzeigen.</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation>Breite:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation>Fadenlauf</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation>Fadenlauf anzeigenn</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation>x 3</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation>Verzeichnisse</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation>Nahtlinie</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation>Linienstärke</translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation>Schnittlinie</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation>Ausschnitte</translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation>Etiketten</translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation>Etikettendaten (Datum/Zeit Format</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation>Schlitz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation>T Markierung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation>U Markierung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation>V Innen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation>V Aussen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation>Burg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation>Schnittmuster Etikett anzeigen</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation>Schnittteil Etikett anzeigen</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation>Breite</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation>Höhe</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation>Vorlagen</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation>Schnittmuster Etikett:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation>Schnittteil Etikett:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation>Etikett Vorlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation>Vorlagen importieren</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation>Markierung auf Schnittlinie anzeigen</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation>Markierung auf Nahtlinie anzeigen</translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation>Interna</translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation>Schnittlinie anzeigen</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation>Nahtlinie ausblenden</translation>
     </message>
@@ -12635,7 +9714,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>Basierend auf Qt %1 (%2, %3 Bit)</translation>
     </message>
@@ -12643,155 +9721,124 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Erstelle ein neues Schnittteil, um mit der Arbeit zu beginnen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>zoll</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Eigenschaft</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Wert</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation>knoten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation>Änderungen übernommen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Falscher Symbolname &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation>Konnte toUInt Parameter nicht umwandeln</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation>Konnte toBool Parameter nicht umwandeln</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation>Leeren Parameter erhalten</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation>Kann toDouble Parameter nicht konvertieren</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation>Falsche Parameter id erhalten. Nur id erforderlich.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation>Stoff</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation>Futter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation>Verstärkung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation>Einlage</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation>Schnitt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation>im Bruch</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation>Verbindungsstück</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation>Schnittteil bewegen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation>Durchgezogene Linie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation>Bindestrich</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation>Strichpunkt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation>Strich Punkt Punkt</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation>Kein Stift</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
@@ -12799,15 +9846,11 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation>Zu wenige Parameter für Summenfunktion.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation>Zu wenige Parameter für Funktion min.</translation>
@@ -12816,217 +9859,181 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unerwartetes Token  &quot;$TOK$&quot; an Position $POS$ gefunden.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Interner Fehler</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Ungültiger Funktions-, Variablen oder Konstantenname: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Ungültiger Binäroperator: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Ungültige Infix-Operator-ID: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Ungültige Postfix-Operator-ID: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Ungültiger Zeiger auf Callback-Funktion.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>Ausdruck ist leer.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Undefinierte Variable.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unerwarteter Operator &quot;$TOK$&quot; an Position $POS$ gefunden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unerwartetes Ende des Ausdrucks an Position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unerwarteter Argumentseparator an Position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unerwartete Klammer &quot;$TOK$&quot; an Position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unerwartete Funktion &quot;$TOK$&quot; an Position $POS$ gefunden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unerwarteter Wert &quot;$TOK$&quot; an Position $POS$ gefunden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unerwartete Variable &quot;$TOK$&quot; an Position $POS$ gefunden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Funktionsargument ohne Funktion benutzt (Position: $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Fehlende Klammer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Zu viele Parameter für die Funktion &quot;$TOK$&quot; in der Ausdrucksposition $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Zu wenige Parameter für die Funktion &quot;$TOK$&quot; in der Ausdrucksposition $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Durch Null teilen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Domainfehler</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Namenskonflikt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>Ungültiger Wert für die Operatorpriorität (muss größer oder gleich Null sein).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Der benutzerdefinierte Binäroperator &quot;$TOK$&quot; steht im Konflikt mit einem eingebauten Operator.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unerwarteter String an Position $POS$ gefunden.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Nicht beendeter String beginnend an der Position $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>Stringfunktion mit einem Argument, das kein String ist, aufgerufen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>String anstelle einer Zahl verwendet.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Kein verwendbarer Overload für Operator &quot;$TOK$&quot; an der Position $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>Funktionsergebnis ist eine Zeichenfolge.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Auswertungsfehler.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>Dezimaltrennzeichen ist identisch zum Trennzeichen des Funktionsarguments.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Der &quot;$TOK$&quot; Operator muss durch eine schließende Klammer eingeschlossen werden.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>Dem if-then-else-Operator fehlt eine else-Klausel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unangebrachter Doppelpunkt an Stellung $POS$</translation>
@@ -13035,7 +10042,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation>Gruppenelement löschen</translation>
     </message>
@@ -13043,7 +10049,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation>Schnittteil umbenennen</translation>
     </message>
@@ -13051,12 +10056,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation>Drücken Sie &lt;b&gt;CTRL&lt;/b&gt; zum Skalieren um die Mitte herum - &lt;b&gt; Seitenverhältnis gesperrt &lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation>Drücken Sie &lt;b&gt;CTRL&lt;/b&gt;, um um die Mitte herum zu skalieren, &lt;b&gt;SHIFT&lt;/b&gt;, um gleichmäßig zu skalieren.</translation>
     </message>
@@ -13064,7 +10067,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation>Detailoption Speichern</translation>
     </message>
@@ -13072,7 +10074,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation>Verzeichnissoptionen sichern</translation>
     </message>
@@ -13080,7 +10081,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation>Werkzeugoption speichern</translation>
     </message>
@@ -13088,88 +10088,70 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>Sprache der Benutzeroberfläche:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation>Schnittmuster System</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation>System:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation>Autor:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation>Buch:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation>Maße bearbeiten</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation>Warnungen zurücksetzen</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation>Symbolleiste</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation>Der Text wird unter dem Symbol angezeigt (empfohlen für Anfänger).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation>Standardkörperhöhe und Größe</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation>Basiskörperhöhe:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation>Größe:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation>Startup</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation>Willkommensbildschirm nicht anzeigen</translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation>Dezimaltrennzeichen:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation>Gebietsschema des Benutzers</translation>
     </message>
@@ -13177,52 +10159,42 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Verzeichnis</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation>Verzeichnis öffnen</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation>Meine individuellen Maße</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>Meine Mehrgrößen Maße</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation>Meine Vorlagen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation>Verzeichnis das SeamlyME benutzt</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation>Meine Körperscans</translation>
     </message>
@@ -13230,57 +10202,46 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Willkommen</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation>Willkommen bei SeamlyME</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation>3D-Look-Benutzer</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation>Um einen 3D Look Körperscan zu verwenden, muss die Datei in das SeamlyME-Format konvertiert werden. </translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation>Hängen Sie Ihre 3DLook-Datei an eine E-Mail an und senden Sie sie an convert@seamly.io.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Sie erhalten dann eine E-Mail mit der konvertierten Datei, die Sie dann wie gewohnt in SeamlyME laden können.</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation>Bitte wählen Sie die gewünschten Einheiten, das Dezimaltrennzeichen und die Sprache. (Sie können diese Angaben später ändern.)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation>Einheiten:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Legt die Standardeinheiten für eine neue Messdatei fest.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Dezimaltrennzeichen:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
@@ -13289,46 +10250,36 @@ Wenn das Kontrollkästchen aktiviert ist, wird das Trennzeichen für das Gebiets
 Wenn es nicht markiert ist, wird der Punkt verwendet.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation>Wenn diese Option aktiviert ist, wird das Willkommensfenster nicht angezeigt. 
 Sie können diese Einstellung in den SeamlyMe-Einstellungen ändern.</translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation>Sprache der Benutzeroberfläche:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation>Legt die für SeamlyMe verwendete Sprache fest.</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation>Nicht mehr anzeigen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Gebietsschema des Benutzers</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Zentimeter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Millimeter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Zoll</translation>
     </message>
@@ -13336,81 +10287,64 @@ Sie können diese Einstellung in den SeamlyMe-Einstellungen ändern.</translatio
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Willkommen</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation>Willkommen bei Seamly2D</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation>Einheiten:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Legt die Standardeinheiten für eine neue Messdatei fest.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Dezimaltrennzeichen:</translation>
     </message>
     <message>
-        <location line="+239"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation>Wenn diese Option aktiviert ist, wird das Willkommensfenster nicht angezeigt. 
 Sie können diese Einstellung in den Seamly2D-Voreinstellungen ändern.</translation>
     </message>
     <message>
-        <location line="-190"/>
         <source>GUI language:</source>
         <translation>Sprache der Benutzeroberfläche:</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Do not show again</source>
         <translation>Nicht mehr anzeigen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Gebietsschema des Benutzers</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Zentimeter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Millimeter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Zoll</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation>Legt die für Seamly2D verwendete Sprache fest.</translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation>Bitte wählen Sie Ihre bevorzugten Einheiten, das Dezimaltrennzeichen, die Sprache und den Auswahlton. (Sie können diese Angaben später ändern.)</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
@@ -13419,12 +10353,10 @@ Wenn das Kontrollkästchen aktiviert ist, wird das Trennzeichen für das Gebiets
 Wenn es nicht markiert ist, wird der Punkt verwendet.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation>Ton:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation>Legt den Klickton für die Knotenauswahl fest.</translation>
     </message>
@@ -13432,12 +10364,10 @@ Wenn es nicht markiert ist, wird der Punkt verwendet.</translation>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation>Schnittteil Farbe ändern</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation>Schnittteilfarbe geändert: </translation>
     </message>
@@ -13445,1071 +10375,854 @@ Wenn es nicht markiert ist, wird der Punkt verwendet.</translation>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation>Abkürzungen in die Zwischenablage kopieren</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation>Verknüpfungen als PDF exportieren</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation>Verknüpfungen an den Drucker senden</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation>Datei</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation>Strg+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation>Strg+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation>Strg+W</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation>Strg+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation>Speichern als</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation>Strg+Umschalt+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation>Drucken</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation>Strg+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation>Schnittteil Voreinstellungen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation>Strg+Umschalt+Comma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation>Dokument Information</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation>Strg+I</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation>Verlassen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation>Strg+Q</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation>Rückgängig</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation>Strg+Z</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation>Strg+Y</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation>Ansicht</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation>Entwurfs-Modus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation>Umschalt+D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation>Stück-Modus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation>Layout-Modus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation>Umschalt+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation>Heranzoomen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation>Strg++</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation>Herauszoomen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation>Strg+-</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation>Zoom 1:1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation>Strg+0</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation>Zoom zum Punkt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation>Strg+Alt+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation>Alles passend</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation>Strg+=</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation>Vorherige</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation>Strg+Links</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation>Ausgewählte</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation>Strg+Right</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation>Gebiet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation>Strg+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation>Pan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation>Z, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation>Namenstext Anzeigen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation>V, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation>Textgröße erhöhen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation>Strg+]</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation>Textgröße verringern</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation>Strg+[</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation>Benutzen Sie das Farbwerkzeug</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation>Wireframe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation>V, W</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation>Kurven Kontrollpunkte</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation>V, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation>Ausgangsachse</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation>V, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation>Nahtzugabe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation>V, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation>Fadenlauf</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation>V, G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation>Etiketten</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation>V, L</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation>Maße</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation>Öffne SeamlyMe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation>Strg+M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation>Variablentabelle</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation>Strg+T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation>Variablentabelle nach CSV exportieren</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation>Strg+E</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation>Werkzeuge</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation>Neuer Entwurfsblock</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation>Strg+Umschalt+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation>Entwurfsblock umbenennen</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation>F2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation>Länge und Winkel</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation>L, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation>Auf Linie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation>O, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation>Auf Senkrechter</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation>O, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation>Auf Winkelhalbierender</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation>O, B</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation>Länge auf einer Linie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation>P, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation>Schneidet Bogen und Linie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation>A, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation>Schneidet Achse und Dreieck</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation>X, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation>Schneidet XY</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation>X, Y</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation>Schneidet Linie und Senkrechte</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation>L, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation>Schneidet Linie und Achse</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation>L, X</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation>Mittelpunkt auf einer Linie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation>Umschalt+O, Umschalt+L</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation>Alt+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation>Punkt - Schneidet Linien</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation>I, L</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation>Kurve - Interaktiv</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation>Alt+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation>Spline - Interaktiv</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation>Kurve - Fixiert</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation>Alt+Umschalt+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation>Spline - Fixiert</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation>Alt+Umschalt+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation>Punkt - Auf Kurve</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation>O, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation>Punkt - Auf Spline	</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation>O, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation>Punkt - Schneidet Kurven</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation>I, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation>Punkt - Schneidet Kurve und Achse</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation>C, X</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation>Bögen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation>Bogen - Radius und Winkel</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation>Bogen - Radius und Länge</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation>Alt+Umschalt+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation>Punkt - Auf einem Bogen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation>O, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation>Punkt - Schneidet Bogen und Achse</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation>A, X</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation>Punkt - Schneidet Bögen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation>I, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation>Punkt - Schneidet Kreise</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation>Umschalt+I, Umschalt+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Punkt - Schneidet Kreis und Tangente</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation>C, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Punkt - Schneidet Bogen und Tangente</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation>A, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation>Bogen - Elliptisch</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation>Alt+E</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation>Arbeitsabläufe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation>Objekte zur Gruppe hinzufügen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation>Drehung</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation>Spiegeln an einer Linie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation>M, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation>Spiegeln an einer Achse</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation>M, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation>Alt+M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation>Abnäherlänge ausgleichen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation>T, D,</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation>Exportiere Entwurfsblöcke</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation>E, D</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation>Bilder</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation>Bild importieren</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation>Alt + I</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation>Schnittteil</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation>Neues Schnittteil</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation>N, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation>Anker Punkt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation>A, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation>Unterverzeichnis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation>I, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation>I, N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation>Eigenschaften bearbeiten</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation>Knebelschloss</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation>Strg+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation>In das Layout aufnehmen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation>Drehen Ausschließen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation>Anheben nach oben</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation>Strg+Home</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation>Unten nach unten</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation>Strg+End</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation>Umbenennen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation>Del</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation>Teile zusammenfügen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation>Schnitteile Exportieren</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation>E, P</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation>Layout</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation>Neue Layout</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation>N, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation>Layout Exportieren</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation>E, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation>Letztes Werkzeug</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation>Strg+Umschalt+L</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation>Chronik</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation>Strg+H</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation>Dienstprogramme</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation>Taschenrechner</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation>Strg+Umschalt+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation>Dezimal Tabelle</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation>Strg+Umschalt+D</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation>Tastaturkurzbefehle</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation>Umschalt+P</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation>PDF exportieren</translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation>Füge Knoten ein</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation>Seamly2D Verknüpfungen</translation>
     </message>
@@ -14517,12 +11230,10 @@ Wenn es nicht markiert ist, wird der Punkt verwendet.</translation>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation>Umschalten der erster Abnäher Sichtbarkeit</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation>Umschalten der zweiten  Abnäher Sichtbarkeit</translation>
     </message>
@@ -14530,42 +11241,34 @@ Wenn es nicht markiert ist, wird der Punkt verwendet.</translation>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation>Dokument Information</translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation>Info in die Zwischenablage kopieren</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation>Als PDF exportieren</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation>Info an den Drucker senden</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation>&lt;Tabellenstil=Schriftgröße:11pt; Schriftstärke:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Firma:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = rights&gt;&lt;b&gt;Kunde:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Schnittmuster Bezeichnung:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Schnittmuster Nummer  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Einheiten:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Maße:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Beschreibung: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Anmerkungen:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/Tabelle &gt;</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation>Info Dateien</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation>PDF exportieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation>_Info</translation>
     </message>
@@ -14573,7 +11276,6 @@ Wenn es nicht markiert ist, wird der Punkt verwendet.</translation>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation>Punktsichtbarkeit umschalten</translation>
     </message>
@@ -14581,7 +11283,6 @@ Wenn es nicht markiert ist, wird der Punkt verwendet.</translation>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation>Punktsichtbarkeit umschalten</translation>
     </message>
@@ -14589,812 +11290,620 @@ Wenn es nicht markiert ist, wird der Punkt verwendet.</translation>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Neu auswählen, um eine neue Maßdatei zu erstellen.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation>Berechneter Wert</translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Formel</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Basiswert</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>In Größen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>In Körperhöhe</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Formel:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation>Basiswert:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation>In Größen:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation>In Körperhöhen:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Beschreibung:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation>Maß nach oben bewegen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Maß nach unten bewegen</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Berechneter Wert:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation>Vollständige Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation>Maßsatztyp</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Verzeichnis:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Im Dateiexplorer anzeigen</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Basisgröße:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation>Wert der Basisgröße</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Basiskörperhöhe:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation>Wert der Basiskörperhöhe</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Vorname:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Nachname:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation>Geburtsdatum:</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>Email:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>Notiz:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>Datei</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Fenster</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Maße</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation>Menü</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation>Gradierung</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation>Individuelle öffnen...</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation>Speichern als ...</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>Über &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>Über SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation>Bekanntes Maß hinzufügen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation>Individuelles Maß hinzufügen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation>Nur lesen</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>Datenbank</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation>Informationen zu allen bekannten Maßen anzeigen</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation>unbenannt %1</translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>Diese Datei ist bereits in einem anderen Fenster geöffnet.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Dateifehler.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Datei konnte nicht gespeichert werden</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Speichern als</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation>&amp;Neues Fenster</translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation>Maß bearbeiten</translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Leeres Eingabefeld.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Auswertungsfehler: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Individuelle Maße</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>ohne Titel</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation>Ungespeicherte Änderungen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Maße wurden geändert. Sollen die Änderungen gespeichert werden?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Leeres Eingabefeld</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation>Von einem Schnittteil importieren</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation>Schnittteil Einheit:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Finden:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation>Vorheriges suchen</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation>Strg+Shift+G</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation>Nächstes finden</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation>Sperren fehlgeschlagen. Diese Datei ist bereits in einem anderen Fenster geöffnet.</translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation>Datei enthält ungültige bekannte Maße.</translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation>Unbekanntes Dateiformat.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Vollständige Bezeichnung</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation>Datei &apos;%1&apos; existiert nicht!</translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation>Die Bezeichnung bekannter Maße kann nicht geändert werden.</translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation>Maß &apos;%1&apos; kann nicht gefunden werden.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation>Die vollständige Bezeichnung bekannter Maße kann nicht geändert werden.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation>Funktionsassistent</translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation>Maß nach ganz oben bewegen</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation>Maß nach ganz unten bewegen</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation>Maß löschen</translation>
     </message>
     <message>
-        <location line="+797"/>
         <source>Gender:</source>
         <translation>Geschlecht:</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation>Schnittmustersystem:</translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation>Erstellen aus vorhandenem...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation>Aus vorhandener Datei erstellen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1624"/>
         <source>Select file</source>
         <translation>Datei auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation>Maßdiagramm</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; Schriftgröße:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;Zentrum\&quot;&gt;Unbekanntes Maß&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; Schriftgröße:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;Zentrumr&quot;&gt;Unbekanntes Maß&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>Über QT</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>Datei wurde noch nicht gesichert.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Suche</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation>Name des Maßes in einer Formel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation>Name des Maßes in einer Formel.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation>Name des Maßes für Menschen lesbar.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>Speichern...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Nicht Speichern</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Datei wird gesperrt</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Die Sperrdatei konnte aufgrund fehlender Berechtigungen nicht erstellt werden.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Ein unbekannter Fehler ist aufgetreten, zum Beispiel hat eine volle Festplattenpartition verhindert, dass die Sperrdatei geschrieben werden konnte.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation>Als CSV exportieren</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Im Finder anzeigen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation>Vorname des Kunden</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation>Nachname des Kunden</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation>Emailadresse des Kunden</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Körperhöhe:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Größe:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation>Alle Dateien</translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation>Das Maße Dokument hat keine Schreibberechtigung.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Kann keine Erlaubniss für %1 als schreibbar setzen.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Kann die Datei nicht sichern.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation>Kann die Datei nicht sichern</translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation>Nur lesen</translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation>Mehrgrößen Maße</translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Ungültiges Ergebnis: Der Wert ist unendlich oder NaN, Bitte die Berechnung prüfen.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation>Leer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation>Mehrgrößen öffnen...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation>Der Export von Mehrgrößen Maßen wird nicht unterstützt.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation>Strg+O</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation>Strg+S</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Umschalt+S</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation>Strg+Q</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation>Strg+N</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation>Strg+Umschalt+O</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation>Strg+,</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation>Verknüpfungen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation>Fehler beim Sperren. Diese Datei ist bereits in einem anderen Fenster geöffnet. Beim Arbeiten mit zwei Kopien des Programms kommt es zu Kollisionen.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation>Drucken</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation>Strg+P</translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation>Nummer</translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation>Strg+E</translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation>In die Zwischenablage kopieren</translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation>Vorlage öffnen ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation>Strg+Alt+O</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation>Schnittmusterdateien</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Diese Datei ist bereits in einem anderen Fenster geöffnet.Ignorieren, wenn Sie fortfahren wollen (nicht empfohlen, kann zu Datenverlust führen).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Die Sperrdatei konnte aufgrund fehlender Berechtigungen nicht erstellt werden. Ignorieren, wenn Sie fortfahren wollen (nicht empfohlen, kann zu Datenverlust führen).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Ein unbekannter Fehler ist aufgetreten, zum Beispiel hat eine volle Festplattenpartition verhindert, dass die Sperrdatei geschrieben werden konnte. Ignorieren, wenn Sie fortfahren wollen (nicht empfohlen, kann zu Datenverlust führen).</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation>Körperscan importieren als</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation>3D Measure Up</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation>3D Look</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+118"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation>unbekannt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>männlich</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>weiblich</translation>
     </message>
     <message>
-        <location line="-2837"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation>Um einen 3DLook-Körperscan zu verwenden, muss die Datei in das SeamlyME-Format konvertiert werden.
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
@@ -15403,7 +11912,6 @@ Do you want to save your changes?</source>
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15414,7 +11922,6 @@ wie gewohnt in SeamlyME laden können.
 </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation>3DLook-Datei konvertieren:</translation>
     </message>
@@ -15422,22 +11929,18 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation>Schnittteil in Layoutliste</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation>Schnittteil in das Layout übernehmen wurde geändert: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation>Einschließen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation>Ausschließen</translation>
     </message>
@@ -15445,22 +11948,18 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation>Schnittteil sperren</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation>Schnittteil sperren wurde geändert: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation>Gesperrt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation>Entsperrt</translation>
     </message>
@@ -15468,47 +11967,38 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation>Erster Punkt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation>Zweiter Punkt</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation>Oberster Punkt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation>Unterster Punkt</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation>Punkt ganz links</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation>Punkt ganz rechts</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation>Vertikale Achse</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation>Horizontale Achse</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation>Linie_</translation>
     </message>
@@ -15516,47 +12006,38 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation>Verbindungswerkzeug</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sollen die Details wirklich vereinigt werden?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation>Die Original Schnittteile zurückbehalten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation>Den ersten Punkt auswählen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation>Das Schnittteil soll mindestens zwei Punkte und drei Objekte haben</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation>Einen zweiten Punkt auswählen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation>Einen eindeutigen Punkt auswählen</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation>Ein Schnittteil auswählen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation>Einen Punkt am Rand auswählen</translation>
     </message>
@@ -15564,7 +12045,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation>Verbindungsschnittteile</translation>
     </message>
@@ -15572,17 +12052,14 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Nicht erneut fragen</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Nicht erneut &amp;fragen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>Nicht mehr &amp;anzeigen</translation>
     </message>
@@ -15590,57 +12067,46 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Versionsinformation konnte nicht gelesen werden.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>Zu viele Tags &lt;%1&gt; in der Datei.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Version &quot;%1&quot; ist ungültig.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Version &quot;0.0.0&quot; ist ungültig.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Ungültige Version. Minimal unterstützte Version ist%1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Ungültige Version. Maximal unterstützte Version ist%1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Fehler: uneindeutige ID.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>Versionsnummer konnte nicht geändert werden.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation>Fehler bei der Erstellung einer Reservekopie : %1.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Unerwartete Version &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation>Fehler beim Öffnen einer temporären Datei %1.</translation>
     </message>
@@ -15648,7 +12114,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation>Spline kann nicht unterteilt werden</translation>
     </message>
@@ -15656,22 +12121,18 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation>Umschreiben des Formats bestätigen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation>Diese Datei verwendet die vorherige Formatversion v%1. Die aktuelle Version ist v%2. Wenn Sie die Datei mit dieser Anwendungsversion speichern, wird die Formatversion für diese Datei aktualisiert. Dies kann dazu führen, dass Sie die Datei nicht mehr mit älteren Programmversionen öffnen können. Möchten Sie wirklich fortfahren?</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation>Komma-getrennte Werte</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation>Als CSV exportieren</translation>
     </message>
@@ -15679,13 +12140,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
@@ -15693,23 +12151,18 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>Werkzeug kann in der Tabelle nicht gefunden werden.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation>Fehler beim Anlegen oder Aktualisieren der Gruppe</translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>Neue Gruppe</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation>Neue Gruppe 2</translation>
     </message>
@@ -15717,7 +12170,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation>Stück</translation>
     </message>
@@ -15725,12 +12177,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
@@ -15738,285 +12188,228 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Löschvorgang bestätigen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Möchtest Du wirklich löschen?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation>Falsche Formel bearbeitet</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation>Grün</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation>Blau</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation>Dunkelrot</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation>Dunkelgrün</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation>Dunkelblau</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation>Gelb</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation>Helles Lachsrosa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation>Goldrute</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation>Orange</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation>Dunkelrosa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation>Violett</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation>Dunkelviolett</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation>Mittleres Meeresgrün</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation>Tiefes Himmelsblau</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation>Kornblumenblau</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation>Schwarz</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation>Gold</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation>Waldgrün</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation>Rasengrün</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation>Lindgrün</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation>Grün Gelb</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation>Sandiges Braun</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation>Orangerot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation>Kastanienbraun</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation>Rosa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation>Leuchtendes Pink</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation>Blauviolett</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation>Mittleres Rotviolett</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation>Indigo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation>Lila</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation>Pflaume</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation>Türkis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation>Mittleres Türkis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation>Puderblau</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation>Helles Himmelsblau</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation>Marineblau</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation>Dunkles Schiefergrau</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation>Grau</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translatorcomment>englischer Mler</translatorcomment>
         <translation>Gainsboro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation>Dunkles Meeresgrün</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation>Hellgrau</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation>Helles Stahlblau</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translatorcomment>ist schon deutsch</translatorcomment>
         <translation>Beige</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation>Distelfarben</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation>Silber</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation>Rauchweiß</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation>Weiß</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation>Dunkelgrau</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation>Kadettenblau</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation>Dunkles Khaki</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translatorcomment>oder auch Gelbbraun</translatorcomment>
         <translation>Hellbraun</translation>
@@ -16025,302 +12418,242 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation>Pfad zur individuellen Maßdatei (Exportmodus).</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation>Die Maßsatzdatei</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation>Format Nummer</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation>Vorlagennummer</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>Die Seitenbreite</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation>Die Maßeinheit</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation>Automatisches Zuschneiden der ungenutzten Länge (Exportmodus).</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation>Layout -Einheiten (eines Papiers mit Ausnahme von px, Export-Modus).</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation>Die Einheit</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation>Die Spaltenbreite</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation>Gruppentyp</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation>Seitenformat und explizite Größe/Einheiten der Seite können nicht zusammen verwendet werden.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation>Höhe, Breite und Einheiten der Seite müssen alle 3 auf einmal benutzt werden.</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation>Ungültiger Rotationswert. Dies muss ein vordefinierter Wert sein.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation>Unbekannte Seitenvorlage verwendet.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation>Nicht unterstützte Papiergröße.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation>Nicht unterstützte Layouteinheiten.</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation>Exportoptionen können nur mit einer Eingabedatei verwendet werden.</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation>Testoption kann nur mit einer Eingabedatei verwendet werden.</translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation>Der Basisdateiname der exportierten Layout-Dateien. Verwenden Sie diesen, um den Export-Konsolen-Modus zu aktivieren.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation>Der Basisdateiname der Layoutdateien</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>Der Zielordner</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation>Die Basisgröße</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation>Die Basiskörperhöhe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Seitenbreite in der derzeitigen Einheit wie 12.0 (kann nicht mit &quot;%1&quot; benutzt werden, Exportmodus).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Seitenhöhe in der derzeitigen Einheit wie 12.0 (kann nicht mit &quot;%1&quot; benutzt werden, Exportmodus).</translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation>Ungültiges Größen Gradierungsmaß.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation>Ungültiges Längen Körperhöhen Gradierungsmaß.</translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Schnittmusterprogramm.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Schnittmusterdatei.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation>Die Spaltenbreite muss zusammen mit Verschiebungseinheiten genutzt werden.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation>Der linke Rand muss zusammen mit Seiteneinheiten genutzt werden.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation>Der rechte Rand muss zusammen mit Seiteneinheiten genutzt werden.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation>Der obere Rand muss zusammen mit Seiteneinheiten genutzt werden.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation>Der untere Rand muss zusammen mit Seiteneinheiten genutzt werden.</translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation>Der Pfad zum Zielordner. Standardmäßig das Verzeichnis, in dem das Programm gestartet wurde.</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation>Einheiten für die Seitenhöhe/-breite (kann nicht mit &quot;%1&quot;, Exportmodus, benutzt werden). Gültige Werte: %2.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation>Ignorieren der Seitenränder zum Druck (Export-Modus). Deaktiviert Werte-Schlüssel: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Setzen Sie alle Seitenränder auf 0.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Linker Seitenrand in der derzeitigen Größe wie 3.0 (Exportmodus). Wenn kein Wert eingegeben wird, wird die Einstellung des Standarddruckers verwendet. Oder 0, falls kein Drucker gefunden werden kann. Der Wert wird ignoriert, falls &quot;%1&quot; verwendet wird.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Rechter Seitenrand in der derzeitigen Größe wie 3.0 (Exportmodus). Wenn kein Wert eingegeben wird, wird die Einstellung des Standarddruckers verwendet. Oder 0, falls kein Drucker gefunden werden kann. Der Wert wird ignoriert, falls &quot;%1&quot; verwendet wird.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Oberer Seitenrand in der derzeitigen Größe wie 3.0 (Exportmodus). Wenn kein Wert eingegeben wird, wird die Einstellung des Standarddruckers verwendet. Oder 0, falls kein Drucker gefunden werden kann. Der Wert wird ignoriert, falls &quot;%1&quot; verwendet wird.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Unterer Seitenrand in der derzeitigen Größe wie 3.0 (Exportmodus). Wenn kein Wert eingegeben wird, wird die Einstellung des Standarddruckers verwendet. Oder 0, falls kein Drucker gefunden werden kann. Der Wert wird ignoriert, falls &quot;%1&quot; verwendet wird.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation>Drehung in Grad (eins der vordefinierten, Exportmodus). Standardwert ist 180. 0 bedeutet keine Drehung. Gültige erte: %1. Jeder Wert zeigt, wie oft Details gedreht werden sollen. Zum Beispiel bedeutet 180, dass das Detail zweimal im 180 Grad gedreht word (360/180=2).</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation>Seiten verbinden, falls möglich (Exportmodus). Maximaler Wert wird durch QImage limitiert, das nur Bilder mit bis zu 32768 x 32768 Pixeln unterstützt.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation>Speichern der Blattlänge, falls gesetzt (Export-Modus). Diese Einstellung sagt dem Programm, möglichst viel der Breite eines Blattes zu benutzen. Die Qualität der Anordnung kann sich verschlechtern, wenn diese Einstellung benutzt wurde.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation>Die Layout-Spaltbreite x2, gemessen in Layout-Einheiten. (Export-Modus). Legt den Abstand zwischen Details und einem Detail und einem Blatt fest.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation>Legt Layoutgruppierungsfälle fest (Export-Modus): %1.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation>Das Programm in einem Testmodus laufen lassen. In diesem Modus lädt das Programm eine einzelne Schnittmuster-Datei und schließt still, ohne das Hauptfenster zu zeigen. Der Schlüssel hat Vorrang vor dem Schlüssel &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation>Verschieben der gemessenen Layoutlängen in Layouteinheiten (Exportmodus). Die Option zeigt, wie viele Punkte entlang der Kante verwendet werden, um ein Layout zu erstellen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation>Verschiebungs-/Ausgleichslänge</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation>Die Verschiebungs-/Ausgleichslänge muss zusammen mit Verschiebungseinheiten genutzt werden.</translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation>Anzahl entspricht Ausgabeformat (default = 0 , Export -Modus):</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation>Anzahl entsprechend Seitenvorlage (Standard = 0, Exportmodus):</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Hohe dpi Skalierung deaktivieren. Diese Option wählen wenn es Probleme mit der Skalierung (StandardSkalierung aaktiviert). Alternativ können die %1 Umgebungsvariablen genutzt werden.</translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation>DXF in binärer Form exportieren.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation>Text als Verzeichnis exportieren.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation>Nur Details exportieren. Details so wie thie im Detailsmodus posiotioniert sind exportieren. Jeglliche Layoutspezifischen Optionen werden ignoriert.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation>Größenwert einer Schnittteildatei setzen, die mit Standardmaßen (Exportmodus) geöffnet wurde. Gültige Werte: %1cm.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation>Körperhöhenwert einer Schnittteildatei setzen, die mit Standardmaßen (Exportmodus) geöffnet wurde. Gültige Werte: %1cm.</translation>
     </message>
@@ -16328,43 +12661,34 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation>Maße</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation>Individuell</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation>Mehrgröße</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation>Vorlagen</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation>Bilder</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation>etikett_vorlagen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation>datensicherungen</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation>körperscans</translation>
     </message>
@@ -16372,55 +12696,42 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>Objekt kann nicht gefunden werden</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation>Objekt kann nicht gelesen werden</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation>Objekt kann nicht gefunden werden. Falscher Typ.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation>Anzahl der freien id&apos;s aufgebraucht.</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation>Kurve vom Typ &apos;%1&apos; kann nicht erstellt werden</translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation>Objekt kann nicht gefunden werden: </translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation>Schnittteil kann nicht gefunden werden: </translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation>Verzeichnis kann nicht gefunden werden: </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation>Objekt Id kann nicht gefunden werden: </translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation>Objekt kann nicht ausgeworfen werden.</translation>
     </message>
@@ -16428,12 +12739,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation>Nicht genügend Punkte vorhanden, um die Spline zu erstellen.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation>Diese Spline existiert nicht.</translation>
     </message>
@@ -16441,51 +12750,41 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>Konnte Datei nicht öffnen %1: %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Konnte Schemadatei nicht öffnen %1:
 %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation>Fehler bei der Gültigkeitsprüfung in Datei %3, Zeile %1, Spalte %2</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation>Auswertungsfehler in Datei %3, Zeile %1, Spalte %2</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation>Konnte&apos;t Knoten nicht erhalten</translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>Diese ID ist nicht eindeutig.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation>Konnte Schemadatei %1 nicht laden.</translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation>Canonical XML kann nicht geschrieben werden.</translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;leer&gt;</translation>
     </message>
@@ -16493,27 +12792,22 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation>Punktbezeichnung anzeigen</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation>Gruppen Objekt hinzufügen</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation>Gruppen Objekt entfernen</translation>
     </message>
@@ -16521,7 +12815,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation>Ausnahme: %1</translation>
     </message>
@@ -16529,11 +12822,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
@@ -16541,7 +12829,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation>Formel:</translation>
     </message>
@@ -16549,7 +12836,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation>Schnittteil %1 hat keine Form.</translation>
     </message>
@@ -16557,7 +12843,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation>Bezeichnung des Punktes anzeigen</translation>
     </message>
@@ -16565,12 +12850,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>Wahr</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>Falsch</translation>
     </message>
@@ -16578,12 +12861,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Verzeichnis</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Datei öffnen</translation>
     </message>
@@ -16591,335 +12872,246 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Fehler beim Auswerten der Datei.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Fehler: Wert kann nicht konvertiert werden.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Fehler: leerer Parameter.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Fehler: falsche ID.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Fehler beim Auswerten der Datei  (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Punkt&quot;</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Punkt mit Abstand und Winkel&quot;</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Punkt auf einer Linie&quot;</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Spezieller Punkt an der Schulter&quot;</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Punkt auf einer Senkrechten&quot;</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Winkelhalbierende&quot;</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Schnittpunkt Kreis und Gerade&quot;</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Punkt&quot;</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Lotfußpunkt&quot;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Dreieck&quot;</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Kurvensegment&quot;</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Pfadsegment&quot;</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Kreisbogen&quot;</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Laufender Schnittpunkt auf Linie&quot;</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Laufender Schnittpunkt auf Kurve&quot;</translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Linie&quot;</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Kurve&quot;</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Gekrümmter Pfad&quot;</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Eintrags vom Typ &quot;Kurve Detail&quot;</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation>Fehler beim Anlegen oder Aktualisieren der Modellierung des  vom Typ &quot;Pfad Detail&quot;</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des einfachen Bogens&quot;</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation>Fehler beim Anlegen oder Aktualisieren der Bogenmodellierung &quot;</translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation>Fehler beim Erstellen oder Aktualisieren des Bogen Schnittpunktes</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation>Fehler beim Erstellen oder Aktualisieren der Kreis Schnittpunktes</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation>Fehler beim Erstellen oder Aktualisieren des Punktes von Kreis und Tangente</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation>Fehler beim Erstellen oder Aktualisieren des Punktes von Bogen und Tangente</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation>Fehler beim Erstellen oder Aktualisieren des Abnäherausgleichs</translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Falsche  Markenbezeichnung &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation>Unbekannter Punkt Typ &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation>Unbekannte Spline Typ &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation>Unbekannter Bogen Typ &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation>Unbekannter Werkzeug Typen &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation>Fehler: uneindeutige ID.</translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation>Fehler beim Anlegen oder Aktualisieren vom Punkt der Schnittkurven&quot;</translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation>Fehler beim Anlegen oder Aktualisieren der einfachen interaktiven Spline</translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des interaktiven Splinepfades</translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation>Fehler beim Erstellen oder Aktualisieren der kubischen Bezierkurve</translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation>Fehler beim Erstellen oder Aktualisieren des Pfades der kubischen Bezierkurve</translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Operation Drehung</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation>Unbekannte Betriebsart &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Operation Bewegen</translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation>Fehler beim Erstellen oder Aktualisieren von Punkt des Linienschnittpunkts</translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des einfachen elliptischen Bogens</translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation>Unbekannter elliptischer Bogen Typ &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation>Fehler beim Anlegen oder Aktualisieren modellieren elliptischer Bogen</translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation>Unbenannter Pfad</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation>Fehler beim Anlegen oder Aktualisieren eines Schnittteil Verzeichnisses</translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Ankerpunkts</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation>Fehler beim Anlegen oder Aktualisieren des Schnittpunkts XY Werkzeugs</translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation>Fehler beim Erstellen oder Aktualisieren der Spiegeln an einer Linie Operation</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation>Fehler beim Erstellen oder Aktualisieren der Spiegeln an einer Achse Operation</translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation>Stück</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation>Weiß</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation>kein Pinsel</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation>Fehler beim Anlegen oder Aktualisieren eines Schnittteils</translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation>Fehler beim Anlegen oder Aktualisieren der Verbindungsschnittteile</translation>
     </message>
@@ -16927,17 +13119,14 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation>Raster ( %1 , %2 )</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation>Seite %1 von %2</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation>Blatt %1 von %2</translation>
     </message>
@@ -16945,12 +13134,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation>Muster</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation>Layouts</translation>
     </message>
@@ -16958,14 +13145,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>Nicht genügend Punkte vorhanden, um die Spline zu erstellen.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>Diese Spline existiert nicht.</translation>
     </message>
@@ -16973,17 +13156,14 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
@@ -16991,27 +13171,22 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation>Anfangswinkel</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation>     Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation>     Radius</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Abschlusswinkel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation>      Etikett</translation>
     </message>
@@ -17019,37 +13194,30 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation>Anfangswinkel</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation>     Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation>     Radius</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Abschlusswinkel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation>      Bezeichnung</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation>      Werkzeug</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation>Bogen - Radius und Länge</translation>
     </message>
@@ -17057,7 +13225,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
@@ -17065,12 +13232,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Kann keinen Schnittpunkt %1 von Punkt %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;zur Kurve %3 mit einem Achsenwinkel von %4 erstellen°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;den Startpunkt als Platzhalter benutzen bis das Mustter korrigiert ist.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation>Schnittpunkt von Kurve &amp; Achse</translation>
     </message>
@@ -17078,32 +13243,26 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation>Bogen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation>Anfangswinkel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation>Endwinkel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation>Radius</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation>Etikett</translation>
     </message>
@@ -17111,18 +13270,14 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation>Etikett</translation>
     </message>
@@ -17130,18 +13285,14 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation>Etikett</translation>
     </message>
@@ -17149,7 +13300,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
@@ -17157,28 +13307,22 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation>Anfangswinkel</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation>     Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation>    Radius</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Endwinkel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation>      Etikett</translation>
     </message>
@@ -17186,17 +13330,14 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
@@ -17204,12 +13345,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Winkel</translation>
     </message>
@@ -17217,7 +13356,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
@@ -17225,27 +13363,22 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Schnittpunkt kann nicht gefunden werden %1 von&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Linie und Achse&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Anfangspunkt als Platzhalter verwenden bis Schnittteil korrigiert ist.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation>Schneidet Linie und Achse</translation>
     </message>
@@ -17253,17 +13386,14 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
@@ -17271,7 +13401,6 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation>Ausgangspunkt</translation>
     </message>
@@ -17279,12 +13408,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation>Erster Punkt der Linie</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation>Zweiter Punkt der Linie</translation>
     </message>
@@ -17292,27 +13419,22 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Mittelpunkt</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation>Rotationspunkt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation>Rotationswinkel</translation>
     </message>
@@ -17320,714 +13442,398 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Ausgangspunkt</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation>Abnäherlänge ausgleichen</translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation>Startpunkt:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation>Mittelpunkt:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation>Erster Winkel:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Zweiter Winkel:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation>Dritter Punkt:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Bezeichnung des Punktes 1:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation>Bezeichnung des Punktes 2:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation>Erster Ausgangspunkt:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation>Zweiter Ausgangspunkt:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation>Erster Abnäherpunkt:</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation>Bogen:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation>Kurve:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation>Erster Punkt der Linie:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Zweiter Punkt der Linie:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Mittelpunkt des Bogens:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation>Erster Bogen:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation>Zweiter Bogen:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation>Nehmen:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation>Erste Kurve:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation>Zweite Kurve:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation>Tangentenpunkt:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation>Kreisradius:</translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>C1 Winkel:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation>C1: Länge:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>C2: Winkel:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation>C2: Länge:</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation>Achsenpunkt:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Axis type:</source>
         <translation>Achsentyp:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation>Drehwinkel:</translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation>Vierter Punkt:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation>Punkt - schneidet XY</translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation>Drehung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation>Drehpunkt:</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation>Spiegeln an einer Linie</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation>Spiegeln an einer Achse</translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation>Koordinaten</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation>Punkt - Länge und Winkel</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation>Punkt - auf Linie</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation>Bogen - Radius und Winkel</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation>Bogen - Radius und Länge</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation>Punkt - auf Winkelhalbierender</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation>Zweiter Abnäherpunkt:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation>Dritter Abnäherpunkt:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation>Punkt - auf Bogen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation>Punkt - auf Kurve</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation>Punkt - auf Spline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation>Punkt - schneidet Linie und Senkrechte</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation>Punkt - schneidet Linien</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation>Erste Linie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation>Zweite Linie</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation>Punkt - auf einer Senkrechten</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation>Drehung:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation>Punkt - schneidet Bogen und Linie</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation>Erster Linienpunkt:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation>Zweiter Linienpunkt:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation>Punkt - schneidet Bögen</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation>Punkt - schneidet Kreise</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation>Erster Kreis:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation>Mitte:</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation>Zweiter Kreis:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation>Punkt - schneidet Kurven</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation>Vertikale Aufnahme:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation>Horizontale Aufnahme:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Punkt - schneidet Kreis und Tangente</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Punkt - schneidet Bogen und Tangente</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation>Punkt - Länge zur Linie</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation>Kurve - interaktiv</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation>Kurve - fixiert</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation>Spline - interaktiv</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation>Spline - fixiert</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation>Punkt - schneidet Achse und Dreieck</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation>Erster Achsenpunkt:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation>Zweiter Achsenpunkt:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation>Punkt - schneidet Linie und Achse</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation>Punkt - schneidet Kurve und Achse</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Origin point:</source>
         <translation>Ausgangspunkt:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Arc - Elliptical</source>
         <translation>Bogen - elliptisch</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation>Bogen_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation>SplVerzeichnis</translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation>Linie_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Mittelpunkt</translation>
     </message>
@@ -18035,12 +13841,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Schnittpunkt kann nicht gefunden werden %1 von &lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 und Tangente&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Ausgangspunkt als Platzhalter benutzen bis Schnittteil korrigiert ist.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation>Schneidet Bogen und Tangente</translation>
     </message>
@@ -18048,17 +13852,14 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
@@ -18066,12 +13867,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Schnittpunkt der Bögen kann nicht gefunden werden %1 von Bögen&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Ausgangspunkt als Platzhalter benutzen bis Schnittteil korrigiert ist.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation>Punkt schneidet Bögen</translation>
     </message>
@@ -18079,12 +13878,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Schnittpunkt kann nicht gefunden werden %1 der Kurven&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Ausgangspunkt als Platzhalter benutzen bis Schnittteil korrigiert ist.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation>Punkt schneidet Kurven</translation>
     </message>
@@ -18092,12 +13889,10 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation>  Ausgangspunkt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation>Drehwinkel</translation>
     </message>
@@ -18105,17 +13900,14 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation>Länge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Winkel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation>Bezeichnung</translation>
     </message>
@@ -18123,1552 +13915,1295 @@ wie gewohnt in SeamlyME laden können.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation>Bunka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation>Bunka Fashion College</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation>Fundamentals of Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation>Barnfield und Richard</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation>Jo Barnfield und Andrew Richards</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation>Pattern Making Primer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation>Friendship/Women</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation>Elizabeth Friendship</translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation>Morris, K.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation>Karen Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation>Sewing Lingerie that Fits</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation>Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation>Lucia Mors de Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation>Patternmaking in Practice</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation>Kim &amp; Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation>Injoo Kim and Mykyung Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation>Apparel Making in Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation>Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation>Norah Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation>Corsets and Crinolines</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation>Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation>Frances Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation>Fashions of the Gilded Age</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation>Thorntons internationales System</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>Ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation>The Great War: Styles and Patterns of the 1910s</translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation>Hillhouse &amp; Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation>Marion S. Hillhouse und Evelyn A. Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation>Dress Design: Draping and Flat Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation>Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation>Esther Kaplan Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation>How to Design Beautiful Clothes: Designing and Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation>Minister &amp; Sohn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>Edward Minister &amp; Sohn, ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation>The Complete Guide to Practical Cutting (1853)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation>Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation>Gertrude Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation>A Tailoring Manual</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation>Loh &amp; Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation>May Loh und Diehl Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternless Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation>Morris, F. R.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation>F. R. Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation>Ladies Garment Cutting and Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation>Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation>Gertrude Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation>Gertrude Mason&apos;s Patternmaking Book</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation>Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation>K. Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation>Master Designer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation>The Master Designer (Chicago, IL)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation>Master Designer&apos;s System of Designing, Cutting and Grading</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation>Kopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation>How to Draft Basic Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation>Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation>Doris Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation>Slacks Cut-to-Fit for Your Figure</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation>Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation>Sarah J. Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation>Sarah&apos;s Key to Pattern Drafting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation>Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation>Karla J. Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation>Design and Sew Jeans</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Lady Boutique magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation>Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation>M. Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting and Grading: Women&apos;s and Misses&apos; Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation>Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation>Dorothy Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation>Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation>Bina Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation>Integrating Draping, Drafting and Drawing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation>Sue S. Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Dressmaking International magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation>Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation>Mabel D. Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation>Practical Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation>Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation>E. L. G. Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>Principles of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation>Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation>Elizabeth M. Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation>European Cut</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation>McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation>Donald H. McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation>How to Make Your Own Sewing Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation>Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation>Zarapkar System of Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation>Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation>Philip Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation>Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation>Jack Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation>Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation>R. I. Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation>MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation>Jason MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation>The Victorian Tailor: An Introduction to Period Tailoring</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation>Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation>Helen Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation>Supreme System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation>Frederick T. Croonberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation>Sugino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation>Dressmaking</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting Vols. I, II, III (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation>Centre Point System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation>Louis Devere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation>The Handbook of Practical Cutting on the Centre Point System</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation>Aldrich/Herren</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation>Winifred Aldrich</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation>Aldrich/Damen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Women&apos;s Wear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation>Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation>Gareth Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation>Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation>Teresa Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation>Pattern-Drafting for Fashion: The Basics</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation>Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation>Dennic Chunman Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation>Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation>Schnittmuster-Design: Die Grundlagen des Zuschneidens und Anpassens</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation>Knowles/Herren</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation>Lori A. Knowles</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation>The Practical Guide to Patternmaking for Fashion Designers: Menswear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation>Friendship/Men</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting for Men&apos;s Costume</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation>Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation>P. Clement Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation>Art in Dress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation>Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation>Jno. J. Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation>GOST 17917-86</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation>Ministry of consumer industry of the USSR</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation>Standard figure boys</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation>Eddy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation>Josephine F. Eddy und Elizabeth C. B. Wiley</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation>Pattern and Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation>Knowles/Damen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation>Praktischer Leitfaden zur Mustererstellung für Modedesigner:JuniorInnen, und Frauen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation>American Garment Cutter</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation>Keine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation>Seamly2D Team</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation>Seamly2D&apos;s interner Standard</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>zoll</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>SplVerzeichnis</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Winkel1SplVerzeichnis</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Winkel2SplVerzeichnis</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation>AktuelleLänge</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation>Größe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation>Körperhöhe</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>C1LängeSplVerzeichnis</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>C2LängeSplVerzeichnis</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation>AktuelleNahtzugabe</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation>Zeit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation>Name des Schnittmusters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation>Nummer des Schnittmusters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation>Autor</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation>Kunde</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation>pExt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation>pDateiname</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation>mDateiname</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation>mExt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation>pBuchstabe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation>pAnmerkung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation>pOrientierung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation>pDrehung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation>pNeigung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation>pPosition des Bruchs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation>pBezeichnung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation>pMenge</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation>mStoff</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation>mFutter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation>mSchnittstelle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation>mEinlage</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation>wSchnitt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation>wOnFold</translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>M_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Variab_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Linie_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Winkellinie_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Bogen_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>ElBogen_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>RadiusBogen_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Radius1ElBogen_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Radius2ElBogen_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Winkel1Bogen_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Winkel2Bogen_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Winkel1ElBogen_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Winkel2ElBogen_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Winkel1Spl_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Winkel2Spl_</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation>Seg_</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>C1LängeSpl_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>C2LängeSpl_</translation>
@@ -19677,17 +15212,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation>&lt;b&gt;gekrümmter Pfad&lt;/b&gt;: sieben oder mehr Punkte auswählen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation>&lt;b&gt;gekrümmter Pfad&lt;/b&gt;: mehr Punkte für gesamtes Segment auswählen</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;gekrümmter Pfad&lt;/b&gt;: sieben oder mehr Punkte auswählen, mit &lt;b&gt;ENTER&lt;/b&gt; Werkzeugerstellung abschließen</translation>
     </message>
@@ -19695,7 +15227,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation>&lt;b&gt;Laufender Schnittpunkt auf Kurve&lt;/b&gt;: Winkel = %1°, SHIFT &lt;b&gt;halten&lt;/b&gt; um Winkel einzuschränken, mit &lt;b&gt;ENTER&lt;/b&gt; die Werkzeugerstellung abschließen </translation>
     </message>
@@ -19703,7 +15234,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Punkt Länge und Winkel&lt;/b&gt;:Winkel = %1°, Länge = %2%3; SHIFT &lt;b&gt;halten&lt;/b&gt; um Winkel einzuschränken, mit &lt;b&gt;ENTER&lt;/b&gt; die Werkzeugerstellung abschließen</translation>
     </message>
@@ -19711,7 +15241,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Schnittpunkt Linie und Achse&lt;/b&gt;: Winkel = %1°, SHIFT &lt;b&gt;halten&lt;/b&gt; um Winkel einzuschränken, Mit &lt;b&gt;ENTER&lt;/b&gt; Werkzeugerstellung abschließen</translation>
     </message>
@@ -19719,12 +15248,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation>Länge = %1%2, Winkel = %3°, &lt;b&gt;Shift&lt;/b&gt; um Winkel einzuschränken, &lt;b&gt;Maus click&lt;/b&gt; - Auswahl einer Position abschließen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation>Länge = %1%2, Winkel = %3°,Drehwinkel = %4° SHIFT &lt;b&gt;halten&lt;/b&gt; um Winkel einzuschränken,&lt;b&gt;CTRL&lt;/b&gt; - Drehwinkelpunkt ändern, &lt;b&gt;Maus click&lt;/b&gt; - Erstellung abschliessen</translation>
     </message>
@@ -19732,7 +15259,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation>Winkel drehen = %1°, SHIFT &lt;b&gt;halten&lt;/b&gt; um Winkel einzuschränken, &lt;b&gt;Maus click&lt;/b&gt; - Erstellung abschließen</translation>
     </message>
@@ -19740,7 +15266,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation>SHIFT &lt;b&gt;halten&lt;/b&gt; um Winkel einzuschränken</translation>
     </message>
@@ -19748,17 +15273,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;gekrümmter Pfad&lt;/b&gt;: drei oder mehr Punkte auswählen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;gekrümmter Pfad &lt;/b&gt;: drei oder mehr Punkte auswählen, Mit &lt;b&gt;ENTER&lt;/b&gt; Werkzeugerstellung abschließen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation>Mit &lt;b&gt;SHIFT&lt;/b&gt; Winkel einschränken</translation>
     </message>
@@ -19766,47 +15288,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>Fehlerbeseitigung:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>WARNUNG:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>KRITISCH:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation>Kritischer Fehler</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation>Fataler Fehler</translation>
     </message>
@@ -19814,47 +15327,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>Fehlerbehebung:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>WARNUNG:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>KRITISCH:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation>Kritischer Fehler</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation>Fataler Fehler</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>Σχετικά με το Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Ιστοσελίδα : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Δεν είναι δυνατό το άνοιγμα του προεπιλεγμένου περιηγητή</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Έλεγχος για ενημερώσεις</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished">άγνωστο</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>προσθήκη ομάδας</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>προσθήκη αντικειμένου</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished">Σημείο:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished">Κομμάτι:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Σφάλμα κακής ταυτότητας. Το πρόγραμμα θα τερματιστεί.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Σφάλμα λόγω αδυναμίας μετατροπής της τιμής. Το πρόγραμμα θα τερματιστεί.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Σφάλμα λόγω κενής παραμέτρου. Το πρόγραμμα θα τερματιστεί.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Σφάλμα λόγω λάθους ταυτότητας. Το πρόγραμμα θα τερματιστεί.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Υπάρχει σφάλμα!!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Σφάλμα κακής ταυτότητας. Το πρόγραμμα θα τερματιστεί.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Σφάλμα λόγω αδυναμίας μετατροπής της τιμής. Το πρόγραμμα θα τερματιστεί.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Σφάλμα λόγω κενής παραμέτρου. Το πρόγραμμα θα τερματιστεί.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Σφάλμα λόγω λάθους ταυτότητας. Το πρόγραμμα θα τερματιστεί.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Υπάρχει σφάλμα!!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation>Επεξεργαστής μετρήσεων του Seamly2D.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation>Το αρχείο μετρήσεων.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation>Το βασικό ύψος</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation>Το βασικό μέγεθος</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation>Ορισμός μονάδων για το αρχείο πατρόν: εκ, χιλ, ίντσες.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation>Η μονάδα του πατρόν</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation>Δεν μπορεί να αρχίσει να ακούει τις εισερχόμενες συνδέσεις στο όνομα &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation>Η δοκιμαστική λειτουργία δεν υποστηρίζει το άνοιγμα πολλών αρχείων.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation>Παρακαλώ, δώστε ένα αρχείο εισόδου.</translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>διαγραφή ομάδας</translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>εργαλείο διαγραφής</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>εργαλείο διαγραφής</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">Σχετικά με το SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished">Έκδοση SeamlyMe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Αναθεώρηση έκδοσης: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished">Αυτό το πρόγραμμα είναι μέρος του Seamly2D project.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Έλεγχος για ενημερώσεις</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Δεν είναι δυνατό το άνοιγμα του προεπιλεγμένου περιηγητή</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Ιστοσελίδα : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished">άγνωστο</translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Επιλέξτε το δεύτερο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Επεξεργασία μήκους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>Πρώτο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Δεύτερο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Η τιμή της ακτίνας δε μπορεί να είναι αρνητική</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Ίσες γωνίες</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Επεξεργασία ακτίνας</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Επεξεργασία πρώτης γωνίας</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Επεξεργασία δεύτερης γωνίας</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Ακτίνα:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>Πρώτη γωνία:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Δεύτερη γωνία:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Κεντρικό σημείο:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Επιλέξτε το κεντρικό σημείο του τόξου</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Χρώμα:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Επεξεργασία ακτίνας</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Επεξεργασία της πρώτης γωνίας</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Επεξεργασία του μήκους τόξου</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Η τιμή της ακτίνας δε μπορεί να είναι αρνητική</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>Το μήκος δεν μπορεί να ισουται με 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Ακτίνα:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>Πρώτη γωνία:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Κεντρικό σημείο:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Χρώμα:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Επιλέξτε το δεύτερο σημείο της γωνίας</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Επιλέξτε το τρίτο σημείο της γωνίας</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Επεξεργασία μήκους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Τρίτο σημείο:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Χρώμα:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Όνομα:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Τρίτο σημείο:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Τέταρτο σημείο:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Επιλέξτε το δεύτερο σημείο της καμπύλης</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Επιλέξτε το τρίτο σημείο της καμπύλης</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Επιλέξτε το τέταρτο σημείο της καμπύλης</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>Άκυρη καμπύλη spline</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Σημείο:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>Λίστα σημείων</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Χρώμα:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Όνομα:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Διαδρομή:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Επιλογή σημείου άξονα</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Επεξεργασία γωνίας</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Γωνία:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Σημείο άξονα:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Καμπύλη:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Επεξεργασία μήκους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Τόξο:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Επεξεργασία μήκους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Καμπύλη:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Επεξεργασία μήκους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Καμπύλη:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation>Ακτίνα1:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού σε πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation>Ακτίνα2:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation>Πρώτη γωνία:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation>Δεύτερη γωνία:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation>Γωνία περιστροφής:</translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation>Κεντρικό σημείο:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation>Επιλέξτε το κεντρικό σημείο του τόξου</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation>Χρώμα:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Η τιμή της ακτίνας δε μπορεί να είναι αρνητική</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Ίσες γωνίες</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation>Επεξεργασία ακτίνας1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation>Επεξεργασία ακτίνας2</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Επεξεργασία πρώτης γωνίας</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Επεξεργασία δεύτερης γωνίας</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation>Αλλαγή γωνίας περιστροφής</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Επεξεργασία γωνίας</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Επεξεργασία μήκους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Γωνία:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Βασικό σημείο:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Επιλογές εξαγωγής</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Εξαγωγή</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>Με επικεφαλίδα</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation>Κωδικοποιητής:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Διαχωριστής</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>κόμμα</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>Άνω τελεία</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Κενό</translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Επιλέξτε το πρώτο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Επιλέξτε το δεύτερο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Βασικό σημείο:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished">Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished">Μονοπάτι</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished">Ανώνυμο μονοπάτι</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished">Δημιουργία ονόματος για το μονοπάτι σας</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished">Τύπος:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished">Κομμάτι:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished">Έτοιμο!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Περιθώριο ραφής</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Φάρδος:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Τιμή</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished">Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished">Κόμβοι</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished">Κόμβος:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished">Πριν:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished">Επιστροφή στο προεπιλεγμένο πλάτος</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished">Μετά:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished">Γωνία:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished">Τύπος</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished">Διχοτόμος</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished">Διατομή</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">Μήκος:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Αντιστροφή</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Διαγραφή</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Τρέχων περιθώριο ραφής</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Επεξεργασία πλάτους περιθωρίου ραφής</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Επεξεργασία πλάτους περιθωρίου ραφής πριν</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Επεξεργασία πλάτους περιθωρίου ραφής μετά</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished">Εσωτερικό μονοπάτι</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished">Προσαρμοσμένο περιθώριο ραφής</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished">Χρειάζονται περισσότερα σημεία!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished">Το πρώτο σημείο του &lt;b&gt;προσαρμοσμένου περιθωρίου ραφής&lt;/b&gt; δεν μπορεί να είναι ίσο με το τελευταίο σημείο!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Έχετε διπλά σημεία!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished">Η λίστα με τις λεπτομέρειες είναι άδεια!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Δεν ήταν δυνατή η προετοιμασία δεδομένων για δημιουργία σχεδίου</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Δημιουργία σχεδίου</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation>Τοποθετημένα κομμάτια: %1 από %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Επιλέξτε δεύτερο σημείο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Γραμμή_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Πρώτη γραμμή</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Δεύτερη γραμμή</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Επιλέξτε το δεύτερο σημείο της πρώτης γραμμής</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Επιλέξτε το πρώτο σημείο της δεύτερης γραμμής</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Επιλέξτε το δεύτερο σημείο της δεύτερης γραμμής</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Πρώτο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Επιλέξτε το δεύτερο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Επιλογή σημείου άξονα</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Σημείο άξονα</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Δεύτερο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Επεξεργασία γωνίας</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Γωνία:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Σημείο άξονα:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished">Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished">Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Μετρήσεις</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished">Εύρεση:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished">Αναζήτηση</translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished">Σημείο άξονα:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished">Κατάληξη:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished">Τύπος άξονα:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Κάθετος άξονας</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Οριζόντιος άξονας</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished">Πρώτο σημείο γραμμής:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished">Δεύτερο σημείο γραμμής:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished">Κατάληξη:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation>Γωνία:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation>Κατάληξη:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation>Επεξεργασία γωνίας</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Επεξεργασία μήκους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished">Αρχικό σημείο:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished">Περιστροφή:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Κεντρικό σημείο</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Μονάδες μέτρησης:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Εκατοστά</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Ίντσες</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Μοναδικό όνομα κομματιού πατρόν</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Επιλογή μοναδικού ονόματος για κομμάτι του πατρόν.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>Νέο πατρόν</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στο πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Επιλέξτε το δεύτερο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Επεξεργασία μήκους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished">Περιστροφή:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Περιγραφή πατρόν</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Ύψη και μεγέθη</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Όλα τα ύψη (εκ)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Όλα τα μεγέθη (εκ)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Προεπιλεγμένο ύψος και μέγεθος</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Προσαρμογή</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Ύψος:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Μέγεθος:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Ασφάλεια</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Άνοιγμα μόνο για ανάγνωση</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>Χωρίς εικόνα</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Διαγραφή εικόνας</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Αλλαγή εικόνας</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Αποθήκευση εικόνας σε αρχείο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Εμφάνιση εικόνας</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation>Εικόνα για το πατρόν</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Εικόνες</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Αποθήκευση Αρχείου</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>ανώνυμο</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Διαδρομή:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Εμφάνιση στην Εξερεύνηση</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;Empty&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>Το αρχείο δεν αποθηκεύτηκε ακόμα.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Εμφάνιση στην Εύρεση</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Όνομα πατρόν:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Αριθμός πατρόν:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Όνομα Επιχείρησης/Σχεδιαστή:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Όνομα πελάτη:</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation type="unfinished">Πατρόν</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Επιλογή ενός τόξου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Σημείο εφαπτομένης:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Τόξο:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Πάρε:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Επιλέξτε το κεντρικό σημείο του τόξου</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Επιλέξτε το δεύτερο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Επεξεργασία ακτίνας</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Ακτίνα:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation>Κέντρο του κύκλου:</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>Πρώτο τόξο:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Δεύτερο τόξο:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Πάρε:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>Πρώτη καμπύλη:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Δεύτερη καμπύλη:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Επιλογή δεύτερης καμπύλης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Πατρόν</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished">Γενικά</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Περιστροφή</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Γωνία:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Κατάληξη:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation>Επεξεργασία γωνίας</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Προτιμήσεις</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Επιλέξτε το πρώτο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Επιλέξτε το δεύτερο σημείο της γραμμής</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Επεξεργασία μήκους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Τρίτο σημείο:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Συντεταγμένες της σελίδας</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Συντεταγμένες</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Βασικό σημείο</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Πρώτο σημείο</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Δεύτερο σημείο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Επιλέξτε το τελευταίο σημείο της καμπύλης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Χρώμα:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Γωνία:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Όνομα:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>Άκυρη καμπύλη spline</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation>Επεξεργασία γωνίας του πρώτου σημείου ελέγχου</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation>Επεξεργασία γωνίας του δεύτερου σημείου ελέγχου</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation>Επεξεργασία μήκους του πρώτου σημείου ελέγχου</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation>Επεξεργασία μήκους του δεύτερου σημείου ελέγχου</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation>Το μήκος δεν είναι δυνατό να έχει αρνητική τιμή</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Λίστα σημείων</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Επιλέξτε σημείο σε καμπύλο μονοπάτι</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Χρώμα:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Σημείο:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation>Πρώτο σημείο ελέγχου</translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Γωνία:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation>Δεύτερο σημείο ελέγχου</translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Όνομα:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Μήκος:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Εμφάνιση πλήρους υπολογισμού στ πλαίσιο μηνύματος&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation>Επεξεργασία γωνίας του πρώτου σημείου ελέγχου</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation>Επεξεργασία γωνίας του δεύτερου σημείου ελέγχου</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation>Επεξεργασία μήκους του πρώτου σημείου ελέγχου</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation>Επεξεργασία μήκους του δεύτερου σημείου ελέγχου</translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation>Το μήκος δεν είναι δυνατό να έχει αρνητική τιμή</translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation>Δε χρησιμοποιείται</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Διαδρομή:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Κενό πεδίο</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Η τιμή δεν μπορεί να είναι 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Πρώτο σημείο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Δεύτερο σημείο</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation>Ψηλότερο σημείο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation>Χαμηλότερο σημείο</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation>Σημείο στην αριστερή ακρη</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation>Σημείο στη δεξιά άκρη</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation>κατά μήκος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Μη έγκυρο αποτέλεσμα. Η τιμή είναι άπειρη ή NaN. Παρακαλώ, ελέγξτε τους υπολογισμούς σας.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation>Η τιμή δεν μπορεί να είναι λιγότερο από 0</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Επιλέξτε δεύτερο σημείο του άξονα</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Επιλέξτε πρώτο σημείο</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Επιλέξτε δεύτερο σημείο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation>Επιλέξτε το δεύτερο σημείο αναφοράς</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation>Επιλέξτε το πρώτο σημείο πένσας</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation>Επιλέξτε το δεύτεεο σημείο πένσας</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation>Επιλέξτε το τρίτο σημείο πένσας</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Αναίρεση</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Επιδιόρθωση φόρμουλας</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Σφάλμα κατα τον υπολογισμό της φόρμουλας. Μπορείτε να δοκιμάσετε να αναιρέσετε την τελευταια λειτουργία ή να επιδιορθώσετε τη χαλασμένη φόρμουλα.</translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Φιλτράρισμα λίστας με λέξη κλειδί</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">Η υπολογισμένη τιμή</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Φόρμουλα</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished">Μετακίνηση μέτρησης προς τα πάνω</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished">Μετακίνηση μέτρησης προς τα κάτω</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Λεπτομέρειες</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Υπολογισμένη τιμή:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished">Φόρμουλα:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished">Υπολογισμός</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished">Περιγραφή:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Γραμμή</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Γωνία</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Καμπύλη</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Τόξο</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Ακτίνα</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Σφάλμα</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished">Κενό πεδίο.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Κενό πεδίο</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Μη έγκυρο αποτέλεσμα. Η τιμή είναι άπειρη ή NaN. Παρακαλώ, ελέγξτε τους υπολογισμούς σας.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Τιμή</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Εργαλείο</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Επεξεργασία φόρμουλας</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Μετρήσεις</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished">Λειτουργίες</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished">Φόρμουλα:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Τιμή</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished">Υπολογισμός</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Εισαγωγή μεταβλητής στη φόρμουλα</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Απόκρυψη κενών μετρήσεων</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished">Πλήρες όνομα</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Φιλτράρισμα λίστας με λέξη κλειδί</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Μήκος γραμμής</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Μήκος καμπύλης</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Γωνία γραμμής</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished">Ακτίνα τόξου</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished">Γωνία καμπύλης</translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Μοναδικό όνομα κομματιού πατρόν</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished">Επεξεργασία</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished">Δεν είναι δυνατή η αποθήκευση αρχείου</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">Σφάλμα στο αρχείο.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Μέγεθος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Ύψος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished">Ύφασμα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished">Φόδρα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished">Ύφασμα ενίσχυσης</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished">Ύφασμα επένδυσης</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished">στη δίπλωση</translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished">Κείμενο ως μονοπάτια</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Διαδρομή:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished">Φάκελος προορισμού</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished">Διαδρομή για φάκελο προορισμού</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished">Επιλογή διαδρομής για φάκελο προορισμού</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished">Περιήγηση...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished">Τύπος αρχείου:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished">Όνομα αρχείου:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished">Όνομα αρχείου βάσης</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished">Περιθώρια</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished">Δεξιά:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished">Αριστερά:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished">Επάνω:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished">Κάτω:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished">Μορφή χαρτιού</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished">Επιλογή φακέλου</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation>Η λήψη της φόρτωσης απέτυχε: %1.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation>Πληροφορίες</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished">Ομάδες</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Διαγραφή</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - Βασικό σημείο</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Τόξο_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished">Επεξεργασία</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">Ιστορικό</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished">Εύρεση:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Βασικό σημείο</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Τόξο_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Περιγραφή</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished">Μονάδες μέτρησης:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Φάρδος:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Ύψος:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished">Περιστροφή:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Διαγραφή</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished">Επικύρωση διαγραφής</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Θέλετε σίγουρα να κάνετε διαγραφή;</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished">Κομμάτι:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Αντιστροφή</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished">Κανένα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Διαγραφή</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished">Πάρε:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation>Κεντρικό σημείο:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Σημείο εφαπτομένης:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Ακτίνα:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Τιμή</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished">Υπολογισμός</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished">Επιλέξτε ένα κέντρο κύκλου</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished">Επεξεργασία ακτίνας</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Σφάλμα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Η τιμή της ακτίνας δε μπορεί να είναι αρνητική</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished">Πάρε:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Ακτίνα:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Τιμή</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished">Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished">Επιλέξτε κέντρο δεύτερου κύκλου</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished">Επεξεργασία πρώτης ακτίνας κύκλου</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished">Επεξεργασία δεύτερης ακτίνας κύκλου</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Σφάλμα</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Η τιμή της ακτίνας δε μπορεί να είναι αρνητική</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Πρότυπα:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Φάρδος:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Ύψος:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Περιστροφή κομματιού</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Περιστροφή κατα</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>μοίρα</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Τρείς ομάδες: μεγάλα, μεσαία, μικρά</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Δύο ομάδες: μεγάλα, μικρά</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>Σμίκρυνση περιοχής</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Εκατοστά</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Ίντσες</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Pixels</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Αυτόματη περικοπή αχρησιμοποίητου μήκους</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Ενοποίηση σελίδων (αν είναι δυνατό)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation>Φάρδος περιθωρίου:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Αποθήκευση μήκους του φύλλου</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Μορφή χαρτιού</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Αριστερά:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Δεξιά:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Επάνω:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Κάτω:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Λανθασμένα πεδία.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6623,84 +5191,67 @@ Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation>Επιλογές τοποθέτησης</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation>Μετατόπιση μήκους:</translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation>Κανόνας για την επιλογή του επόμενου κομματιού εργασίας</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation>Διαίρεση σε λωρίδες</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation>Πολλαπλασιαστής</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation>Η ενεργοποίηση φύλλων μεγάλου μεγέθους θα επιταχύνει τη δημιουργία.</translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Εκτυπωτής:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation>Κανένα</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation>Κείμενο</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation>Εξαγωγή κειμένου ως μονοπάτια</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation>Περιθώρια</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation>Αγνόηση περιθωρίων</translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6708,32 +5259,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6741,2660 +5286,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Εργαλεία για δημιουργία σημείων.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Σημείο</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Εργαλεία για δημιουργία γραμμών.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Γραμμή</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Εργαλεία για δημιουργία καμπύλων.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Καμπύλη</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Εργαλεία για δημιουργία τόξων.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Τόξο</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;Αρχείο</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Βοήθεια</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Μετρήσεις</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Νέο</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Νέο</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Δημιουργία νέου πατρόν</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Άνοιγμα</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Άνοιγμα αρχείου με πατρόν</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Αποθήκευση</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Αποθήκευση</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Αποθήκευση πατρόν</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Αποθήκευση &amp;ως...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Το πατρόν δεν έχει αποθηκευθεί ακόμα</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Λεπτομέρειες</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Εργαλεία δείκτη</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Ιστορικό</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>Σχετικά &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;Σχετικά με το Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>Έ&amp;ξοδος</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Προτιμήσεις</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Αναφορά σφάλματος</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Εμφάνιση βοήθειας online</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>Σχετικά με το Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Αποθήκευση ως</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Δεν είναι δυνατή η αποθήκευση αρχείου</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Άνοιγμα αρχείου</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Σφάλμα κατά την ανάλυση του αρχείου.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Σφάλμα λόγω αδυναμίας μετατροπής της τιμής.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Σφάλμα κενής παραμέτρου.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Σφάλμα λόγω λάθους ταυτότητας.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Κακή ταυτότητα.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>Αποθηκευμένο αρχείο</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>Ανώνυμο.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>Το πατρόν έχει τροποποιηθεί.
 Θέλετε να αποθηκελυσετε τις αλλαγές;</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Αναίρεση</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Ακύρωση αναίρεσης</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>Αυτό το αρχείο είναι ήδη ανοιχτό σε ένα άλλο παράθυρο.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Λανθασμένες μονάδες.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>Το αρχείο φορτώθηκε</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Το Seamly2D δεν τερματίστηκε σωστά. Θέλετε να ανοίξετε εκ νέου τα αρχεία (%1) που είχατε ανοιχτά;</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Άνοιγμα αρχείων εκ νέου.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Τοποθέτηση</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation>Εκτύπωση</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation>Εκτύπωση τεμαχισμένου PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation>Διαχωρισμός και εκτύπωση της διάταξης σε μικρότερες σελίδες (για κανονικούς εκτυπωτές)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation>Προεπισκόπιση εκτύπωσης</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation>Προεπισκόπιση εκτύπωσης της αρχικής τοποθέτησης</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation>Εξαγωγή ως...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation>Λειτουργία τοποθέτησης</translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation>Αλλαγές χωρίς αποθήκευση</translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation>Οι μετρήσεις φορτώθηκαν</translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation>Δεν μπορείς να εξάγεις άδεια σκηνή.</translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation>Το αρχείο μετρήσεων περιλαμβάνει μη έγκυρες γνωστές μετρήσεις.</translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation>Το αρχείο μετρήσεων είναι άγνωστης μορφής.</translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation>Δεν ήταν δυνατός ο συγχρονισμός των μετρήσεων.</translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation>Δεν ήταν δυνατή η ενημέρωση των μετρήσεων.</translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation>Το αρχείο μετρήσεων &apos;%1&apos; δε βρέθηκε.</translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation>Φόρτωση αρχείου μετρήσεων</translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation>Η τιμή μεγέθους &apos;%1&apos; δεν υποστηρίζεται για αυτό το αρχείο πατρόν.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation>Δεν ήταν δυνατός ο ορισμός μεγέθους. Το αρχείο δεν ανοίχτηκε.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation>Δεν ήταν δυνατός ο ορισμός ύψους. Το αρχείο δεν ανοίχτηκε.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation>Παρακαλώ, δώστε ένα αρχείο εισόδου.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation>Εκτύπωση μίας αρχικής διάταξης</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation>Προεπισκόπιση τεμαχισμένου PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation>Προεπισκόπηση εκτύπωσης τεμαχισμένης διάταξης</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>Νέο πατρόν</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation>Άνοιγμα πατρόν</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation>Δημιουργία/Επεξεργασία μετρήσεων</translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>Αποθήκευση...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Χωρίς αποθήκευση</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Κλείδωμα αρχείου</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Αυτό το αρχείο είναι ήδη ανοιχτό σε άλλο παράθυρο. Αγνοήστε αν θέλετε να συνεχίσετε (δε συνιστάται, μπορεί να προκαλέσει καταστροφή δεδομένων).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Παρουσιάστηκε άγνωστο σφάλμα, για παράδειγμα μία πλήρης διχοτόμηση εμπόδισε την εγγραφή του αρχείου κλειδώματος.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation>Λειτουργίες</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation>Κλείσιμο πατρόν</translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation>Εργαλείο δείκτη</translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation>Αρχικό zoom</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Ύψος:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Μέγεθος:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation>Έγινε αλλαγή των μετρήσεων. Θέλετε να συγχρονίσετε τις μετρήσεις τώρα;</translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation>Οι μετρήσεις συγχρονίστηκαν</translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Could not save the file.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation>Δεν ήταν δυνατή η αποθήκευση του αρχείου</translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation>μόνο για ανάγνωση</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation>Φόρτωση Ατομικών</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation>Φόρτωση φακέλου Ατομικών μετρήσεων</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation>Άνοιγμα SeamlyMe</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation>Επεξεργασία Τρέχοντος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation>Συγχρονισμός</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation>Ατομικές μετρήσεις</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Αρχεία πατρόν</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation>Φόρουμ</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation>Όνομα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished">Η υπολογισμένη τιμή</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished">Φόρμουλα</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished">Επεξεργασία</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished">Περιστροφή</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Μετακίνηση</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">Σχετικά με το Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished">Ετικέτες</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished">Εξαγωγή</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Διαγραφή</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished">Εικόνες</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished">Σημείο:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">ανώνυμο</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
@@ -9402,86 +7288,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Η δημιουργία αρχείου &apos;%1&apos; απέτυχε! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Κρίσιμο σφάλμα!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation>Σφάλμα εκτύπωσης</translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation>Η συνέχεια είναι αδύνατη διότι δεν υπάρχουν διαθέσιμοι εκτυπωτές στ σύστημα.</translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation>χωρίς όνομα</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation>Η τοποθέτηση δέν ενημερώθηκε μετά απο την τελευταία αλλαγή πατρόν. Θέλετε να συνεχίσετε;</translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Δεν ήταν δυνατή η προετοιμασία δεδομένων για δημιουργία σχεδίου</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation>Δεν είναι δυνατή η δημιουργία μονοπατιού</translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Πατρόν</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9489,148 +7355,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished">Αρχείο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Νέο</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Εκτύπωση</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Αποθήκευση</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Αποθήκευση ως</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Εξαγωγή σε CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished">Βοήθεια</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished">Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished">Ctrl+G</translation>
     </message>
@@ -9638,123 +7474,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished">Σύμπτηξη Όλων</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished">Ανάπτυξη Όλων</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished">Επιλογή όλων</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished">Αποεπιλογή όλων</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Απ&apos;ευθείας ύψος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Απ&apos;ευθείας φάρδος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Χέρι</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Πόδι</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Κεφάλι</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Περίμετρος και τόξο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Κάθετα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Οριζόντια</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Στήθος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Ισορροπία</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Μπράτσο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Πόδι</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Καβάλο και ύψος καβάλου</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Άνδρες &amp; Ράψιμο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Διαστάσεις σχεδίασης πατρόν</translation>
@@ -9763,18 +7578,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation>Δεν είναι δυνατή η εύρεση της μέτρησης &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation>Το όνομα μέτρησης είναι κενό!</translation>
     </message>
@@ -9782,37 +7589,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Μονάδες μέτρησης:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9820,12 +7620,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9833,7 +7631,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9841,7 +7638,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation>μετακίνηση ετικέτας σημείου</translation>
     </message>
@@ -9849,7 +7645,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished">μετακίνηση ετικέτας σημείου</translation>
     </message>
@@ -9857,7 +7652,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9865,7 +7659,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation>μετακίνηση καμπύλης spline</translation>
     </message>
@@ -9873,7 +7666,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation>μετακίνηση μονοπατιού καμπύλης spline</translation>
     </message>
@@ -9881,52 +7673,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>Νέο αρχείο μετρήσεων</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Τύπος μέτρησης:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Μονάδες μέτρησης:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Βασικό μέγεθος:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Βασικό ύψος:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Ατομικές</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Εκατοστά</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Ίντσες</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9934,87 +7716,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished">Letter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished">Legal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished">Ρολό 24 ιντσών</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished">Ρολό 30 ιντσών</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished">Ρολό 36 ιντσών</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished">Ρολό 42 ιντσών</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished">Ρολό 44 ιντσών</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished">Προσαρμογή</translation>
     </message>
@@ -10022,887 +7787,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished">Το όνομα δε μπορεί να είναι κενό</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished">Γράμμα:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished">Γράμμα του κομματιού πατρόν</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished">Τοποθέτηση:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished">στη δίπλωση</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished">Περιστροφή:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">Κανένα</translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished">Περιορισμός καθρεφτίσματος κομματιού στην τοποθέτηση.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished">Όλα τα αντικείμενα του μονοπατιού θα πρέπει να ακολουθούν ωρολογιακή φορά.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished">Έτοιμο!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Απόκρυψη του κύριου μονοπατιού αν το περιθώριο ραφής είναι ενεργοποιημένο</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Φάρδος:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Τιμή</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Βοηθός φόρμουλας</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished">Υπολογισμός</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished">Κόμβοι</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished">Κόμβος:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished">Πριν:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished">Επιστροφή στο προεπιλεγμένο πλάτος</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished">Μετά:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished">Γωνία:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished">Προσαρμογή</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished">Αρχικό σημείο:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished">Τελικό σημείο:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished">Ύψος:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Μήκος:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished">Τύπος:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished">Τύπος</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished">Διχοτόμος</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished">Διατομή</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Αντιστροφή</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished">Εξαιρούμενο</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Διαγραφή</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Επιλογές</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished">Απεριόριστο/απροσδιόριστο αποτέλεσμα</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished">Το μήκος θα πρέπει να έχει θετική τιμή</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Σφάλμα</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished">Επεξεργασία μήκους</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished">Επεξεργασία γωνίας</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished">Επεξεργασία ύψους</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished">Επεξεργασία πλάτους</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Τρέχων περιθώριο ραφής</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Επεξεργασία πλάτους περιθωρίου ραφής</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Επεξεργασία πλάτους περιθωρίου ραφής πριν</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Επεξεργασία πλάτους περιθωρίου ραφής μετά</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished">Χρειάζονται περισσότερα σημεία!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Έχετε διπλά σημεία!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished">Κάθε σημείο στο μονοπάτι πρέπει να είναι μοναδικό!</translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished">Κενό</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished">κύριο μονοπάτι</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished">προσαρμοσμένο περιθώριο ραφής</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished">Και τα δύο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished">Μόνο μπροστά</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished">Μόνο πίσω</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished">Ετικέτες</translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished">Επάνω:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished">Κάτω:</translation>
     </message>
@@ -10910,218 +8422,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Τρέχων περιθώριο ραφής</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished">μετακίνηση ετικέτας κομματιού πατρόν</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished">αλλαγή διαστάσεων ετικέτας κομματιού πατρόν</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished">περιστροφή ετικέτας κομματιού πατρόν</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished">μετακίνηση ετικέτας πληροφοριών πατρόν</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished">αλλαγή διαστάσεων ετικέτας πληροφοριών πατρόν</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished">περιστροφή ετικέτας πληροφοριών πατρόν</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished">μετακίνηση γραμμής ίσιου</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished">αλλαγή διάστασης γραμμής ίσιου</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished">περιστροφή γραμμής ίσιου</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Διαγραφή</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11129,27 +8589,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11157,77 +8612,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11235,139 +8675,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11375,62 +8770,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished">Επιλέξτε σημείο για την τιμή του Υ (οριζόντια)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
@@ -11438,316 +8821,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished">Χρονικό διάστημα:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished">Προεπιλεγμένη μονάδα:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished">Οι προεπιλεγμένες μονάδες έχουν ενημερωθεί και θα χρησιμοποιηθούν ως προεπιλογή για το επόμενο πατρόν που θα δημιουργήσετε.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation>Εκατοστά</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Ίντσες</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished">Αναίρεση</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished">Κανένα</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished">Διεύθυνση email:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11755,582 +9072,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Σημείο</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Γραμμή</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Καμπύλη</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Τόξο</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished">Λειτουργίες</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Λεπτομέρειες</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished">Τοποθέτηση</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished">Μέγεθος:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Φάρδος:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished">Εξαγωγή</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation>Διαδρομές φακέλων που χρησιμοποιεί το Seamly2D</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation>Τύπος</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Μονοπάτι</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation>Προεπιλογή</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished">Επεξεργασία</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished">Άνοιγμα φακέλου</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation>Πατρόν μου</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation>Διατάξεις μου</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation>Πρότυπά μου</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12338,272 +9487,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation>Αποτροπή αντιστροφής</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation>Από προεπιλογή, απόκρυψη του κύριου μονοπατιού αν το περιθώριο ραφής ήταν ενεργοποιημένο</translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation>Περιθώριο ραφής</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation>Προεπιλεγμένη τιμή:</translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished">Τύπος:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">Μήκος:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Φάρδος:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished">Ετικέτες</translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Φάρδος</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Ύψος</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished">Πρότυπα</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12611,7 +9690,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12619,155 +9697,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Δημιουργήστε νέο κομμάτι πατρόν για να ξεκινήσετε να δουλεύετε.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>χιλ</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>εκ</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>ίντσες</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Ιδιοκτησία</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation>προσθήκη κόμβου</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation>Οι αλλαγές εφαρμόστηκαν.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation>Λήψη λάθους παραμέτρου ταυτότητας. Χρειάζεται μόνο ταυτότητα &gt; 0.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished">Ύφασμα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished">Φόδρα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished">Ύφασμα ενίσχυσης</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished">Ύφασμα επένδυσης</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished">στη δίπλωση</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12775,15 +9822,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
@@ -12792,217 +9835,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Εσωτερικό σφάλμα</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Λείπει παρένθεση</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Διαίρεση με το μηδέν</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
@@ -13011,7 +10018,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13019,7 +10025,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished">μετονομασία κομματιού πατρόν</translation>
     </message>
@@ -13027,12 +10032,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13040,7 +10043,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13048,7 +10050,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13056,7 +10057,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13064,88 +10064,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Γλώσσα</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished">Μέθοδος σχεδίασης πατρόν</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished">Σύστημα:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">Συγγραφέας:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished">Βιβλίο:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished">Επαναφορά προειδοποιήσεων</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished">Προεπιλεγμένο ύψος και μέγεθος</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Ύψος:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished">Μέγεθος:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13153,52 +10135,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished">Τύπος</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Μονοπάτι</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished">Επεξεργασία</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished">Άνοιγμα φακέλου</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished">Πρότυπά μου</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13206,102 +10178,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished">Μονάδες μέτρησης:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Εκατοστά</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Ίντσες</translation>
     </message>
@@ -13309,92 +10260,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished">Μονάδες μέτρησης:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Εκατοστά</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Ίντσες</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13402,12 +10334,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13415,1071 +10345,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished">Αρχείο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Νέο</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished">Άνοιγμα</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Αποθήκευση</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Αποθήκευση ως</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Εκτύπωση</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished">Επεξεργασία</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished">Αναίρεση</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished">Ετικέτες</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Μετρήσεις</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished">Άνοιγμα SeamlyMe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Σημείο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Γραμμή</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished">Λειτουργίες</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished">Περιστροφή</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Μετακίνηση</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished">Εικόνες</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished">Μετονομασία</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Διαγραφή</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Λεπτομέρειες</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished">Τοποθέτηση</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">Ιστορικό</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished">Βοήθεια</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14487,12 +11200,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14500,42 +11211,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14543,7 +11246,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14551,7 +11253,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14559,819 +11260,626 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Επιλέξτε Νέο για τη δημιουργία αρχείου μετρήσεων.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Όνομα</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation>Υπολογισμένη τιμή</translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Φόρμουλα</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>Σε μεγέθη</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>Σε ύψη</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Λεπτομέρειες</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Όνομα:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Φόρμουλα:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation>Σε μεγέθη:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation>Σε ύψη:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Περιγραφή:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation>Μετακίνηση μέτρησης προς τα πάνω</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Μετακίνηση μέτρησης προς τα κάτω</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Υπολογισμένη τιμή:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation>Πλήρες όνομα:</translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>Πληροφορίες</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Τύπος:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation>Τύπος μέτρησης</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Διαδρομή:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Εμφάνιση στην Εξερεύνηση</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Βασικό μέγεθος:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation>Τιμή βασικού μεγέθους</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Βασικό ύψος:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation>Τιμή βασικού ύψους</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Όνομα:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Επίθετο:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation>Ημερομηνία γέννησης:</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>Διεύθυνση email:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>Σημειώσεις:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>Αρχείο</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Παράθυρο</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Βοήθεια</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Μετρήσεις</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation>Μενού</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Αποθήκευση</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation>Αποθήκευση ως ...</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>Σχετικά &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>Σχετικά με το SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Νέο</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation>Προσθήκη προσαρμογής</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation>Μόνο ανάγνωση</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>Βάση δεδομένων</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation>Εμφάνιση πληροφοριών για όλες τις γνωστές μετρήσεις</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Προτιμήσεις</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation>ανώνυμο %1</translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>Αυτό το αρχείο είναι ήδη ανοιχτό σε ένα άλλο παράθυρο.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Σφάλμα στο αρχείο.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Δεν είναι δυνατή η αποθήκευση αρχείου</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Αποθήκευση ως</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation>&amp;Νέο παράθυρο</translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation>Επεξεργασία μέτρησης</translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Κενό πεδίο.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Ατομικές μετρήσεις</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>ανώνυμο</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation>Αλλαγές χωρίς αποθήκευση</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Οι μετρήσεις έχουν τροποποιηθεί.
 Θέλετε να αποθηκεύσετε τις αλλαγές?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Κενό πεδίο</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Τιμή</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Άνοιγμα αρχείου</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation>Εισαγωγή απο ένα πατρόν</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Εύρεση:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation>Εύρεση προηγούμενου</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation>Ευρεση Επόμενου</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation>Αποτυχία κλειδώματος. Το αρχείο έχει ήδη ανοιχτεί σε ένα άλλο παράθυρο.</translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation>Το αρχείο είναι άγνωστης μορφής.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Πλήρες όνομα</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation>Το αρχείο &apos;%1&apos; δεν υπάρχει!</translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation>Η διάσταση &apos;%1&apos; δεν είναι δυνατό να βρεθεί.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation>Μετακίνηση διάστασης ψηλά</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation>Μετακίνηση διάστασης χαμηλά</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation>Διαγραφή διάστασης</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation>άγνωστο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>αρσενικό</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>θηλυκό</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation>Γένος:</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation>Μέθοδος σχεδίασης πατρόν:</translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation>Δημιουργία απο υπάρχον ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation>Δημιουργία απο υπάρχον αρχείο</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation>Επιλογή αρχείου</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation>Διάγραμμα μετρήσεων</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Άγνωστη μέτρηση&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Άγνωστη μέτρηση&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>Σχετικά με το Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>Το αρχείο δεν αποθηκεύτηκε ακόμα.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Αναζήτηση</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation>Όνομα διάστασης σε μια φόρμουλα</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation>Όνομα διάστασης στη φόρμουλα.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>Αποθήκευση...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Χωρίς αποθήκευση</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Κλείδωμα αρχείου</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Παρουσιάστηκε άγνωστο σφάλμα, για παράδειγμα μία πλήρης διχοτόμηση εμπόδισε την εγγραφή του αρχείου κλειδώματος.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation>Εξαγωγή σε CSV</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Εμφάνιση στην Εύρεση</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation>Όνομα πελάτη</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation>Επώνυμο πελάτη</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation>Διεύθυνση email πελάτη</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Ύψος:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Μέγεθος:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation>Όλα τα αρχεία</translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Could not save the file.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation>Δεν ήταν δυνατή η αποθήκευση του αρχείου</translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation>μόνο για ανάγνωση</translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Μη έγκυρο αποτέλεσμα. Η τιμή είναι άπειρη ή NaN. Παρακαλώ, ελέγξτε τους υπολογισμούς σας.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation>Κενό</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished">Εκτύπωση</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation type="unfinished">Αρχεία πατρόν</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished">Αυτό το αρχείο είναι ήδη ανοιχτό σε άλλο παράθυρο. Αγνοήστε αν θέλετε να συνεχίσετε (δε συνιστάται, μπορεί να προκαλέσει καταστροφή δεδομένων).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15379,7 +11887,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15387,22 +11894,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15410,22 +11913,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15433,47 +11932,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">Πρώτο σημείο</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Δεύτερο σημείο</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished">Ψηλότερο σημείο</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished">Χαμηλότερο σημείο</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished">Σημείο στην αριστερή ακρη</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished">Σημείο στη δεξιά άκρη</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Κάθετος άξονας</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Οριζόντιος άξονας</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Γραμμή_</translation>
     </message>
@@ -15481,47 +11971,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Εργαλείο ένωσης</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished">Διατήρηση αρχικών κομματιών</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Επιλέξτε ένα δεύτερο σημείο</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Επιλέξτε ένα μοναδικό σημείο</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished">Επιλέξτε ένα σημείο σην άκρη</translation>
     </message>
@@ -15529,7 +12010,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15537,17 +12017,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Να μη γίνει ερώτηση ξανά</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Να μη γίνει &amp;ερώτηση ξανά</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15555,57 +12032,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Δε βρέθηκαν οι πληροφορίες της έκδοσης.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Η έκδοση &quot;%1&quot; είναι άκυρη.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Η έκδοση &quot;0.0.0&quot; είναι άκυρη.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Η έκδοση είναι άκυρη. Η ελάχιστη έκδοση που υποστηρίζεται είναι η %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Η έκδοση είναι άκυρη. Η μέγιστη έκδοση που υποστηρίζεται είναι η %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Σφάλμα λόγω μη μοναδικής ταυτότητας.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>Δεν είναι δυνατή η αλλαγή έκδοσης.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Απρόσμενη έκδοση &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15613,7 +12079,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15621,22 +12086,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Εξαγωγή σε CSV</translation>
     </message>
@@ -15644,13 +12105,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
@@ -15658,23 +12116,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>Δεν είναι δυνατή η εύρεση του εργαλείου στον πίνακα.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>Νέα ομάδα</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15682,7 +12135,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15690,12 +12142,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
@@ -15703,283 +12153,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Επικύρωση διαγραφής</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Θέλετε σίγουρα να κάνετε διαγραφή;</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished">Επεξεργασία εσφαλμένης φόρμουλας</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15987,302 +12380,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation>Το αρχείο μετρήσεων</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>Το φάρδος σελίδας</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Γωνία</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation>Αυτόματηπερικοπή του μήκους που δε χρησιμοποιείται (λειτουργία εξαγωγής).</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation>Τύπος ομαδοποίησης</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation>Επιλέχθηκε άγνωστο πρότυπο σελίδας.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation>Οι επιλογές εξαγωγής μπορούν να χρησιμοποιηθούν μόνο με ένα αρχείο εισαγωγής.</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>Ο φάκελος προορισμού</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation>Η τιμή μεγέθους</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation>Η τιμή ύψους</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Πρόγραμμα σχεδίασης πατρόν.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Αρχείο πατρόν.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16290,43 +12623,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished">μετρήσεις</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16334,55 +12658,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16390,12 +12701,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation>Δεν υπάρχουν αρκετά σημεία για τη δημιουργία της καμπύλης spline.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation>Αυτή η καμπύλη spline δεν υπάρχει.</translation>
     </message>
@@ -16403,50 +12712,40 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16454,27 +12753,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16482,7 +12776,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16490,11 +12783,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
@@ -16502,7 +12790,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished">Φόρμουλα:</translation>
     </message>
@@ -16510,7 +12797,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16518,7 +12804,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16526,12 +12811,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>Αληθές</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>Ψευδές</translation>
     </message>
@@ -16539,12 +12822,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Φάκελος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Άνοιγμα αρχείου</translation>
     </message>
@@ -16552,335 +12833,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Σφάλμα κατά την ανάλυση του αρχείου.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Σφάλμα λόγω αδυναμίας μετατροπής της τιμής.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Σφάλμα κενής παραμέτρου.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Σφάλμα λόγω λάθους ταυτότητας.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση ενός σημείου</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση σημείου στο τέλος γραμμής</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση σημείου κατα μήκος τηςγραμμής</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση σημείου του σημείου ώμου</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση σημείου του σημείου της διχοτόμου</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση του σημείου επαφής</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση σημείου του ύψους</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση σημείου τριγώνου</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση γραμμής</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση απλής καμπύλης</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση μονοπατιού καμπύλης</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση απλού τόξου</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση του σημείου τομής τόξων</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση του σημείου τομής κύκλων</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση σημείου απο κύκλο και εφαπτομένη</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation>Σφάλμα κατα τη δημιουργία ή ενημέρωση σημείου απο τόξο και εφαπτομένη</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation>Σφάλμα λόγω μη μοναδικής ταυτότητας.</translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation>Σφάλμα στη δημιουργία ή ενημέρωση της κυβικής καμπύλης Bezier</translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation>Σφάλμα στη δημιουργία ή ενημέρωση της</translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation>Σφάλμα στη δημιουργία ή ενημέρωση της λειτουργίας περιστροφής</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation>Ανώνυμο μονοπάτι</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16888,17 +13080,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16906,12 +13095,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16919,14 +13106,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>Δεν υπάρχουν αρκετά σημεία για τη δημιουργία της καμπύλης spline.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>Αυτή η καμπύλη spline δεν υπάρχει.</translation>
     </message>
@@ -16934,17 +13117,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Γωνία</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
@@ -16952,27 +13132,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16980,37 +13155,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17018,7 +13186,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
@@ -17026,12 +13193,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17039,32 +13204,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Τόξο</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17072,18 +13231,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Καμπύλη</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17091,18 +13246,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Καμπύλη</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17110,7 +13261,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
@@ -17118,28 +13268,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17147,17 +13291,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Γωνία</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
@@ -17165,12 +13306,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Γωνία</translation>
     </message>
@@ -17178,7 +13317,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
@@ -17186,27 +13324,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Γωνία</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17214,17 +13347,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Γωνία</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
@@ -17232,7 +13362,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17240,12 +13369,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">Πρώτο σημείο γραμμής</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Δεύτερο σημείο γραμμής</translation>
     </message>
@@ -17253,27 +13380,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Κεντρικό σημείο</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Γωνία</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17281,714 +13403,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Βασικό σημείο</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation>Εξομάλυνση πενσών</translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished">Βασικό σημείο:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Μήκος:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished">Γωνία:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Κεντρικό σημείο:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Ακτίνα:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation>Πρώτη γωνία:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Δεύτερη γωνία:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished">Τρίτο σημείο:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished">Πρώτο σημείο αναφοράς:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished">Δεύτερο σημείο αναφοράς:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished">Πρώτο σημείο πένσας:</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished">Τόξο:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished">Καμπύλη:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished">Πρώτο σημείο γραμμής:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished">Δεύτερο σημείο γραμμής:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished">Κέντρο του κύκλου:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished">Πρώτο τόξο:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished">Δεύτερο τόξο:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation>Πάρε:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished">Πρώτη καμπύλη:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished">Δεύτερη καμπύλη:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Σημείο εφαπτομένης:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation>Όνομα:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished">Σημείο άξονα:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished">Κατάληξη:</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation>Σημείο προέλευσης:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation type="unfinished">Τύπος άξονα:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation>Γωνία περιστροφής:</translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished">Τέταρτο σημείο:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Περιστροφή</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished">Μετακίνηση</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Συντεταγμένες</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished">Δεύτερο σημείο πένσας:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished">Τρίτο σημείο πένσας:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Γραμμή</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">Πρώτη γραμμή</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Δεύτερη γραμμή</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished">Περιστροφή:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Τόξο_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Γραμμή_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished">Κεντρικό σημείο</translation>
     </message>
@@ -17996,12 +13802,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18009,17 +13813,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Γωνία</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
@@ -18027,12 +13828,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18040,12 +13839,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18053,12 +13850,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18066,17 +13861,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Μήκος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Γωνία</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Όνομα</translation>
     </message>
@@ -18084,1552 +13876,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation>Bunka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation>Bunka Fashion College</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation>Fundamentals of Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation>Barnfield and Richard</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation>Jo Barnfield and Andrew Richards</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation>Pattern Making Primer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation>Friendship/Women</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation>Elizabeth Friendship</translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation>Morris, K.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation>Karen Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation>Sewing Lingerie that Fits</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation>Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation>Lucia Mors de Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation>Patternmaking in Practic</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation>Kim &amp; Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation>Injoo Kim and Mykyung Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation>Apparel Making in Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation>Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation>Norah Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation>Corsets and Crinolines</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation>Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation>Frances Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation>Fashions of the Gilded Age</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation>Thornton&apos;s International System</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation>The Great War: Styles and Patterns of the 1910s</translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation>Hillhouse &amp; Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation>Marion S. Hillhouse and Evelyn A. Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation>Dress Design: Draping and Flat Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation>Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation>Esther Kaplan Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation>How to Design Beautiful Clothes: Designing and Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation>Minister &amp; Son</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>Edward Minister &amp; Son, ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation>The Complete Guide to Practical Cutting (1853)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation>Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation>Gertrude Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation>A Tailoring Manual</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation>Loh &amp; Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation>May Loh and Diehl Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternless Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation>Morris, F. R.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation>F. R. Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation>Ladies Garment Cutting and Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation>Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation>Gertrude Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation>Gertrude Mason&apos;s Patternmaking Book</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation>Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation>K. Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation>Master Designer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation>The Master Designer (Chicago, IL)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation>Master Designer&apos;s System of Designing, Cutting and Grading</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation>Kopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation>How to Draft Basic Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation>Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation>Doris Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation>Slacks Cut-to-Fit for Your Figure</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation>Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation>Sarah J. Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation>Sarah&apos;s Key to Pattern Drafting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation>Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation>Karla J. Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation>Design and Sew Jeans</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Lady Boutique magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation>Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation>M. Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation>Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation>Dorothy Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation>Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation>Bina Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation>Integrating Draping, Drafting and Drawing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation>Sue S. Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation>Scientific Pattern Drafting όπως διδάσκεται στο Style Center School of Costume Design, Dressmaking and Millinery</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Dressmaking International magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation>Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation>Mabel D. Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation>Practical Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation>Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation>E. L. G. Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>Principles of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation>Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation>Elizabeth M. Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation>European Cut</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation>McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation>Donald H. McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation>How to Make Your Own Sewing Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation>Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation>Zarapkar System of Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation>Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation>Philip Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation>Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation>Jack Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation>Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation>R. I. Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation>MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation>Jason MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation>The Victorian Tailor: An Introduction to Period Tailoring</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation>Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation>Helen Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation>Supreme System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation>Frederick T. Croonberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation>Sugino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation>Dressmaking</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting Vols. I, II, III (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation>Centre Point System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation>Louis Devere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation>The Handbook of Practical Cutting on the Centre Point System</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation>Aldrich/Ανδρικά</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation>Winifred Aldrich</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation>Aldrich/Γυναικεία</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Women&apos;s Wear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation>Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation>Gareth Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation>Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation>Teresa Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation>Pattern-Drafting for Fashion: The Basics</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation>Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation>Dennic Chunman Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation>Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation>Dress Pattern Designing: The Basic Principles of Cut and Fit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation>Knowles/Ανδρικά</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation>Lori A. Knowles</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation>The Practical Guide to Patternmaking for Fashion Designers: Menswear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation>Friendship/Ανδρικά</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting for Men&apos;s Costume</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation>Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation>P. Clement Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation>Art in Dress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation>Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation>Jno. J. Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation>GOST 17917-86</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation>Ministry of consumer industry of the USSR</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation>Standard figure boys</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation>Eddy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation>Josephine F. Eddy and Elizabeth C. B. Wiley</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation>Pattern and Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation>Knowles/Γυναικεία</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation>American Garment Cutter</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation>Κανένα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation>Ομάδα του Seamly2D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>εκ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>χιλ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>ίντσες</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation>ΤρέχονΜήκος</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation>μέγεθος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation>ύψος</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation>ΤρέχονΠεριθώριοΡαφής</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Γραμμή_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Τόξο_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19638,17 +15173,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation>&lt;b&gt;Μονοπάτι καμπύλης&lt;/b&gt;: επιλέξτε επτά ή περισσότερα σημεία</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation>&lt;b&gt;Μονοπάτι καμπύλης&lt;/b&gt;: επιλέξτε περισσότερα σημεία για ολοκληρωμενο τμήμα</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19656,7 +15188,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19664,7 +15195,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19672,7 +15202,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19680,12 +15209,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19693,7 +15220,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19701,7 +15227,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19709,17 +15234,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Μονοπάτι καμπύλης&lt;/b&gt;: επιλέξτε τρία ή περισσότερα σημεία</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19727,47 +15249,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>ΕΚΣΦΑΛΜΑΤΩΣΗ:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>ΠΡΟΕΙΔΟΠΟΙΗΣΗ:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>ΚΡΙΣΙΜΟ:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>ΑΝΕΠΑΝΟΡΘΩΤΟ:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>ΠΛΗΡΟΦΟΡΙΕΣ:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation>Προειδοποίηση</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation>Πληροφορίες</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19775,47 +15288,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>ΕΚΣΦΑΛΜΑΤΩΣΗ:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>ΠΡΟΕΙΔΟΠΟΙΗΣΗ:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>ΚΡΙΣΙΜΟ:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>ΑΝΕΠΑΝΟΡΘΩΤΟ:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>ΠΛΗΡΟΦΟΡΙΕΣ:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished">Προειδοποίηση</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished">Πληροφορίες</translation>
     </message>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>About Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Web site : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Built on %1 at %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Check For Updates</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished">unknown</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>add group</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>add object</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Error parsing file. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Error bad id. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Error can&apos;t convert value. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Error empty parameter. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Error wrong id. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Something&apos;s wrong!!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Parser error: %1. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Exception thrown: %1. Program will be terminated.</translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Error parsing file. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Error bad id. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Error can&apos;t convert value. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Error empty parameter. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Error wrong id. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Something&apos;s wrong!!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Parser error: %1. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Exception thrown: %1. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation>Seamly2D&apos;s measurements editor.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation>The measurement file.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation>The base height</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation>The base size</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation>Set pattern file unit: cm, mm, inch.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation>The pattern unit</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation>Invalid base size argument. Must be cm, mm or inch.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation>Test mode doesn&apos;t support Opening several files.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation>Please, provide one input file.</translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation>Open with the base size. Valid values: %1cm.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation>Invalid base height argument. Must be %1cm.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation>Invalid base size argument. Must be %1cm.</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation>Open with the base height. Valid values: %1cm.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation>Use for unit testing. Run the program and open a file without showing the main window.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>delete group</translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>delete tool</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>delete tool</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">About SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished">SeamlyMe version</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Build revision: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished">This program is part of Seamly2D project.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Check For Updates</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Built on %1 at %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Web site : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished">unknown</translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>First point of the line</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Second point of the line</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Angles equal</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Edit radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Edit first angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Edit second angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>First angle:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Second angle:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Center point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Select center point of the arc</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Edit radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Edit the first angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Edit the arc length</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>Length can&apos;t be equal 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>First angle:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Center point:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Select second point of angle</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Select third point of angle</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Third point:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Third point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Fourth point:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Select the second point of curve</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Select the third point of curve</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Select the fourth point of curve</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>Invalid spline</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Point:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>List of points</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation>Invalid spline path</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Select axis point</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Axis point:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Curve:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Arc:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Curve:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Curve:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation>Radius1:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation>Calulation</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation>Radius2:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation>First angle:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation>Second angle:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation>Rotation angle:</translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation>Center point:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation>Select center point of the arc</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Angles equal</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation>Edit radius1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation>Edit radius2</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Edit first angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Edit second angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation>Edit rotation angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Edit angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Base point:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Export options</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>With header</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation>Codec:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Separator</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>Comma</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>Semicolon</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Space</translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Select first point of line</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Base point:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished">Unnamed path</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished">Create name for your path</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished">Ready!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Seam allowance</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished">Nodes</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished">Node:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished">Before:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished">Return to default width</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished">After:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished">Notch:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished">Straightforward</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished">Bisector</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished">Intersection</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Edit seam allowance width</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Edit seam allowance width before</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Edit seam allowance width after</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished">Internal path</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished">Custom seam allowance</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished">You need more points!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished">First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">You have double points!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished">Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished">List of details is empty!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished">Please, select a detail to insert into!</translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Couldn&apos;t prepare data for creation layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Create a Layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation>Arranged workpieces: %1 from %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Select second point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>First line</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Second line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Select second point of first line</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Select first point of second line</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Select second point of second line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>First point of line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Select axis point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Axis Point</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Second point of line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Axis point:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Measurements</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished">Find:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished">Search</translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished">Axis point:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished">Axis type:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Vertical axis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Horizontal axis</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished">First line point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished">Second line point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation>Edit angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished">Origin Point:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Units:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Unique pattern piece name</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Choose unique pattern piece name.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>New pattern</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Pattern description</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Heights and Sizes</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>All heights (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>All sizes (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Default height and size</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Custom</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Height:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Size:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Security</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Open only for read</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation>Call context menu for edit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>No image</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Delete image</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Change image</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Save image to file</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Show image</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation>Image for pattern</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Images</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Save File</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>untitled</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Path:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Show in Explorer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;Empty&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>File was not saved yet.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Show in Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Pattern name:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Pattern number:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Company/Designer name:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Customer name:</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation type="unfinished">Pattern</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Select an arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Tangent point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Arc:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Take:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Select point of center of arc</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Edit radius</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation>Center of arc:</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation>Select second an arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>First arc:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Second arc:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Take:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>First curve:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Second curve:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Select second curve</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Pattern</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished">General</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Rotation</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation>Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferences</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Configuration</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Select first point of line</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Third point:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Coordinates on the sheet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Coordinates</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Base Point</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>First point</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Second point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Select last point of curve</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>Invalid spline</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation>Edit first control point angle</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation>Edit second control point angle</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation>Edit first control point length</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation>Edit second control point length</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation>Length can&apos;t be negative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>List of points</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Select point of curve path</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Point:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation>First control point</translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation>Second control point</translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation>Invalid spline path</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation>Edit first control point angle</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation>Edit second control point angle</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation>Edit first control point length</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation>Edit second control point length</translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation>Length can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation>Not used</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Empty field</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Value can&apos;t be 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Parser error: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>First point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Second point</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation>Highest point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation>Lowest point</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation>Leftmost point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation>Rightmost point</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation>by length</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation>by points intersetions</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation>by first edge symmetry</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation>by second edge symmetry</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation>by first edge right angle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation>by second edge right angle</translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation>Value can&apos;t be less than 0</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Select second point of axis</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Select first point</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Select second point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation>Select the second base point</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation>Select the first dart point</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation>Select the second dart point</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation>Select the third dart point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Broken formula</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Undo</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Fix formula</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancel</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Error while calculation formula. You can try to undo last operation or fix broken formula.</translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filter list by keyword</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">The calculated value</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished">Move measurement up</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished">Move measurement down</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Calculated value:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished">Description:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Radius</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished">Empty field.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Empty field</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Tool</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Edit formula</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished">Functions</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Insert variable into formula</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Hide empty measurements</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished">Full name</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filter list by keyword</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Line length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Curve length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Line Angle</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished">Arc radius</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished">Curve angle</translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Unique pattern piece name</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished">Could not save file</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">File error.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Size</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished">Fabric</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished">Lining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished">Interfacing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished">Interlining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished">Cut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished">Destination folder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished">Path to destination folder</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished">Select path to destination folder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished">Browse...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished">File format:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished">File name:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished">File base name</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished">Right:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished">Left:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished">Paper format</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished">The base filename does not match a regular expression.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished">Select folder</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished">Tried to use out of range format number.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished">Selected not present format.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation>Feed download failed: %1.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished">Groups</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - Base point</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">History</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished">Find:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Base Point</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Description</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished">Unit:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished">Confirm deletion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Do you really want to delete?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished">Notch</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Tangent point:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished">Select a circle center</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished">Edit radius</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished">Select second circle center</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished">Edit first circle radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished">Edit second circle radius</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Templates:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Width:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Height:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Rotate workpiece</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Rotate by</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>degree</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Three groups: big, middle, small</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Two groups: big, small</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>Descending area</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Pixels</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Auto crop unused length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Unite pages (if possible)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation>Gap width:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Save length of the sheet</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Paper format</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Left:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Right:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Top:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Bottom:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Wrong fields.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6626,84 +5194,67 @@ Apply settings anyway?</source>
 	Descending area = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation>Layout options</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation>Shift/Offset length:</translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation>Rule for choosing the next workpiece</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation>Divide into strips</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation>Multiplier</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation>Set multiplier for length of the biggest workpiece in layout.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation>Enabling for sheets that have big height will speed up creating.</translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Printer:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation>None</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6711,32 +5262,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,2660 +5289,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Tools for creating points.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Point</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Tools for creating lines.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Line</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Tools for creating curves.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Curve</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Tools for creating arcs.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Arc</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Measurements</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>New</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;New</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Create a new pattern</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Open</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Open file with pattern</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Save</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Save pattern</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Save &amp;As...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Save not yet saved pattern</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Pointer tools</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>History</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>About &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;About Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>E&amp;xit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Preferences</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Report bug</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Show online help</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>About Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Save as</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Could not save file</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Open file</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Error parsing file.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Error can&apos;t convert value.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Error empty parameter.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Error wrong id.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Error parsing file (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Bad id.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>File saved</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>untitled.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>The pattern has been modified.
 Do you want to save your changes?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Undo</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Redo</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>This file already opened in another window.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Wrong units.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>File loaded</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Reopen files.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Layout</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation>Print</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation>Print tiled PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation>Split and print a layout into smaller pages (for regular printers)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation>Print preview</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation>Print preview original layout</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation>Export As...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation>Layout mode</translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation>Unsaved changes</translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation>Measurements loaded</translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation>You can&apos;t export empty scene.</translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation>Measurement file contains invalid known measurement(s).</translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation>Measurement file has unknown format.</translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation>Measurement files types have not match.</translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation>Couldn&apos;t sync measurements.</translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation>Couldn&apos;t update measurements.</translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation>The measurements file &apos;%1&apos; could not be found.</translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation>Loading measurements file</translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation>Not supported size value &apos;%1&apos; for this pattern file.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation>Couldn&apos;t set size. File wasn&apos;t opened.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation>The method %1 does nothing in GUI mode</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation>Not supported height value &apos;%1&apos; for this pattern file.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation>Couldn&apos;t set height. File wasn&apos;t opened.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation>Please, provide one input file.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation>Print an original layout</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation>Preview tiled PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation>Print preview tiled layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation>Measurements unloaded</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation>Couldn&apos;t unload measurements. Some of them are used in the pattern.</translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>New pattern</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation>Open pattern</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation>Create/Edit measurements</translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>Save...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Don&apos;t Save</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Locking file</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>The lock file could not be created, for lack of permissions.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Unknown error happened, for instance a full partition prevented writing out the lock file.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation>Operations</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation>Close pattern</translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation>Tool pointer</translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation>Original zoom</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Height:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Size:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation>Measurements were changed. Do you want to sync measurements now?</translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Gradation doesn&apos;t support inches</translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation>Measurements have been synced</translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation>The document has no write permissions.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Cannot set permissions for %1 to writable.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Could not save the file.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation>Could not save the file</translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation>read only</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation>Load Individual</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation>Load Individual measurements file</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation>Load Multisize</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation>Load multisize measurements file</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation>Open SeamlyMe</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation>Edit Current</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation>Edit linked to the pattern measurements</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation>Sync</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation>Synchronize linked to the pattern measurements after change</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation>Unload Current</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation>Unload measurements if they were not used in a pattern file</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation>Individual measurements</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation>Multisize measurements</translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Pattern files</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation>Wiki</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation>Forum</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation>The calculated value</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation>Formula</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation>You can&apos;t use Layout mode yet.</translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished">Images</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">untitled</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
@@ -9405,86 +7291,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Creating file &apos;%1&apos; failed! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Critical error!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation>Print error</translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation>Cannot proceed because there are no available printers in your system.</translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation>unnamed</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation>The layout is stale.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation>The layout was not updated since last pattern modification. Do you want to continue?</translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Couldn&apos;t prepare data for creation layout</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation>Can&apos;t open printer %1</translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation>For previewing multipage document all sheet should have the same size.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation>For printing multipages document all sheet should have the same size.</translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation>Pages will be cropped because they do not fit printer paper size.</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation>Cannot set printer margins</translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation type="unfinished">Pattern</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9492,148 +7358,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished">File</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">New</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Save</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Save as</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Export to CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished">Help</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished">Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished">Ctrl+G</translation>
     </message>
@@ -9641,123 +7477,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished">Collapse All</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished">Expand All</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished">Check all</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished">Uncheck all</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Direct Height</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Direct Width</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Indentation</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Hand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Foot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Head</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Circumference and Arc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Vertical</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Horizontal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Bust</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Balance</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Arm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Leg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Crotch and Rise</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Men &amp; Tailoring</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Historical &amp; Specialty</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Patternmaking measurements</translation>
@@ -9766,18 +7581,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation>Can&apos;t find measurement &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation>The measurement name is empty!</translation>
     </message>
@@ -9785,37 +7592,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9823,12 +7623,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation>move the first dart label</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation>move the second dart label</translation>
     </message>
@@ -9836,7 +7634,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9844,7 +7641,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation>move point label</translation>
     </message>
@@ -9852,7 +7648,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished">move point label</translation>
     </message>
@@ -9860,7 +7655,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation>move single point</translation>
     </message>
@@ -9868,7 +7662,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation>move spline</translation>
     </message>
@@ -9876,7 +7669,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation>move spline path</translation>
     </message>
@@ -9884,52 +7676,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>New measurement file</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Measurement type:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Unit:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Base size:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Base height:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Individual</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9937,87 +7719,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished">Letter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished">Legal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished">Roll 24in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished">Roll 30in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished">Roll 36in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished">Roll 42in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished">Roll 44in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
@@ -10025,887 +7790,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished">Name can&apos;t be empty</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished">Letter:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished">Letter of pattern piece</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished">Placement:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished">Forbid piece be mirrored in a layout.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished">Main path</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished">All objects in path should follow in clockwise direction.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished">Ready!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished">Internal paths</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">The seam allowance is part of main path</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished">Built in</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Hide the main path if the seam allowance is enabled</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished">Nodes</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished">Node:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished">Before:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished">Return to default width</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished">After:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished">Start point:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished">End point:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished">Include as:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished">Notch:</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished">Straightforward</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished">Bisector</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished">Intersection</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished">Notch</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished">Excluded</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Options</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished">Error. Can&apos;t save piece path.</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished">Infinite/undefined result</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished">Length should be positive</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished">Edit height</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished">Edit width</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Edit seam allowance width</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Edit seam allowance width before</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Edit seam allowance width after</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished">Grainline</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished">You need more points!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">You have double points!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished">Each point in the path must be unique!</translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished">Empty</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished">main path</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished">custom seam allowance</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished">Both</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished">Just front</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished">Just rear</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Paths</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
@@ -10913,218 +8425,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished">move pattern piece label</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished">resize pattern piece label</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished">rotate pattern piece label</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished">move pattern info label</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished">resize pattern info label</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished">rotate pattern info label</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished">move grainline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished">resize grainline</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished">rotate grainline</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11132,27 +8592,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11160,77 +8615,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11238,139 +8678,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11378,62 +8773,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished">Select point for Y value (horizontal)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -11441,316 +8824,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation>Interval:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>GUI language:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation>Default unit:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>The Default unit has been updated and will be used as the default for the next pattern you create.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished">Undo</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished">Email:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11758,582 +9075,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished">Operations</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished">Graphical output</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation>Paths that Seamly2D uses</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Path</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation>Default</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation>Open Directory</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation>My Individual Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>My Multisize Measurements</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation>My Patterns</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation>My Layouts</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation>My Templates</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation>My Label Templates</translation>
     </message>
@@ -12341,272 +9490,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation>Forbid flipping</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation>By default forbid flipping for all new created workpieces</translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation>By default hide the main path if the seam allowance was enabled</translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Seam allowance</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Paths</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Width</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished">Templates</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12614,7 +9693,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>Based on Qt %1 (%2, %3 bit)</translation>
     </message>
@@ -12622,155 +9700,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Create new pattern piece to start working.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>inch</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Property</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Value</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation>add node</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation>Changes applied.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Wrong tag name &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation>Can&apos;t convert toUInt parameter</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation>Can&apos;t convert toBool parameter</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation>Got empty parameter</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation>Can&apos;t convert toDouble parameter</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation>Got wrong parameter id. Need only id &gt; 0.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished">Fabric</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished">Lining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished">Interfacing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished">Interlining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished">Cut</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12778,15 +9825,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation>too few arguments for function sum.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation>too few arguments for function min.</translation>
@@ -12795,217 +9838,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected token &quot;$TOK$&quot; found at position $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Internal error</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Invalid binary operator identifier: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Invalid infix operator identifier: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Invalid postfix operator identifier: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Invalid pointer to callback function.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>Expression is empty.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Invalid pointer to variable.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected operator &quot;$TOK$&quot; found at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unexpected end of expression at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unexpected argument separator at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected function &quot;$TOK$&quot; at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected value &quot;$TOK$&quot; found at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected variable &quot;$TOK$&quot; found at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Function arguments used without a function (position: $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Missing parenthesis</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Divide by zero</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Domain error</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Name conflict</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>Invalid value for operator priority (must be greater or equal to zero).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unexpected string token found at position $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unterminated string starting at position $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>String function called with a non string type of argument.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>String value used where a numerical argument is expected.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>Function result is a string.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Parser error.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>Decimal separator is identic to function argument separator.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>If-then-else operator is missing an else clause</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Misplaced colon at position $POS$</translation>
@@ -13014,7 +10021,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13022,7 +10028,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished">rename pattern piece</translation>
     </message>
@@ -13030,12 +10035,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13043,7 +10046,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation>save detail option</translation>
     </message>
@@ -13051,7 +10053,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation>save path options</translation>
     </message>
@@ -13059,7 +10060,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation>save tool option</translation>
     </message>
@@ -13067,88 +10067,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Language</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished">Pattern making system</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished">System:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">Author:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished">Book:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished">Measurements editing</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished">Reset warnings</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished">Toolbar</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished">The text appears under the icon (recommended for beginners).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished">Default height and size</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13156,52 +10138,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished">Open Directory</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished">My Individual Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished">My Multisize Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished">My Templates</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13209,102 +10181,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimeters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Inches</translation>
     </message>
@@ -13312,92 +10263,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimeters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Inches</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13405,12 +10337,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13418,1071 +10348,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished">File</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">New</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Save</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Save as</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished">Undo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished">Open SeamlyMe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished">Operations</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished">Images</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished">Rename</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">History</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished">Help</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14490,12 +11203,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14503,42 +11214,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14546,7 +11249,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14554,7 +11256,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14562,819 +11263,626 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation>Calculated value</translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Formula</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Base value</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>In sizes</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>In heights</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Formula:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation>Base value:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation>In sizes:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation>In heights:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Description:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation>Move measurement up</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Move measurement down</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Calculated value:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation>Full name:</translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Type:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation>Measurement type</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Path:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Show in Explorer</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Base size:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation>Base size value</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Base height:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation>Base height value</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Given name:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Family name:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation>Birth date:</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>Email:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>Notes:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>File</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Window</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Measurements</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation>Menu</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation>Gradation</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation>Open individual ...</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation>Save As ...</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>About &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>About SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>New</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation>Add known</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation>Add custom</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation>Read only</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>Database</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation>Show information about all known measurement</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Preferences</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation>untitled %1</translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>This file already opened in another window.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>File error.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Could not save file</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Save as</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation>&amp;New Window</translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation>Edit measurement</translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Empty field.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Parser error: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Individual measurements</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>untitled</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation>Unsaved changes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Measurements have been modified.
 Do you want to save your changes?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Empty field</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Open file</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation>Import from a pattern</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation>Pattern unit:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Find:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation>Find Previous</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation>Find Next</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation>Failed to lock. This file already opened in another window.</translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation>File contains invalid known measurement(s).</translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation>File has unknown format.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Full name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation>File &apos;%1&apos; doesn&apos;t exist!</translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation>The name of known measurement forbidden to change.</translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation>Can&apos;t find measurement &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation>The full name of known measurement forbidden to change.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation>Function Wizard</translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation>Move measurement top</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation>Move measurement bottom</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation>Delete measurement</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation>unknown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>male</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>female</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation>Gender:</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation>PM system:</translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation>Create from existing ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation>Create from existing file</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation>Select file</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation>Measurement diagram</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>About Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>File was not saved yet.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation>Measurement&apos;s name in a formula</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation>Measurement&apos;s name in a formula.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation>Measurement&apos;s human-readable name.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>Save...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Don&apos;t Save</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Locking file</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>The lock file could not be created, for lack of permissions.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Unknown error happened, for instance a full partition prevented writing out the lock file.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation>Export to CSV</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Show in Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation>Customer&apos;s name</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation>Customer&apos;s family name</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation>Customer&apos;s email address</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Height:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Size:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation>All files</translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation>The measurements document has no write permissions.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Cannot set permissions for %1 to writable.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Could not save the file.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation>Could not save the file</translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation>read only</translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation>Multisize measurements</translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation>Empty</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation>Open template ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation type="unfinished">Pattern files</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished">This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished">The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished">Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15382,7 +11890,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15390,22 +11897,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15413,22 +11916,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15436,47 +11935,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">First point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Second point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished">Highest point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished">Lowest point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished">Leftmost point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished">Rightmost point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Vertical axis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Horizontal axis</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
@@ -15484,47 +11974,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Union tool</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished">Retain original pieces</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Select a second point</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Select a unique point</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished">Select a point on edge</translation>
     </message>
@@ -15532,7 +12013,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15540,17 +12020,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Do not ask again</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Do not &amp;ask again</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>Do not &amp;show again</translation>
     </message>
@@ -15558,57 +12035,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Couldn&apos;t get version information.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>Too many tags &lt;%1&gt; in file.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Version &quot;%1&quot; invalid.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Version &quot;0.0.0&quot; invalid.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Invalid version. Minimum supported version is %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Invalid version. Maximum supported version is %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Error no unique id.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>Could not change version.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation>Error creating a reserv copy: %1.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Unexpected version &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation>Error Opening a temp file: %1.</translation>
     </message>
@@ -15616,7 +12082,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation>Can&apos;t cut this spline</translation>
     </message>
@@ -15624,22 +12089,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Export to CSV</translation>
     </message>
@@ -15647,13 +12108,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
@@ -15661,23 +12119,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>Can&apos;t find tool in table.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation>Error creating or updating group</translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>New group</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15685,7 +12138,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15693,12 +12145,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -15706,283 +12156,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Confirm deletion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Do you really want to delete?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation>Edit wrong formula</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15990,302 +12383,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation>Path to custom measure file (export mode).</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation>The measure file</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation>Format number</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation>Template number</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>The page width</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation>The measure unit</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Angle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation>Auto crop unused length (export mode).</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation>Layout units (as paper&apos;s one except px, export mode).</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation>The unit</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation>The gap width</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation>Grouping type</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation>Cannot use pageformat and page explicit size/units together.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation>Page height, width, units must be used all 3 at once.</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation>Invalid rotation value. That must be one of predefined values.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation>Unknown page templated selected.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation>Unsupported paper units.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation>Unsupported layout units.</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation>Export options can be used with single input file only.</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation>Test option can be used with single input file only.</translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation>The base filename of exported layout files. Use it to enable console export mode.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation>The base filename of layout files</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>The destination folder</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation>The size value</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation>The height value</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation>Invalid gradation size value.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation>Invalid gradation height value.</translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Pattern making program.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Pattern file.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation>Gap width must be used together with shift units.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation>Left margin must be used together with page units.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation>Right margin must be used together with page units.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation>Top margin must be used together with page units.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation>Bottom margin must be used together with page units.</translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation>The path to output destination folder. By default the directory at which the application was started.</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation>Sets layout groupping cases (export mode): %1.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation>Shift/Offset length</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation>Shift/Offset length must be used together with shift units.</translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation>Number corresponding to output format (default = 0, export mode):</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation>Number corresponding to page template (default = 0, export mode):</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16293,43 +12626,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation>measurements</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation>individual</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation>multisize</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation>templates</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16337,55 +12661,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>Can&apos;t find object</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation>Can&apos;t cast object</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation>Can&apos;t find object. Type mismatch.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation>Number of free id exhausted.</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation>Can&apos;t create a curve with type &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16393,12 +12704,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation>Not enough points to create the spline.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation>This spline does not exist.</translation>
     </message>
@@ -16406,52 +12715,42 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>Can&apos;t open file %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Can&apos;t open schema file %1:
 %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation>Validation error file %3 in line %1 column %2</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation>Parsing error file %3 in line %1 column %2</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation>Couldn&apos;t get node</translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>This id is not unique.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation>Could not load schema file &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation>Fail to write Canonical XML.</translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16459,27 +12758,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16487,7 +12781,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation>Exception: %1</translation>
     </message>
@@ -16495,11 +12788,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
@@ -16507,7 +12795,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
@@ -16515,7 +12802,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation>Piece %1 doesn&apos;t have shape.</translation>
     </message>
@@ -16523,7 +12809,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16531,12 +12816,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>True</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>False</translation>
     </message>
@@ -16544,12 +12827,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Directory</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Open File</translation>
     </message>
@@ -16557,335 +12838,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Error parsing file.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Error can&apos;t convert value.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Error empty parameter.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Error wrong id.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Error parsing file (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Error creating or updating single point</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Error creating or updating point of end line</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Error creating or updating point along line</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Error creating or updating point of shoulder</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation>Error creating or updating point of normal</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Error creating or updating point of bisector</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Error creating or updating point of contact</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation>Error creating or updating modeling point</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Error creating or updating height</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Error creating or updating triangle</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation>Error creating or updating cut spline point</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation>Error creating or updating cut spline path point</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation>Error creating or updating cut arc point</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation>Error creating or updating point of intersection line and axis</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation>Error creating or updating point of intersection curve and axis</translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Error creating or updating line</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Error creating or updating simple curve</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Error creating or updating curve path</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation>Error creating or updating modeling simple curve</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation>Error creating or updating modeling curve path</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Error creating or updating simple arc</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation>Error creating or updating modeling arc</translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation>Error creating or updating point of intersection arcs</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation>Error creating or updating point of intersection circles</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation>Error creating or updating point from circle and tangent</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation>Error creating or updating point from arc and tangent</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation>Error creating or updating true darts</translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Wrong tag name &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation>Unknown point type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation>Unknown spline type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation>Unknown arc type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation>Unknown tools type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation>Error not unique id.</translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation>Error creating or updating point of intersection curves</translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation>Error creating or updating simple interactive spline</translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation>Error creating or updating interactive spline path</translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation>Error creating or updating cubic bezier curve</translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation>Error creating or updating cubic bezier path curve</translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation>Error creating or updating operation of rotation</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation>Unknown operation type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation>Error creating or updating operation of moving</translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation>Error creating or updating point of line intersection</translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation>Error creating or updating simple elliptical arc</translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation>Unknown elliptical arc type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation>Error creating or updating modeling elliptical arc</translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation>Unnamed path</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation>Error creating or updating a piece path</translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16893,17 +13085,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation>Grid ( %1 , %2 )</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation>Page %1 of %2</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation>Sheet %1 of %2</translation>
     </message>
@@ -16911,12 +13100,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation>patterns</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation>layouts</translation>
     </message>
@@ -16924,14 +13111,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>Not enough points to create the spline.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>This spline does not exist.</translation>
     </message>
@@ -16939,17 +13122,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -16957,27 +13137,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16985,37 +13160,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17023,7 +13191,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17031,12 +13198,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17044,32 +13209,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17077,18 +13236,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17096,18 +13251,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17115,7 +13266,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17123,28 +13273,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17152,17 +13296,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17170,12 +13311,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
@@ -17183,7 +13322,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17191,27 +13329,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17219,17 +13352,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17237,7 +13367,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17245,12 +13374,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">First line point</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Second line point</translation>
     </message>
@@ -17258,27 +13385,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17286,714 +13408,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Base point</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation>True darts</translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation>Base point:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation>Center point:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation>First angle:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Second angle:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation>Third point:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Point 1 label:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation>Point 2 label:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation>First base point:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation>Second base point:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation>First dart point:</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation>Arc:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation>Curve:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation>First line point:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Second line point:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Center of arc:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation>First arc:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation>Second arc:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation>Take:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation>First curve:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation>Second curve:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation>Tangent point:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation>Circle radius:</translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>C1: angle:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation>C1: length:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>C2: angle:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation>C2: length:</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation>Axis point:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation>Origin point:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation>Axis type:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation>Rotation angle:</translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation>Fourth point:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinates</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished">Second dart point:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished">Third dart point:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">First line</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Second line</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
@@ -18001,12 +13807,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18014,17 +13818,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -18032,12 +13833,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18045,12 +13844,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18058,12 +13855,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18071,17 +13866,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -18089,1552 +13881,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation>Bunka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation>Bunka Fashion College</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation>Fundamentals of Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation>Barnfield and Richard</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation>Jo Barnfield and Andrew Richards</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation>Pattern Making Primer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation>Friendship/Women</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation>Elizabeth Friendship</translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation>Morris, K.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation>Karen Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation>Sewing Lingerie that Fits</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation>Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation>Lucia Mors de Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation>Patternmaking in Practic</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation>Kim &amp; Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation>Injoo Kim and Mykyung Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation>Apparel Making in Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation>Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation>Norah Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation>Corsets and Crinolines</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation>Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation>Frances Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation>Fashions of the Gilded Age</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation>Thornton&apos;s International System</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation>The Great War: Styles and Patterns of the 1910s</translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation>Hillhouse &amp; Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation>Marion S. Hillhouse and Evelyn A. Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation>Dress Design: Draping and Flat Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation>Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation>Esther Kaplan Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation>How to Design Beautiful Clothes: Designing and Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation>Minister &amp; Son</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>Edward Minister &amp; Son, ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation>The Complete Guide to Practical Cutting (1853)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation>Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation>Gertrude Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation>A Tailoring Manual</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation>Loh &amp; Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation>May Loh and Diehl Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternless Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation>Morris, F. R.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation>F. R. Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation>Ladies Garment Cutting and Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation>Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation>Gertrude Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation>Gertrude Mason&apos;s Patternmaking Book</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation>Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation>K. Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation>Master Designer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation>The Master Designer (Chicago, IL)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation>Master Designer&apos;s System of Designing, Cutting and Grading</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation>Kopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation>How to Draft Basic Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation>Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation>Doris Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation>Slacks Cut-to-Fit for Your Figure</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation>Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation>Sarah J. Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation>Sarah&apos;s Key to Pattern Drafting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation>Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation>Karla J. Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation>Design and Sew Jeans</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Lady Boutique magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation>Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation>M. Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation>Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation>Dorothy Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation>Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation>Bina Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation>Integrating Draping, Drafting and Drawing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation>Sue S. Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Dressmaking International magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation>Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation>Mabel D. Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation>Practical Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation>Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation>E. L. G. Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>Principles of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation>Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation>Elizabeth M. Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation>European Cut</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation>McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation>Donald H. McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation>How to Make Your Own Sewing Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation>Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation>Zarapkar System of Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation>Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation>Philip Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation>Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation>Jack Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation>Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation>R. I. Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation>MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation>Jason MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation>The Victorian Tailor: An Introduction to Period Tailoring</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation>Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation>Helen Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation>Supreme System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation>Frederick T. Croonberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation>Sugino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation>Dressmaking</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting Vols. I, II, III (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation>Centre Point System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation>Louis Devere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation>The Handbook of Practical Cutting on the Centre Point System</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation>Aldrich/Men</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation>Winifred Aldrich</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation>Aldrich/Women</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Women&apos;s Wear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation>Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation>Gareth Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation>Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation>Teresa Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation>Pattern-Drafting for Fashion: The Basics</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation>Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation>Dennic Chunman Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation>Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation>Dress Pattern Designing: The Basic Principles of Cut and Fit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation>Knowles/Men</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation>Lori A. Knowles</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation>The Practical Guide to Patternmaking for Fashion Designers: Menswear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation>Friendship/Men</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting for Men&apos;s Costume</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation>Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation>P. Clement Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation>Art in Dress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation>Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation>Jno. J. Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation>GOST 17917-86</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation>Ministry of consumer industry of the USSR</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation>Standard figure boys</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation>Eddy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation>Josephine F. Eddy and Elizabeth C. B. Wiley</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation>Pattern and Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation>Knowles/Women</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation>American Garment Cutter</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation>None</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation>Seamly2D team</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation>Seamly2D&apos;s internal standard</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>in</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>SplPath</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Angle1SplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Angle2SplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation>Seg_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation>CurrentLength</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation>size</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation>height</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>C1LengthSplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>C2LengthSplPath</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation>CurrentSeamAllowance</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">M_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">AngleLine_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">RadiusArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle1Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle2Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle1Spl_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle2Spl_</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">C1LengthSpl_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">C2LengthSpl_</translation>
@@ -19643,17 +15178,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19661,7 +15193,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19669,7 +15200,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19677,7 +15207,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19685,12 +15214,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19698,7 +15225,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19706,7 +15232,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19714,17 +15239,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19732,47 +15254,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>DEBUG:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>WARNING:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>CRITICAL:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation>Warning</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19780,47 +15293,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>DEBUG:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>WARNING:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>CRITICAL:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished">Warning</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Web site : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Built on %1 at %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Check For Updates</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished">unknown</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">About SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished">SeamlyMe version</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Build revision: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished">This program is part of Seamly2D project.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Check For Updates</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Built on %1 at %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Web site : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished">unknown</translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation type="unfinished">Edit radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation type="unfinished">Edit radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation type="unfinished">Axis point:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished">Unnamed path</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished">Create name for your path</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished">Ready!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Seam allowance</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished">Nodes</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished">Node:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished">Before:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished">Return to default width</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished">After:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished">Notch:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished">Straightforward</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished">Bisector</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished">Intersection</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Edit seam allowance width</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Edit seam allowance width before</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Edit seam allowance width after</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished">Internal path</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished">Custom seam allowance</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished">You need more points!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished">First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">You have double points!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished">Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished">List of details is empty!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished">Please, select a detail to insert into!</translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation type="unfinished">First line</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation type="unfinished">Second line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation type="unfinished">Axis point:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished">Find:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished">Search</translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished">Axis point:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished">Axis type:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Vertical axis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Horizontal axis</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished">First line point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished">Second line point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished">Origin Point:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Unique pattern piece name</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation type="unfinished">Default height and size</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation type="unfinished">untitled</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation type="unfinished">Pattern</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Tangent point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation type="unfinished">Edit radius</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation type="unfinished">Pattern</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished">General</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferences</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Configuration</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinates</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Base Point</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation type="unfinished">First point</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation type="unfinished">Second point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation type="unfinished">Empty field</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation type="unfinished">First point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation type="unfinished">Second point</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation type="unfinished">Highest point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation type="unfinished">Lowest point</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation type="unfinished">Leftmost point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation type="unfinished">Rightmost point</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filter list by keyword</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">The calculated value</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished">Move measurement up</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished">Move measurement down</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Calculated value:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished">Description:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Radius</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished">Empty field.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Empty field</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Tool</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Edit formula</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished">Functions</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Insert variable into formula</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Hide empty measurements</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished">Full name</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filter list by keyword</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Line length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Curve length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Line Angle</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished">Arc radius</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished">Curve angle</translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Unique pattern piece name</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished">Could not save file</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">File error.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Size</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished">Fabric</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished">Lining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished">Interfacing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished">Interlining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished">Cut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished">Destination folder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished">Path to destination folder</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished">Select path to destination folder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished">Browse...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished">File format:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished">File name:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished">File base name</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished">Right:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished">Left:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished">Paper format</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished">The base filename does not match a regular expression.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished">Select folder</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished">Tried to use out of range format number.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished">Selected not present format.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished">Groups</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - Base point</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">History</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished">Find:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Base Point</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Description</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished">Notch</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Tangent point:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished">Select a circle center</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished">Edit radius</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished">Select second circle center</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished">Edit first circle radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished">Edit second circle radius</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation type="unfinished">Paper format</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation type="unfinished">Left:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation type="unfinished">Right:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6626,84 +5194,67 @@ Apply settings anyway?</source>
 	Descending area = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6711,32 +5262,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,2660 +5289,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation type="unfinished">History</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferences</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation type="unfinished">Could not save file</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>The pattern has been modified.
 Do you want to save your changes?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation type="unfinished">Operations</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished">The calculated value</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">untitled</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
@@ -9405,86 +7291,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation type="unfinished">Pattern</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9492,148 +7358,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Export to CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9641,123 +7477,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished">Collapse All</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished">Expand All</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished">Check all</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished">Uncheck all</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Direct Height</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Direct Width</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Indentation</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Hand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Foot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Head</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Circumference and Arc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Vertical</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Horizontal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Bust</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Balance</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Arm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Leg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Crotch and Rise</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Men &amp; Tailoring</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Historical &amp; Specialty</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Patternmaking measurements</translation>
@@ -9766,18 +7581,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9785,37 +7592,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9823,12 +7623,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9836,7 +7634,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9844,7 +7641,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation type="unfinished">move point label</translation>
     </message>
@@ -9852,7 +7648,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished">move point label</translation>
     </message>
@@ -9860,7 +7655,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9868,7 +7662,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9876,7 +7669,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9884,52 +7676,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9937,87 +7719,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished">Letter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished">Legal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished">Roll 24in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished">Roll 30in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished">Roll 36in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished">Roll 42in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished">Roll 44in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
@@ -10025,887 +7790,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished">Name can&apos;t be empty</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished">Letter:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished">Letter of pattern piece</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished">Placement:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished">Forbid piece be mirrored in a layout.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished">Main path</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished">All objects in path should follow in clockwise direction.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished">Ready!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished">Internal paths</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">The seam allowance is part of main path</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished">Built in</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Hide the main path if the seam allowance is enabled</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished">Nodes</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished">Node:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished">Before:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished">Return to default width</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished">After:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished">Start point:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished">End point:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished">Include as:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished">Notch:</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished">Straightforward</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished">Bisector</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished">Intersection</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished">Notch</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished">Excluded</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Options</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished">Error. Can&apos;t save piece path.</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished">Infinite/undefined result</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished">Length should be positive</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished">Edit height</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished">Edit width</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Edit seam allowance width</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Edit seam allowance width before</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Edit seam allowance width after</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished">Grainline</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished">You need more points!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">You have double points!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished">Each point in the path must be unique!</translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished">Empty</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished">main path</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished">custom seam allowance</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished">Both</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished">Just front</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished">Just rear</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Paths</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
@@ -10913,218 +8425,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished">move pattern piece label</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished">resize pattern piece label</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished">rotate pattern piece label</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished">move pattern info label</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished">resize pattern info label</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished">rotate pattern info label</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished">move grainline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished">resize grainline</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished">rotate grainline</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11132,27 +8592,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11160,77 +8615,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11238,139 +8678,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11378,62 +8773,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished">Select point for Y value (horizontal)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -11441,316 +8824,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished">Language</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished">Undo</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11758,582 +9075,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished">Operations</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished">Graphical output</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished">Paths that Seamly2D uses</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished">Open Directory</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished">My Individual Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished">My Multisize Measurements</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished">My Templates</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12341,272 +9490,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished">Forbid flipping</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Seam allowance</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Paths</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Width</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished">Templates</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12614,7 +9693,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12622,155 +9700,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished">Fabric</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished">Lining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished">Interfacing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished">Interlining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished">Cut</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12778,15 +9825,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
@@ -12795,217 +9838,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
@@ -13014,7 +10021,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13022,7 +10028,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished">rename pattern piece</translation>
     </message>
@@ -13030,12 +10035,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13043,7 +10046,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13051,7 +10053,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13059,7 +10060,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13067,88 +10067,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Language</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished">Pattern making system</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished">System:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">Author:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished">Book:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished">Measurements editing</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished">Reset warnings</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished">Toolbar</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished">The text appears under the icon (recommended for beginners).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished">Default height and size</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13156,52 +10138,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished">Open Directory</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished">My Individual Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished">My Multisize Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished">My Templates</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13209,102 +10181,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13312,92 +10263,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13405,12 +10337,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13418,1071 +10348,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished">Undo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished">Operations</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished">Rename</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">History</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14490,12 +11203,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14503,42 +11214,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14546,7 +11249,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14554,7 +11256,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14562,819 +11263,626 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation type="unfinished">Description:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation type="unfinished">Move measurement up</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished">Move measurement down</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Calculated value:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">About SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferences</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation type="unfinished">File error.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation type="unfinished">Could not save file</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation type="unfinished">Empty field.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation type="unfinished">untitled</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Measurements have been modified.
 Do you want to save your changes?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation type="unfinished">Empty field</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation type="unfinished">Find:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation type="unfinished">Full name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation type="unfinished">unknown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation type="unfinished">Search</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Export to CSV</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished">Empty</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15382,7 +11890,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15390,22 +11897,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15413,22 +11916,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15436,47 +11935,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">First point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Second point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished">Highest point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished">Lowest point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished">Leftmost point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished">Rightmost point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Vertical axis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Horizontal axis</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
@@ -15484,47 +11974,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Union tool</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished">Retain original pieces</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Select a second point</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Select a unique point</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished">Select a point on edge</translation>
     </message>
@@ -15532,7 +12013,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15540,17 +12020,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15558,57 +12035,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15616,7 +12082,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15624,22 +12089,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Export to CSV</translation>
     </message>
@@ -15647,13 +12108,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
@@ -15661,23 +12119,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15685,7 +12138,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15693,12 +12145,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -15706,283 +12156,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15990,302 +12383,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16293,43 +12626,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16337,55 +12661,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16393,12 +12704,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16406,52 +12715,42 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>Can&apos;t open file %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Can&apos;t open schema file %1:
 %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16459,27 +12758,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16487,7 +12781,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16495,11 +12788,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
@@ -16507,7 +12795,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
@@ -16515,7 +12802,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16523,7 +12809,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16531,12 +12816,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16544,12 +12827,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16557,335 +12838,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation type="unfinished">Unnamed path</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16893,17 +13085,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16911,12 +13100,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16924,14 +13111,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16939,17 +13122,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -16957,27 +13137,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16985,37 +13160,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17023,7 +13191,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17031,12 +13198,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17044,32 +13209,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17077,18 +13236,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17096,18 +13251,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17115,7 +13266,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17123,28 +13273,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17152,17 +13296,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17170,12 +13311,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
@@ -17183,7 +13322,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17191,27 +13329,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17219,17 +13352,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17237,7 +13367,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17245,12 +13374,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">First line point</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Second line point</translation>
     </message>
@@ -17258,27 +13385,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17286,714 +13408,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished">First line point:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished">Second line point:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Tangent point:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished">Axis point:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation type="unfinished">Axis type:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinates</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished">Second dart point:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished">Third dart point:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">First line</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Second line</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
@@ -18001,12 +13807,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18014,17 +13818,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -18032,12 +13833,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18045,12 +13844,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18058,12 +13855,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18071,17 +13866,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -18089,1552 +13881,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation type="unfinished">degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation type="unfinished">radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation type="unfinished">sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation type="unfinished">cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation type="unfinished">tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation type="unfinished">asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation type="unfinished">acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation type="unfinished">atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation type="unfinished">sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation type="unfinished">cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation type="unfinished">tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation type="unfinished">asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation type="unfinished">acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation type="unfinished">atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation type="unfinished">sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation type="unfinished">cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation type="unfinished">tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation type="unfinished">asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation type="unfinished">acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation type="unfinished">atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation type="unfinished">log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation type="unfinished">log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation type="unfinished">log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation type="unfinished">ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation type="unfinished">exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation type="unfinished">sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation type="unfinished">sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation type="unfinished">rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation type="unfinished">abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation type="unfinished">fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19643,17 +15178,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19661,7 +15193,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19669,7 +15200,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19677,7 +15207,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19685,12 +15214,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19698,7 +15225,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19706,7 +15232,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19714,17 +15239,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19732,47 +15254,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation type="unfinished">Warning</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19780,47 +15293,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished">Warning</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>About Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Web site : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Built on %1 at %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Check For Updates</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished">unknown</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>add group</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>add object</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Error parsing file. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Error bad id. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Error can&apos;t convert value. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Error empty parameter. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Error wrong id. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Something&apos;s wrong!!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Parser error: %1. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Exception thrown: %1. Program will be terminated.</translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Error parsing file. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Error bad id. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Error can&apos;t convert value. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Error empty parameter. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Error wrong id. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Something&apos;s wrong!!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Parser error: %1. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Exception thrown: %1. Program will be terminated.</translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation>Seamly2D&apos;s measurements editor.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation>The measurement file.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation>The base height</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation>The base size</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation>Set pattern file unit: cm, mm, inch.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation>The pattern unit</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation>Invalid base size argument. Must be cm, mm or inch.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation>Test mode doesn&apos;t support Opening several files.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation>Please, provide one input file.</translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation>Open with the base size. Valid values: %1cm.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation>Invalid base height argument. Must be %1cm.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation>Invalid base size argument. Must be %1cm.</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation>Open with the base height. Valid values: %1cm.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation>Use for unit testing. Run the program and open a file without showing the main window.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>delete group</translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>delete tool</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>delete tool</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">About SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished">SeamlyMe version</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Build revision: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished">This program is part of Seamly2D project.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Check For Updates</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Built on %1 at %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Web site : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished">unknown</translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>First point of the line</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Second point of the line</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Angles equal</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Edit radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Edit first angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Edit second angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>First angle:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Second angle:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Center point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Select center point of the arc</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Edit radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Edit the first angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Edit the arc length</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>Length can&apos;t be equal 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>First angle:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Center point:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Select second point of angle</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Select third point of angle</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Third point:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Third point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Fourth point:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Select the second point of curve</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Select the third point of curve</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Select the fourth point of curve</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>Invalid spline</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Point:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>List of points</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation>Invalid spline path</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Select axis point</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Axis point:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Curve:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Arc:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Curve:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Curve:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation>Radius1:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation>Calulation</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation>Radius2:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation>First angle:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation>Second angle:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation>Rotation angle:</translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation>Center point:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation>Select center point of the arc</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Angles equal</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation>Edit radius1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation>Edit radius2</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Edit first angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Edit second angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation>Edit rotation angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Edit angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Base point:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Export options</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>With header</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation>Codec:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Separator</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>Comma</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>Semicolon</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Space</translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Select first point of line</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Base point:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished">Unnamed path</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished">Create name for your path</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished">Ready!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Seam allowance</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished">Nodes</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished">Node:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished">Before:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished">Return to default width</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished">After:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished">Notch:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished">Straightforward</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished">Bisector</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished">Intersection</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Edit seam allowance width</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Edit seam allowance width before</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Edit seam allowance width after</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished">Internal path</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished">Custom seam allowance</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished">You need more points!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished">First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">You have double points!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished">Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished">List of details is empty!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished">Please, select a detail to insert into!</translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Couldn&apos;t prepare data for creation layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Create a Layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation>Arranged workpieces: %1 from %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Select second point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>First line</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Second line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Select second point of first line</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Select first point of second line</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Select second point of second line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>First point of line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Select axis point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Axis Point</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Second point of line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Axis point:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Measurements</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished">Find:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished">Search</translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished">Axis point:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished">Axis type:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Vertical axis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Horizontal axis</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished">First line point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished">Second line point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation>Edit angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished">Origin Point:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Units:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Unique pattern piece name</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Choose unique pattern piece name.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>New pattern</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Pattern description</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Heights and Sizes</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>All heights (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>All sizes (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Default height and size</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Custom</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Height:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Size:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Security</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Open only for read</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation>Call context menu for edit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>No image</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Delete image</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Change image</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Save image to file</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Show image</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation>Image for pattern</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Images</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Save File</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>untitled</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Path:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Show in Explorer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;Empty&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>File was not saved yet.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Show in Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Pattern name:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Pattern number:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Company/Designer name:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Customer name:</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation type="unfinished">Pattern</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Select an arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Tangent point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Arc:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Take:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Select point of center of arc</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Edit radius</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation>Center of arc:</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation>Select second an arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>First arc:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Second arc:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Take:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>First curve:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Second curve:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Select second curve</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Pattern</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished">General</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Rotation</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation>Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferences</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Configuration</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Select first point of line</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Select second point of line</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Third point:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Coordinates on the sheet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Coordinates</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Base Point</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>First point</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Second point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Select last point of curve</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>Invalid spline</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation>Edit first control point angle</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation>Edit second control point angle</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation>Edit first control point length</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation>Edit second control point length</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation>Length can&apos;t be negative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>List of points</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Select point of curve path</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Point:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation>First control point</translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation>Second control point</translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation>Invalid spline path</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formula wizard</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation>Edit first control point angle</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation>Edit second control point angle</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation>Edit first control point length</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation>Edit second control point length</translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation>Length can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation>Not used</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Calculation</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Empty field</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Value can&apos;t be 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Parser error: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>First point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Second point</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation>Highest point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation>Lowest point</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation>Leftmost point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation>Rightmost point</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation>by length</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation>by points intersetions</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation>by first edge symmetry</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation>by second edge symmetry</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation>by first edge right angle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation>by second edge right angle</translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation>Value can&apos;t be less than 0</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Select second point of axis</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Select first point</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Select second point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation>Select the second base point</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation>Select the first dart point</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation>Select the second dart point</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation>Select the third dart point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Broken formula</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Undo</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Fix formula</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancel</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Error while calculation formula. You can try to undo last operation or fix broken formula.</translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filter list by keyword</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">The calculated value</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished">Move measurement up</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished">Move measurement down</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Calculated value:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished">Description:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Radius</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished">Empty field.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Empty field</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Tool</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Edit formula</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished">Functions</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Insert variable into formula</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Hide empty measurements</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished">Full name</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filter list by keyword</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Line length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Curve length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Line Angle</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished">Arc radius</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished">Curve angle</translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Unique pattern piece name</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished">Could not save file</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">File error.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Size</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished">Fabric</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished">Lining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished">Interfacing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished">Interlining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished">Cut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished">Destination folder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished">Path to destination folder</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished">Select path to destination folder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished">Browse...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished">File format:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished">File name:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished">File base name</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished">Right:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished">Left:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished">Paper format</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished">The base filename does not match a regular expression.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished">Select folder</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished">Tried to use out of range format number.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished">Selected not present format.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation>Feed download failed: %1.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished">Groups</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - Base point</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">History</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished">Find:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Base Point</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Description</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished">Unit:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished">Confirm deletion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Do you really want to delete?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished">Notch</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Tangent point:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished">Select a circle center</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished">Edit radius</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished">Select second circle center</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished">Edit first circle radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished">Edit second circle radius</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Templates:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Width:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Height:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Rotate workpiece</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Rotate by</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>degree</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Three groups: big, middle, small</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Two groups: big, small</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>Descending area</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Pixels</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Auto crop unused length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Unite pages (if possible)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation>Gap width:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Save length of the sheet</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Paper format</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Left:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Right:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Top:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Bottom:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Wrong fields.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6626,84 +5194,67 @@ Apply settings anyway?</source>
 	Descending area = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation>Layout options</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation>Shift/Offset length:</translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation>Rule for choosing the next workpiece</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation>Divide into strips</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation>Multiplier</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation>Set multiplier for length of the biggest workpiece in layout.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation>Enabling for sheets that have big height will speed up creating.</translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Printer:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation>None</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6711,32 +5262,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,2660 +5289,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Tools for creating points.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Point</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Tools for creating lines.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Line</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Tools for creating curves.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Curve</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Tools for creating arcs.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Arc</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Measurements</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>New</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;New</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Create a new pattern</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Open</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Open file with pattern</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Save</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Save pattern</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Save &amp;As...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Save not yet saved pattern</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Pointer tools</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>History</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>About &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;About Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>E&amp;xit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Preferences</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Report bug</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Show online help</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>About Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Save as</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Could not save file</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Open file</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Error parsing file.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Error can&apos;t convert value.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Error empty parameter.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Error wrong id.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Error parsing file (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Bad id.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>File saved</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>untitled.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>The pattern has been modified.
 Do you want to save your changes?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Undo</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Redo</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>This file already opened in another window.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Wrong units.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>File loaded</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Reopen files.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Layout</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation>Print</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation>Print tiled PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation>Split and print a layout into smaller pages (for regular printers)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation>Print preview</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation>Print preview original layout</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation>Export As...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation>Layout mode</translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation>Unsaved changes</translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation>Measurements loaded</translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation>You can&apos;t export empty scene.</translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation>Measurement file contains invalid known measurement(s).</translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation>Measurement file has unknown format.</translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation>Measurement files types have not match.</translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation>Couldn&apos;t sync measurements.</translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation>Couldn&apos;t update measurements.</translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation>The measurements file &apos;%1&apos; could not be found.</translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation>Loading measurements file</translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation>Not supported size value &apos;%1&apos; for this pattern file.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation>Couldn&apos;t set size. File wasn&apos;t opened.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation>The method %1 does nothing in GUI mode</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation>Not supported height value &apos;%1&apos; for this pattern file.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation>Couldn&apos;t set height. File wasn&apos;t opened.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation>Please, provide one input file.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation>Print an original layout</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation>Preview tiled PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation>Print preview tiled layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation>Measurements unloaded</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation>Couldn&apos;t unload measurements. Some of them are used in the pattern.</translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>New pattern</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation>Open pattern</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation>Create/Edit measurements</translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>Save...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Don&apos;t Save</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Locking file</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>The lock file could not be created, for lack of permissions.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Unknown error happened, for instance a full partition prevented writing out the lock file.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation>Operations</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation>Close pattern</translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation>Tool pointer</translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation>Original zoom</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Height:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Size:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation>Measurements were changed. Do you want to sync measurements now?</translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Gradation doesn&apos;t support inches</translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation>Measurements have been synced</translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation>The document has no write permissions.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Cannot set permissions for %1 to writable.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Could not save the file.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation>Could not save the file</translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation>read only</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation>Load Individual</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation>Load Individual measurements file</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation>Load Multisize</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation>Load multisize measurements file</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation>Open SeamlyMe</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation>Edit Current</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation>Edit linked to the pattern measurements</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation>Sync</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation>Synchronize linked to the pattern measurements after change</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation>Unload Current</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation>Unload measurements if they were not used in a pattern file</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation>Individual measurements</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation>Multisize measurements</translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Pattern files</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation>Wiki</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation>Forum</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation>The calculated value</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation>Formula</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation>You can&apos;t use Layout mode yet.</translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished">Images</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">untitled</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
@@ -9405,86 +7291,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Creating file &apos;%1&apos; failed! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Critical error!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation>Print error</translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation>Cannot proceed because there are no available printers in your system.</translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation>unnamed</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation>The layout is stale.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation>The layout was not updated since last pattern modification. Do you want to continue?</translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Couldn&apos;t prepare data for creation layout</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation>Can&apos;t open printer %1</translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation>For previewing multipage document all sheet should have the same size.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation>For printing multipages document all sheet should have the same size.</translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation>Pages will be cropped because they do not fit printer paper size.</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation>Cannot set printer margins</translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation type="unfinished">Pattern</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9492,148 +7358,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished">File</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">New</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Save</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Save as</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Export to CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished">Help</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished">Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished">Ctrl+G</translation>
     </message>
@@ -9641,123 +7477,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished">Collapse All</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished">Expand All</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished">Check all</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished">Uncheck all</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Direct Height</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Direct Width</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Indentation</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Hand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Foot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Head</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Circumference and Arc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Vertical</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Horizontal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Bust</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Balance</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Arm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Leg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Crotch and Rise</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Men &amp; Tailoring</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Historical &amp; Specialty</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Patternmaking measurements</translation>
@@ -9766,18 +7581,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation>Can&apos;t find measurement &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation>The measurement name is empty!</translation>
     </message>
@@ -9785,37 +7592,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9823,12 +7623,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation>move the first dart label</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation>move the second dart label</translation>
     </message>
@@ -9836,7 +7634,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9844,7 +7641,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation>move point label</translation>
     </message>
@@ -9852,7 +7648,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished">move point label</translation>
     </message>
@@ -9860,7 +7655,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation>move single point</translation>
     </message>
@@ -9868,7 +7662,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation>move spline</translation>
     </message>
@@ -9876,7 +7669,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation>move spline path</translation>
     </message>
@@ -9884,52 +7676,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>New measurement file</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Measurement type:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Unit:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Base size:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Base height:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Individual</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9937,87 +7719,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished">Letter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished">Legal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished">Roll 24in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished">Roll 30in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished">Roll 36in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished">Roll 42in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished">Roll 44in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
@@ -10025,887 +7790,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished">Name can&apos;t be empty</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished">Letter:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished">Letter of pattern piece</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished">Placement:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished">Forbid piece be mirrored in a layout.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished">Main path</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished">All objects in path should follow in clockwise direction.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished">Ready!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished">Internal paths</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">The seam allowance is part of main path</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished">Built in</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Hide the main path if the seam allowance is enabled</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished">Nodes</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished">Node:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished">Before:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished">Return to default width</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished">After:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished">Start point:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished">End point:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished">Include as:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished">Notch:</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished">Straightforward</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished">Bisector</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished">Intersection</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished">Notch</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished">Excluded</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Options</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished">Error. Can&apos;t save piece path.</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished">Infinite/undefined result</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished">Length should be positive</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished">Edit height</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished">Edit width</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Edit seam allowance width</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Edit seam allowance width before</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Edit seam allowance width after</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished">Grainline</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished">You need more points!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">You have double points!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished">Each point in the path must be unique!</translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished">Empty</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished">main path</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished">custom seam allowance</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished">Both</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished">Just front</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished">Just rear</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Paths</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
@@ -10913,218 +8425,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished">move pattern piece label</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished">resize pattern piece label</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished">rotate pattern piece label</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished">move pattern info label</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished">resize pattern info label</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished">rotate pattern info label</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished">move grainline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished">resize grainline</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished">rotate grainline</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11132,27 +8592,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11160,77 +8615,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11238,139 +8678,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11378,62 +8773,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished">Select point for Y value (horizontal)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -11441,316 +8824,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation>Interval:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>GUI language:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation>Default unit:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>The Default unit has been updated and will be used as the default for the next pattern you create.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished">Undo</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished">Email:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11758,582 +9075,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished">Operations</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished">Graphical output</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation>Paths that Seamly2D uses</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Path</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation>Default</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation>Open Directory</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation>My Individual Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>My Multisize Measurements</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation>My Patterns</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation>My Layouts</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation>My Templates</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12341,272 +9490,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation>Forbid flipping</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation>By default forbid flipping for all new created workpieces</translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation>By default hide the main path if the seam allowance was enabled</translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Seam allowance</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Paths</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Width</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished">Templates</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12614,7 +9693,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>Based on Qt %1 (%2, %3 bit)</translation>
     </message>
@@ -12622,155 +9700,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Create new pattern piece to start working.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>inch</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Property</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Value</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation>add node</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation>Changes applied.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Wrong tag name &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation>Can&apos;t convert toUInt parameter</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation>Can&apos;t convert toBool parameter</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation>Got empty parameter</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation>Can&apos;t convert toDouble parameter</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation>Got wrong parameter id. Need only id &gt; 0.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished">Fabric</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished">Lining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished">Interfacing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished">Interlining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished">Cut</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12778,15 +9825,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation>too few arguments for function sum.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation>too few arguments for function min.</translation>
@@ -12795,217 +9838,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected token &quot;$TOK$&quot; found at position $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Internal error</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Invalid binary operator identifier: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Invalid infix operator identifier: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Invalid postfix operator identifier: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Invalid pointer to callback function.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>Expression is empty.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Invalid pointer to variable.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected operator &quot;$TOK$&quot; found at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unexpected end of expression at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unexpected argument separator at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected function &quot;$TOK$&quot; at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected value &quot;$TOK$&quot; found at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Unexpected variable &quot;$TOK$&quot; found at position $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Function arguments used without a function (position: $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Missing parenthesis</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Divide by zero</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Domain error</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Name conflict</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>Invalid value for operator priority (must be greater or equal to zero).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unexpected string token found at position $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Unterminated string starting at position $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>String function called with a non string type of argument.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>String value used where a numerical argument is expected.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>Function result is a string.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Parser error.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>Decimal separator is identic to function argument separator.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>If-then-else operator is missing an else clause</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Misplaced colon at position $POS$</translation>
@@ -13014,7 +10021,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13022,7 +10028,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished">rename pattern piece</translation>
     </message>
@@ -13030,12 +10035,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13043,7 +10046,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation>save detail option</translation>
     </message>
@@ -13051,7 +10053,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation>save path options</translation>
     </message>
@@ -13059,7 +10060,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation>save tool option</translation>
     </message>
@@ -13067,88 +10067,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Language</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished">Pattern making system</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished">System:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">Author:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished">Book:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished">Measurements editing</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished">Reset warnings</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished">Toolbar</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished">The text appears under the icon (recommended for beginners).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished">Default height and size</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13156,52 +10138,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished">Open Directory</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished">My Individual Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished">My Multisize Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished">My Templates</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13209,102 +10181,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimeters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Inches</translation>
     </message>
@@ -13312,92 +10263,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimeters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Inches</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13405,12 +10337,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13418,1071 +10348,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished">File</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">New</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Save</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Save as</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished">Undo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished">Open SeamlyMe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished">Operations</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished">Images</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished">Rename</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">History</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished">Help</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14490,12 +11203,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14503,42 +11214,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14546,7 +11249,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14554,7 +11256,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14562,819 +11263,626 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation>Calculated value</translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Formula</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Base value</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>In sizes</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>In heights</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Formula:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation>Base value:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation>In sizes:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation>In heights:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Description:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation>Move measurement up</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Move measurement down</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Calculated value:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation>Full name:</translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Type:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation>Measurement type</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Path:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Show in Explorer</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Base size:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation>Base size value</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Base height:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation>Base height value</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Given name:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Family name:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation>Birth date:</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>Email:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>Notes:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>File</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Window</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Measurements</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation>Menu</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation>Gradation</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation>Open individual ...</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation>Save As ...</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>About &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>About SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>New</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation>Add known</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation>Add custom</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation>Read only</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>Database</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation>Show information about all known measurement</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Preferences</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation>untitled %1</translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>This file already opened in another window.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>File error.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Could not save file</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Save as</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation>&amp;New Window</translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation>Edit measurement</translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Empty field.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Parser error: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Individual measurements</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>untitled</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation>Unsaved changes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Measurements have been modified.
 Do you want to save your changes?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Empty field</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Value</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Open file</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation>Import from a pattern</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation>Pattern unit:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Find:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation>Find Previous</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation>Find Next</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation>Failed to lock. This file already opened in another window.</translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation>File contains invalid known measurement(s).</translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation>File has unknown format.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Full name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation>File &apos;%1&apos; doesn&apos;t exist!</translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation>The name of known measurement forbidden to change.</translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation>Can&apos;t find measurement &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation>The full name of known measurement forbidden to change.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation>Function Wizard</translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation>Move measurement top</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation>Move measurement bottom</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation>Delete measurement</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation>unknown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>male</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>female</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation>Gender:</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation>PM system:</translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation>Create from existing ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation>Create from existing file</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation>Select file</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation>Measurement diagram</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>About Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>File was not saved yet.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation>Measurement&apos;s name in a formula</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation>Measurement&apos;s name in a formula.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation>Measurement&apos;s human-readable name.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>Save...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Don&apos;t Save</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Locking file</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>The lock file could not be created, for lack of permissions.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Unknown error happened, for instance a full partition prevented writing out the lock file.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation>Export to CSV</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Show in Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation>Customer&apos;s name</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation>Customer&apos;s family name</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation>Customer&apos;s email address</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Height:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Size:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation>All files</translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation>The measurements document has no write permissions.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Cannot set permissions for %1 to writable.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Could not save the file.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation>Could not save the file</translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation>read only</translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation>Multisize measurements</translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation>Empty</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation type="unfinished">Pattern files</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished">This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished">The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished">Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15382,7 +11890,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15390,22 +11897,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15413,22 +11916,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15436,47 +11935,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">First point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Second point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished">Highest point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished">Lowest point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished">Leftmost point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished">Rightmost point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Vertical axis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Horizontal axis</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
@@ -15484,47 +11974,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Union tool</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished">Retain original pieces</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Select a second point</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Select a unique point</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished">Select a point on edge</translation>
     </message>
@@ -15532,7 +12013,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15540,17 +12020,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Do not ask again</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Do not &amp;ask again</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>Do not &amp;show again</translation>
     </message>
@@ -15558,57 +12035,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Couldn&apos;t get version information.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>Too many tags &lt;%1&gt; in file.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Version &quot;%1&quot; invalid.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Version &quot;0.0.0&quot; invalid.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Invalid version. Minimum supported version is %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Invalid version. Maximum supported version is %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Error no unique id.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>Could not change version.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation>Error creating a reserv copy: %1.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Unexpected version &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation>Error Opening a temp file: %1.</translation>
     </message>
@@ -15616,7 +12082,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation>Can&apos;t cut this spline</translation>
     </message>
@@ -15624,22 +12089,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Export to CSV</translation>
     </message>
@@ -15647,13 +12108,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
@@ -15661,23 +12119,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>Can&apos;t find tool in table.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation>Error creating or updating group</translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>New group</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15685,7 +12138,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15693,12 +12145,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -15706,283 +12156,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Confirm deletion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Do you really want to delete?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation>Edit wrong formula</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15990,302 +12383,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation>Path to custom measure file (export mode).</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation>The measure file</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation>Format number</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation>Template number</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>The page width</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation>The measure unit</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Angle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation>Auto crop unused length (export mode).</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation>Layout units (as paper&apos;s one except px, export mode).</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation>The unit</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation>The gap width</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation>Grouping type</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation>Cannot use pageformat and page explicit size/units together.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation>Page height, width, units must be used all 3 at once.</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation>Invalid rotation value. That must be one of predefined values.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation>Unknown page templated selected.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation>Unsupported paper units.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation>Unsupported layout units.</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation>Export options can be used with single input file only.</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation>Test option can be used with single input file only.</translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation>The base filename of exported layout files. Use it to enable console export mode.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation>The base filename of layout files</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>The destination folder</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation>The size value</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation>The height value</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation>Invalid gradation size value.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation>Invalid gradation height value.</translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Pattern making program.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Pattern file.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation>Gap width must be used together with shift units.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation>Left margin must be used together with page units.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation>Right margin must be used together with page units.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation>Top margin must be used together with page units.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation>Bottom margin must be used together with page units.</translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation>The path to output destination folder. By default the directory at which the application was started.</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation>Sets layout groupping cases (export mode): %1.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation>Shift/Offset length</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation>Shift/Offset length must be used together with shift units.</translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation>Number corresponding to output format (default = 0, export mode):</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation>Number corresponding to page template (default = 0, export mode):</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16293,43 +12626,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation>measurements</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation>individual</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation>multisize</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation>templates</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16337,55 +12661,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>Can&apos;t find object</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation>Can&apos;t cast object</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation>Can&apos;t find object. Type mismatch.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation>Number of free id exhausted.</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation>Can&apos;t create a curve with type &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16393,12 +12704,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation>Not enough points to create the spline.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation>This spline does not exist.</translation>
     </message>
@@ -16406,52 +12715,42 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>Can&apos;t open file %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Can&apos;t open schema file %1:
 %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation>Validation error file %3 in line %1 column %2</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation>Parsing error file %3 in line %1 column %2</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation>Couldn&apos;t get node</translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>This id is not unique.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation>Could not load schema file &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation>Fail to write Canonical XML.</translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16459,27 +12758,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16487,7 +12781,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation>Exception: %1</translation>
     </message>
@@ -16495,11 +12788,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
@@ -16507,7 +12795,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
@@ -16515,7 +12802,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation>Piece %1 doesn&apos;t have shape.</translation>
     </message>
@@ -16523,7 +12809,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16531,12 +12816,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>True</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>False</translation>
     </message>
@@ -16544,12 +12827,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Directory</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Open File</translation>
     </message>
@@ -16557,335 +12838,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Error parsing file.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Error can&apos;t convert value.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Error empty parameter.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Error wrong id.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Error parsing file (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Error creating or updating single point</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Error creating or updating point of end line</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Error creating or updating point along line</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Error creating or updating point of shoulder</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation>Error creating or updating point of normal</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Error creating or updating point of bisector</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Error creating or updating point of contact</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation>Error creating or updating modeling point</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Error creating or updating height</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Error creating or updating triangle</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation>Error creating or updating cut spline point</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation>Error creating or updating cut spline path point</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation>Error creating or updating cut arc point</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation>Error creating or updating point of intersection line and axis</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation>Error creating or updating point of intersection curve and axis</translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Error creating or updating line</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Error creating or updating simple curve</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Error creating or updating curve path</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation>Error creating or updating modeling simple curve</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation>Error creating or updating modeling curve path</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Error creating or updating simple arc</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation>Error creating or updating modeling arc</translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation>Error creating or updating point of intersection arcs</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation>Error creating or updating point of intersection circles</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation>Error creating or updating point from circle and tangent</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation>Error creating or updating point from arc and tangent</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation>Error creating or updating true darts</translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Wrong tag name &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation>Unknown point type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation>Unknown spline type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation>Unknown arc type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation>Unknown tools type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation>Error not unique id.</translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation>Error creating or updating point of intersection curves</translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation>Error creating or updating simple interactive spline</translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation>Error creating or updating interactive spline path</translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation>Error creating or updating cubic bezier curve</translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation>Error creating or updating cubic bezier path curve</translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation>Error creating or updating operation of rotation</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation>Unknown operation type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation>Error creating or updating operation of moving</translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation>Error creating or updating point of line intersection</translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation>Error creating or updating simple elliptical arc</translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation>Unknown elliptical arc type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation>Error creating or updating modeling elliptical arc</translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation>Unnamed path</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation>Error creating or updating a piece path</translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16893,17 +13085,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation>Grid ( %1 , %2 )</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation>Page %1 of %2</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation>Sheet %1 of %2</translation>
     </message>
@@ -16911,12 +13100,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation>patterns</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation>layouts</translation>
     </message>
@@ -16924,14 +13111,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>Not enough points to create the spline.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>This spline does not exist.</translation>
     </message>
@@ -16939,17 +13122,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -16957,27 +13137,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16985,37 +13160,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17023,7 +13191,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17031,12 +13198,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17044,32 +13209,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17077,18 +13236,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17096,18 +13251,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17115,7 +13266,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17123,28 +13273,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17152,17 +13296,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17170,12 +13311,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
@@ -17183,7 +13322,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17191,27 +13329,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17219,17 +13352,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17237,7 +13367,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17245,12 +13374,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">First line point</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Second line point</translation>
     </message>
@@ -17258,27 +13385,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17286,714 +13408,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Base point</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation>True darts</translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation>Base point:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation>Center point:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation>First angle:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Second angle:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation>Third point:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Point 1 label:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation>Point 2 label:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation>First base point:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation>Second base point:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation>First dart point:</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation>Arc:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation>Curve:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation>First line point:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Second line point:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Center of arc:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation>First arc:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation>Second arc:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation>Take:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation>First curve:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation>Second curve:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation>Tangent point:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation>Circle radius:</translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation>Name:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>C1: angle:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation>C1: length:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>C2: angle:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation>C2: length:</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation>Axis point:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation>Suffix:</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation>Origin point:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation>Axis type:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation>Rotation angle:</translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation>Fourth point:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinates</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished">Second dart point:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished">Third dart point:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">First line</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Second line</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
@@ -18001,12 +13807,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18014,17 +13818,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -18032,12 +13833,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18045,12 +13844,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18058,12 +13855,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18071,17 +13866,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -18089,1552 +13881,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation>Bunka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation>Bunka Fashion College</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation>Fundamentals of Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation>Barnfield and Richard</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation>Jo Barnfield and Andrew Richards</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation>Pattern Making Primer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation>Friendship/Women</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation>Elizabeth Friendship</translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation>Morris, K.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation>Karen Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation>Sewing Lingerie that Fits</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation>Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation>Lucia Mors de Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation>Patternmaking in Practic</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation>Kim &amp; Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation>Injoo Kim and Mykyung Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation>Apparel Making in Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation>Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation>Norah Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation>Corsets and Crinolines</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation>Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation>Frances Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation>Fashions of the Gilded Age</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation>Thornton&apos;s International System</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation>The Great War: Styles and Patterns of the 1910s</translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation>Hillhouse &amp; Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation>Marion S. Hillhouse and Evelyn A. Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation>Dress Design: Draping and Flat Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation>Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation>Esther Kaplan Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation>How to Design Beautiful Clothes: Designing and Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation>Minister &amp; Son</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>Edward Minister &amp; Son, ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation>The Complete Guide to Practical Cutting (1853)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation>Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation>Gertrude Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation>A Tailoring Manual</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation>Loh &amp; Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation>May Loh and Diehl Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternless Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation>Morris, F. R.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation>F. R. Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation>Ladies Garment Cutting and Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation>Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation>Gertrude Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation>Gertrude Mason&apos;s Patternmaking Book</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation>Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation>K. Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation>Master Designer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation>The Master Designer (Chicago, IL)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation>Master Designer&apos;s System of Designing, Cutting and Grading</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation>Kopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation>How to Draft Basic Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation>Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation>Doris Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation>Slacks Cut-to-Fit for Your Figure</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation>Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation>Sarah J. Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation>Sarah&apos;s Key to Pattern Drafting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation>Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation>Karla J. Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation>Design and Sew Jeans</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Lady Boutique magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation>Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation>M. Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation>Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation>Dorothy Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation>Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation>Bina Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation>Integrating Draping, Drafting and Drawing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation>Sue S. Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Dressmaking International magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation>Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation>Mabel D. Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation>Practical Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation>Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation>E. L. G. Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>Principles of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation>Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation>Elizabeth M. Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation>European Cut</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation>McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation>Donald H. McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation>How to Make Your Own Sewing Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation>Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation>Zarapkar System of Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation>Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation>Philip Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation>Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation>Jack Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation>Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation>R. I. Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation>MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation>Jason MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation>The Victorian Tailor: An Introduction to Period Tailoring</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation>Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation>Helen Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation>Supreme System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation>Frederick T. Croonberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation>Sugino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation>Dressmaking</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting Vols. I, II, III (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation>Centre Point System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation>Louis Devere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation>The Handbook of Practical Cutting on the Centre Point System</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation>Aldrich/Men</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation>Winifred Aldrich</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation>Aldrich/Women</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Women&apos;s Wear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation>Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation>Gareth Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation>Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation>Teresa Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation>Pattern-Drafting for Fashion: The Basics</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation>Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation>Dennic Chunman Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation>Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation>Dress Pattern Designing: The Basic Principles of Cut and Fit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation>Knowles/Men</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation>Lori A. Knowles</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation>The Practical Guide to Patternmaking for Fashion Designers: Menswear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation>Friendship/Men</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting for Men&apos;s Costume</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation>Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation>P. Clement Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation>Art in Dress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation>Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation>Jno. J. Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation>GOST 17917-86</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation>Ministry of consumer industry of the USSR</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation>Standard figure boys</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation>Eddy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation>Josephine F. Eddy and Elizabeth C. B. Wiley</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation>Pattern and Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation>Knowles/Women</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation>American Garment Cutter</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation>None</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation>Seamly2D team</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation>Seamly2D&apos;s internal standard</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>in</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>SplPath</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Angle1SplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Angle2SplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation>Seg_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation>CurrentLength</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation>size</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation>height</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>C1LengthSplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>C2LengthSplPath</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation>CurrentSeamAllowance</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">M_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">AngleLine_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">RadiusArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle1Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle2Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle1Spl_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle2Spl_</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">C1LengthSpl_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">C2LengthSpl_</translation>
@@ -19643,17 +15178,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19661,7 +15193,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19669,7 +15200,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19677,7 +15207,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19685,12 +15214,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19698,7 +15225,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19706,7 +15232,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19714,17 +15239,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19732,47 +15254,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>DEBUG:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>WARNING:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>CRITICAL:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation>Warning</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19780,47 +15293,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>DEBUG:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>WARNING:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>CRITICAL:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished">Warning</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Web site : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Built on %1 at %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Check For Updates</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished">unknown</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">About SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished">SeamlyMe version</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Build revision: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished">This program is part of Seamly2D project.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Check For Updates</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Built on %1 at %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Web site : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished">unknown</translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation type="unfinished">Edit radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation type="unfinished">Edit radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation type="unfinished">Axis point:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished">Unnamed path</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished">Create name for your path</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished">Ready!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Seam allowance</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished">Nodes</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished">Node:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished">Before:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished">Return to default width</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished">After:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished">Notch:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished">Straightforward</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished">Bisector</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished">Intersection</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Edit seam allowance width</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Edit seam allowance width before</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Edit seam allowance width after</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished">Internal path</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished">Custom seam allowance</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished">You need more points!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished">First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">You have double points!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished">Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished">List of details is empty!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished">Please, select a detail to insert into!</translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation type="unfinished">First line</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation type="unfinished">Second line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation type="unfinished">Axis point:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished">Find:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished">Search</translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished">Axis point:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished">Axis type:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Vertical axis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Horizontal axis</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished">First line point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished">Second line point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished">Origin Point:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Unique pattern piece name</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation type="unfinished">Default height and size</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation type="unfinished">untitled</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation type="unfinished">Pattern</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Tangent point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation type="unfinished">Edit radius</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation type="unfinished">Pattern</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished">General</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferences</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Configuration</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinates</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Base Point</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation type="unfinished">First point</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation type="unfinished">Second point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation type="unfinished">Empty field</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation type="unfinished">First point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation type="unfinished">Second point</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation type="unfinished">Highest point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation type="unfinished">Lowest point</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation type="unfinished">Leftmost point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation type="unfinished">Rightmost point</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filter list by keyword</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">The calculated value</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished">Move measurement up</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished">Move measurement down</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Calculated value:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished">Description:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Radius</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished">Empty field.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Empty field</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Tool</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Edit formula</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished">Functions</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Insert variable into formula</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Hide empty measurements</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished">Full name</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filter list by keyword</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Line length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Curve length</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Line Angle</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished">Arc radius</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished">Curve angle</translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Unique pattern piece name</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished">Could not save file</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">File error.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Size</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished">Fabric</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished">Lining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished">Interfacing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished">Interlining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished">Cut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished">Destination folder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished">Path to destination folder</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished">Select path to destination folder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished">Browse...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished">File format:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished">File name:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished">File base name</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished">Right:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished">Left:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished">Paper format</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished">The base filename does not match a regular expression.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished">Select folder</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished">Tried to use out of range format number.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished">Selected not present format.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished">Groups</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - Base point</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">History</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished">Find:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Base Point</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Description</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished">Piece:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished">Notch</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Tangent point:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished">Select a circle center</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished">Edit radius</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished">Select second circle center</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished">Edit first circle radius</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished">Edit second circle radius</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Radius can&apos;t be negative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation type="unfinished">Paper format</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation type="unfinished">Left:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation type="unfinished">Right:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6626,84 +5194,67 @@ Apply settings anyway?</source>
 	Descending area = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6711,32 +5262,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,2660 +5289,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation type="unfinished">History</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferences</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation type="unfinished">Could not save file</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>The pattern has been modified.
 Do you want to save your changes?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation type="unfinished">Operations</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished">The calculated value</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished">Point:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">untitled</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
@@ -9405,86 +7291,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation type="unfinished">Pattern</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9492,148 +7358,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Export to CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9641,123 +7477,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished">Collapse All</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished">Expand All</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished">Check all</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished">Uncheck all</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Direct Height</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Direct Width</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Indentation</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Hand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Foot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Head</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Circumference and Arc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Vertical</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Horizontal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Bust</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Balance</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Arm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Leg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Crotch and Rise</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Men &amp; Tailoring</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Historical &amp; Specialty</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Patternmaking measurements</translation>
@@ -9766,18 +7581,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9785,37 +7592,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9823,12 +7623,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9836,7 +7634,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9844,7 +7641,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation type="unfinished">move point label</translation>
     </message>
@@ -9852,7 +7648,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished">move point label</translation>
     </message>
@@ -9860,7 +7655,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9868,7 +7662,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9876,7 +7669,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9884,52 +7676,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9937,87 +7719,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished">Letter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished">Legal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished">Roll 24in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished">Roll 30in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished">Roll 36in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished">Roll 42in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished">Roll 44in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
@@ -10025,887 +7790,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished">Name can&apos;t be empty</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished">Letter:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished">Letter of pattern piece</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished">Placement:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished">Forbid piece be mirrored in a layout.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished">Main path</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished">All objects in path should follow in clockwise direction.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished">Ready!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished">Internal paths</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">The seam allowance is part of main path</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished">Built in</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Hide the main path if the seam allowance is enabled</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula wizard</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished">Calculation</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished">Nodes</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished">Node:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished">Before:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished">Return to default width</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished">After:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished">Custom</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished">Start point:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished">End point:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished">Include as:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished">Notch:</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished">Straightforward</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished">Bisector</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished">Intersection</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished">Notch</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished">Excluded</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Options</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished">Error. Can&apos;t save piece path.</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished">Infinite/undefined result</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished">Length should be positive</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished">Edit length</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished">Edit angle</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished">Edit height</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished">Edit width</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Edit seam allowance width</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Edit seam allowance width before</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Edit seam allowance width after</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished">Grainline</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished">You need more points!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">You have double points!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished">Each point in the path must be unique!</translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished">Empty</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished">main path</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished">custom seam allowance</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished">Both</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished">Just front</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished">Just rear</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Paths</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
@@ -10913,218 +8425,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Current seam allowance</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished">move pattern piece label</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished">resize pattern piece label</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished">rotate pattern piece label</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished">move pattern info label</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished">resize pattern info label</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished">rotate pattern info label</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished">move grainline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished">resize grainline</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished">rotate grainline</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11132,27 +8592,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11160,77 +8615,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11238,139 +8678,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11378,62 +8773,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished">Select point for Y value (horizontal)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
@@ -11441,316 +8824,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished">Language</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished">Undo</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11758,582 +9075,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished">Operations</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished">Graphical output</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished">Paths that Seamly2D uses</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished">Open Directory</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished">My Individual Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished">My Multisize Measurements</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished">My Templates</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12341,272 +9490,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished">Forbid flipping</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Seam allowance</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Paths</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Width</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Height</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished">Templates</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12614,7 +9693,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12622,155 +9700,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished">Fabric</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished">Lining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished">Interfacing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished">Interlining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished">Cut</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished">on fold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12778,15 +9825,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
@@ -12795,217 +9838,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
@@ -13014,7 +10021,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13022,7 +10028,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished">rename pattern piece</translation>
     </message>
@@ -13030,12 +10035,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13043,7 +10046,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13051,7 +10053,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13059,7 +10060,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13067,88 +10067,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Language</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished">Pattern making system</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished">System:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">Author:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished">Book:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished">Measurements editing</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished">Reset warnings</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished">Toolbar</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished">The text appears under the icon (recommended for beginners).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished">Default height and size</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13156,52 +10138,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished">Open Directory</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished">My Individual Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished">My Multisize Measurements</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished">My Templates</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13209,102 +10181,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13312,92 +10263,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished">Units:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI language:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13405,12 +10337,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13418,1071 +10348,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished">Edit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished">Undo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished">Labels</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished">Operations</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished">Rename</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">History</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14490,12 +11203,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14503,42 +11214,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14546,7 +11249,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14554,7 +11256,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14562,819 +11263,626 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Details</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation type="unfinished">Description:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation type="unfinished">Move measurement up</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished">Move measurement down</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Calculated value:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation type="unfinished">Path:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation type="unfinished">Measurements</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">About SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferences</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation type="unfinished">File error.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation type="unfinished">Could not save file</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation type="unfinished">Empty field.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Parser error: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation type="unfinished">untitled</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Measurements have been modified.
 Do you want to save your changes?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation type="unfinished">Empty field</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation type="unfinished">Find:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation type="unfinished">Full name</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation type="unfinished">unknown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation type="unfinished">Search</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Export to CSV</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation type="unfinished">Height:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation type="unfinished">Size:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Invalid result. Value is infinite or NaN. Please, check your calculations.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished">Empty</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished">Print</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15382,7 +11890,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15390,22 +11897,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15413,22 +11916,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15436,47 +11935,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">First point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Second point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished">Highest point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished">Lowest point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished">Leftmost point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished">Rightmost point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Vertical axis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Horizontal axis</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
@@ -15484,47 +11974,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Union tool</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished">Retain original pieces</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Select a second point</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Select a unique point</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished">Select a point on edge</translation>
     </message>
@@ -15532,7 +12013,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15540,17 +12020,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15558,57 +12035,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15616,7 +12082,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15624,22 +12089,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Export to CSV</translation>
     </message>
@@ -15647,13 +12108,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
@@ -15661,23 +12119,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15685,7 +12138,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15693,12 +12145,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -15706,283 +12156,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15990,302 +12383,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16293,43 +12626,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16337,55 +12661,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16393,12 +12704,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16406,52 +12715,42 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>Can&apos;t open file %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Can&apos;t open schema file %1:
 %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16459,27 +12758,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16487,7 +12781,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16495,11 +12788,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
@@ -16507,7 +12795,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
@@ -16515,7 +12802,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16523,7 +12809,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16531,12 +12816,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16544,12 +12827,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16557,335 +12838,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation type="unfinished">Unnamed path</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16893,17 +13085,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16911,12 +13100,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16924,14 +13111,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16939,17 +13122,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -16957,27 +13137,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16985,37 +13160,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17023,7 +13191,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17031,12 +13198,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17044,32 +13209,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17077,18 +13236,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17096,18 +13251,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17115,7 +13266,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17123,28 +13273,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17152,17 +13296,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17170,12 +13311,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
@@ -17183,7 +13322,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17191,27 +13329,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17219,17 +13352,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -17237,7 +13367,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17245,12 +13374,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">First line point</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Second line point</translation>
     </message>
@@ -17258,27 +13385,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17286,714 +13408,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished">First line point:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished">Second line point:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished">Take:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Tangent point:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished">Axis point:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffix:</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation type="unfinished">Axis type:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinates</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished">Second dart point:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished">Third dart point:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Line</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">First line</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Second line</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>
@@ -18001,12 +13807,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18014,17 +13818,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -18032,12 +13833,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18045,12 +13844,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18058,12 +13855,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18071,17 +13866,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Length</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -18089,1552 +13881,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19643,17 +15178,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19661,7 +15193,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19669,7 +15200,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19677,7 +15207,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19685,12 +15214,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19698,7 +15225,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19706,7 +15232,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19714,17 +15239,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19732,47 +15254,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation type="unfinished">Warning</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19780,47 +15293,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished">Warning</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>Sobre Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Sitio web: %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>No se puede abrir su navegador por defecto</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation>De izquierda a derecha</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation>De derecha a izquierda</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Construido el %1 a la %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation>Copiar datos de construcción al portapapeles</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation>Seamly 2D</translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation>Fecha de construcción:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation>CPU:</translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation>Compilador:</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation>Revisión:</translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation>Versión:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation>Arquitectura</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation>OS:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation>Versión OS:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation>Localidad</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation>País:</translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation>Punto decimal:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation>Nombre del guión:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation>Códec del sistema:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation>Dirección del texto:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation>Signo positivo:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation>Signo negativo:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation>Aplicación</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation>Argumentos:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation>Colaboradores</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Buscar actualizaciones</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation>Descarga del instalador %p% completa</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation>añadir bloque de borrador %1</translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>añadir grupo</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation>Añadir elemento al grupo</translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation>Añadir pieza</translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>añadir objeto</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation>Añadir al Grupo</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation>Añadir Punto de Anclaje</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation>Herramienta Punto de Anclaje</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation>Punto:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation>Pieza:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Error al procesar el archivo. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Error de identificación. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Error al convertir valor. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Error de parámetro vacío. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Error de identidad equivocada. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>¡¡Algo ha fallado!!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Error al procesar: %1. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Se produjo una excepción: %1. El programa se cerrará.</translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Error al procesar el archivo. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Error de identificación. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Error al convertir valor. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Error de parámetro vacío. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Error de identidad equivocada. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>¡¡Algo ha fallado!!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Error al procesar: %1. El programa se cerrará.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Se ha lanzado una excepción: %1. El programa se terminará.</translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation>Editor de medidas de Seamly2D.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation>Archivo de medidas.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation>La altura base</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation>La talla base</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation>Establecer unidades del fichero patrón: cm, mm, inch.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation>Las unidades del patrón</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation>Argumento de talla base inválida. Deben ser cm, mm o inch.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation>No se puede comenzar la escucha de conexiones entrantes en &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation>En el modo de prueba no se puede abrir varios archivos.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation>Por favor, proporcione un fichero de entrada.</translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation>Abrir con la talla base. Valores válidos: %1cm.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation>Argumento altura base inválido. Debe ser %1cm.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation>Argumento talla base inválido. Debe ser %1cm.</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation>Abrir con la altura base. Valores válidos: %1cm.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation>Úselo para pruebas unitarias. Ejecute el programa y abra un archivo sin mostrar la ventana principal.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Desactive la escala de altos en puntos por pulgada. Llame a esta opción si tiene problemas con el escalado (de forma predeterminada, el escalado está habilitado). Alternativamente, puede utilizar la variable de entorno %1.</translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation>Calculadora</translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation>±</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation>MC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation>MR</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation>MS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation>M+</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation>÷</translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation>×</translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation>Sqrt</translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation>x²</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation>1/x</translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation>=</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation>Calculadora</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation>####</translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation>Gráfico decimal</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -599,7 +482,6 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;15/16 = .9375&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -620,7 +502,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>eliminar grupo</translation>
     </message>
@@ -628,7 +509,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>herramienta de borrar</translation>
     </message>
@@ -636,7 +516,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation>eliminar bloque de borrador %1</translation>
     </message>
@@ -644,7 +523,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>herramienta eliminar</translation>
     </message>
@@ -652,52 +530,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation>Sobre SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation>Versión de SeamlyMe</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation>Este programa es parte del proyecto Seamly2D.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation>Descarga del instalador %p% completa</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation>Buscar actualizaciones</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+90"/>
         <source>Cannot open your default browser</source>
         <translation>No se puede abrir su navegador predeterminado</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Build revision: %1</source>
         <translation>Revisión de la creación: %1</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Built on %1 at %2</source>
         <translation>Creado el %1 a las %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation>Sitio web: %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
@@ -705,107 +573,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Seleccione segundo punto de línea</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Editar largo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Largo:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>Primer punto de la línea</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Segundo punto de la línea</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation>Punto - En Línea</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Eligir nombre único.</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -813,138 +660,104 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radio no puede ser negativo</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Ángulos iguales</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Editar radio</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Editar primer ángulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Editar segundo ángulo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Radio:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>Primer ángulo:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Segundo ángulo:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Punto central:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Seleccione punto central del arco</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation>Arco - Radio y Ángulos</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Cálculo del primer ángulo&lt;/span&gt;&lt;br/&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Cálculo de ángulos&lt;/b&gt;&lt;br&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -952,127 +765,96 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Editar radio</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Editar primer ángulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Editar longitud del arco</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Radio no puede ser negativo</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>Longitud no puede ser 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Radio:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>Primer ángulo:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Punto central:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation>Arco - Radio y Longitud</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Cálculo de ángulos&lt;/b&gt;&lt;br&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -1080,107 +862,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Seleccione segundo punto de ángulo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Seleccione tercer punto de ángulo</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Editar largo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Tercer punto:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation>Punto - En Bisectriz</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Eliga el nombre único.</translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -1188,77 +949,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Tercer punto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Cuarto punto:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Seleccione el segundo punto de curva</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Seleccione el tercer punto de curva</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Seleccione el cuarto punto de curva</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>spline no válido</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation>Curva - Fija</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
@@ -1266,57 +1012,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Punto:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>Lista de puntos</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation>Ruta de spline no válida</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation>Spline - Fijo</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation>Ruta:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
@@ -1324,99 +1059,80 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Seleccione punto del eje</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Editar ángulo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Punto del eje:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation>Intersección - Curva y Eje</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Eligir nombre único.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Cálculo de ángulos&lt;/b&gt;&lt;br&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -1424,67 +1140,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Editar largo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Arco:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation>Punto - En Arco</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Eligir nombre único.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -1492,67 +1195,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Editar largo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation>Punto - En curva</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Eligir nombre único.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -1560,67 +1250,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Editar largo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation>Punto - En Spline</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Eligir nombre único.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -1628,22 +1305,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation>Editor de la fecha y hora de etiqueta</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation>Formato:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation>Insertar un formato</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;vacío&gt;</translation>
     </message>
@@ -1651,170 +1324,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation>Radio1:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar el cálculo completo en la caja de mensaje&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation>Radio2:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation>Primer ángulo:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation>Segundo ángulo:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation>Ángulo de rotación:</translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation>Punto central:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation>Seleccione punto central del arco</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation>El radio no puede ser negativo</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Ángulos iguales</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation>Editar radio1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation>Editar radio2</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Editar el primer ángulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Editar el segundo ángulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation>Editar ángulo de rotación</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation>Arco - Elíptico</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Cálculo del primer ángulo&lt;/span&gt;&lt;br/&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Cálculo del segundo ángulo&lt;/span&gt;&lt;br/&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Cálculo del ángulo de rotación&lt;/span&gt;&lt;br/&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -1822,107 +1447,84 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Editar ángulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Editar largo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Punto base:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation>Punto - longitud y ángulo</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Eligir nombre único.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Cálculo de ángulos&lt;/b&gt;&lt;br&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -1930,47 +1532,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Opciones de exportar</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>Con cabezera</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation>Codec:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Separador</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation>Pestaña</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>Coma</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>punto y coma</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Espacio</translation>
     </message>
@@ -1978,72 +1571,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Seleccione primer punto de línea</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Seleccione segundo punto de línea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Punto base:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation>Punto - Intersección de Línea y Perpendicular</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Elija nombre único.</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -2051,356 +1630,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation>Herramienta de ruta interna</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation>Ruta</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation>Ruta sin nombre</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation>Crea un nombre para su ruta</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation>Tipo:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation>Pieza:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation>Mover fila al principio de la lista</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation>Mover fila por encima de una fila</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation>Mover fila por debajo de una fila</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation>Mover fila al final de la lista</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation>La ruta es un contorno cortado</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation>Cortar en tela</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation>Estado:</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation>¡Listo!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation>Márgenes de costura</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation>Ancho:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation>Asistente de fórmula</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar el cálculo completo en el cuadro de mensaje&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation>Nodos</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation>Nodo:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation>Antes:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation>Volver al ancho predeterminado</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation>Después:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation>Piquetes</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation>Piquete:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation>Abertura</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation>T Piquete</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation>U Piquete</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation>V Interno</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation>V Externo</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation>Castillo</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation>Diamante</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation>Subtipo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation>Directo</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation>Bisectriz</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation>Seleccione para designar el punto de la esquina como un piquete</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation>Intersección</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation>Restablecer el ángulo de piquete a su valor predeterminado.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation>Contar:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation>Restablecer el piquete a sus valores predeterminados.</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation>Esta opción tiene efecto sólo si el segundo piquete en la línea de costura está habilitado en las preferencias globales. La opción ayuda a desactivar el segundo piquete sólo para este piquete.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation>Mostrar el segundo piquete en la línea de costura</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation>Restablecer la longitud del piquete a su valor predeterminado.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation> Ancho:</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation>Seleccione objetos de ruta principal, use&lt;b&gt;SHIFT&lt;/b&gt; para invertir la dirección de la curva, presione&lt;b&gt;ENTER&lt;/b&gt;para finalizar la creación de la ruta </translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation>Reverso</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation>Acual margen de costura</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation>Editar margen de costura</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation>Editar el ancho de margen de costura anterior</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation>Editar el ancho de margen de costura posterior</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation>Ruta interna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation>Personalizar el margen de costura</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation>¡Necesita más puntos!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation>¡Primer punto del &lt;b&gt; margen de costura personalizado&lt;/b&gt; no puede ser el mismo que el último puinto!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation>¡Tiene puntos duplicados!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation>¡Cada punto en la ruta de &lt;b&gt;margen de costura personalizado&lt;/b&gt; debe ser único!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation>¡La lista de detalles está vacía!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation>¡Por favor, seleccione un detalle para insertar!</translation>
     </message>
@@ -2408,28 +1905,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>No se ha podido preparar los datos para la creación del maquetación</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Crear un Maquetación</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation>Piezas de trabajo ordenadas: %1 de %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Buscando la mejor posición para las piezas. Espere por favor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation>Una o más piezas del patrón son más grandes que el formato de papel que seleccionó. Seleccione un formato de papel más grande.</translation>
     </message>
@@ -2437,58 +1928,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Selección segundo punto de línea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation>Línea - Entre puntos</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation>Línea_</translation>
     </message>
@@ -2496,64 +1975,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Primera línea</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Segunda línea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Seleccionar segundo punto de la primera línea</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Seleccionar primer punto de la segunda línea</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Seleccionar segundo punto de la segunda línea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation>Punto - Intersección de Líneas</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Eligir nombre único.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -2561,124 +2026,100 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Primer punto de línea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Seleccionar segundo punto de línea</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Seleccionar punto del eje</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Punto del eje</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Segundo punto de la línea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Editar ángulo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Punto del eje:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation>Intersección - De línea y eje</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Eligir nombre único.</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;bCálculo de ángulos&lt;/b&gt;&lt;br&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -2686,22 +2127,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Medidas</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation>Base de datos ME: agregar medidas conocidas</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation>Buscar:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
@@ -2709,47 +2146,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation>Reflejar por Eje</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation>Punto del eje:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation>Sufijo:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation>Tipo de eje:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation>Seleccionar punto de rotación del eje</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation>Seleccionar punto de rotación del eje que no forma parte de la lista de objetos</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation>Eje vertical</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation>Eje horizontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
@@ -2757,47 +2185,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation>Reflejar por Línea</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation>Primer punto de línea:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation>Segundo punto de línea:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation>Sufijo:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation>Seleccione el primer punto de la línea del reflejo</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation>Seleccione el primer punto de la línea del relfejo que no forma parte de la lista de objetos</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation>Seleccione el segundo punto de la línea del reflejo</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation>Seleccione el segundo punto de la línea del relfejo que no forma parte de la lista de objetos</translation>
     </message>
@@ -2805,94 +2224,72 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation>Asistente de formula</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation>Sufijo:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation>Editar ángulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Editar longitud</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation>Punto de orgien:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation>Rotación:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Punto central</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation>Editar rotación</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Cálculo de ángulos&lt;/b&gt;&lt;br&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Cálculo del ángulo de rotación&lt;/span&gt;&lt;br/&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -2900,42 +2297,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Unidades:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Centímetros</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Pulgadas</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Nombre único de pieza del patrón</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Elige un nombre único para la pieza del patrón.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>Nuevo patrón</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation>Milímetros</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation>Nombre de bloque del debujo:</translation>
     </message>
@@ -2943,107 +2332,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Seleccionar segundo punto de línea</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Editar largo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation>Punto - En Perpendicular</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Elija Nombre único.</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation>Rotación:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Ángulo de Rotación&lt;/span&gt;&lt;br/&gt;Los ángulos se especifican en grados, es decir, un círculo completo equivale a 360 grados. Los valores positivos para un ángulo significan en sentido contrario a las agujas del reloj, mientras que un valor negativo significa en el sentido de las agujas del reloj. Cero grados está en la posición de las 3 en punto.&lt;br/&gt;&lt;br/&gt;El ángulo de rotación se suma al ángulo de la perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -3051,210 +2419,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Descripción del patrón</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Alturas y Tallas</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Todas las alturas (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Todos las tallas (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Altura y talla por defecto</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Personalizado</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Talla:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Seguridad</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Abrir solo para lectura</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation>Llamar al menu de contexto para editar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>Sin imagen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Borrar imagen</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Cambiar imagen</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Guardar imagen en un archivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Mostrar imagen</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation>Imagen para el patrón</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Imágenes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Guardar Archivo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>sin título</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Ruta:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Mostrar en el Explorador</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;vacío&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>El archivo aún no ha sido guardado.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Mostrar en el Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Nombre del Patrón:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Número del patrón:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Nombre de la empresa/diseñador:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Nombre del cliente:</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation>Desde las medidas multitalla</translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Patrón</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation>Para notas técnicas</translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation>Feha de la etiqueta</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation>Plantilla de la etiqueta:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation>Editar etiqueta del patrón</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation>Editar plantilla</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation>Formato de fecha:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation>Formato de hora:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation>Guardar la fecha de la etiqueta.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation>Se cambió la fecha de la etiqueta. ¿Quiere guardarla antes de editar la plantilla de la etiqueta?</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation>Preferencias de patrón</translation>
     </message>
@@ -3262,47 +2586,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Seleccione un arco</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Punto en la tangente:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Arco:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Coger:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Punto - Intersección Arco y Tangente</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Eligir nombre único.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -3310,87 +2625,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Seleccionar punto del centro del arco</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Selección segundo punto de línea</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Editar radio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Radio:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation>Centro del arco:</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation>Punto - Intersección Arco y Línea</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Elija un nombre único.</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation>Punto de primera línea:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation>punto de la segunda línea</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -3398,47 +2696,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation>Seleccione segundo arco</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>Primer arco:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Segundo arco:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Coger:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation>Punto - Intersección de Arcos</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Elija un nombre único.</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -3446,52 +2735,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>Primera curva:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Segunda curva:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Seleccione segunda curva</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation>Punto - Intersección de Curvas</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Elija un nombre único.</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation>Coja vertical:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation>Coja horizontal:</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -3499,27 +2778,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Patrón</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation>Preferencias de aplicación</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation>Rutas de Archivos</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation>Gráficos</translation>
     </message>
@@ -3527,62 +2801,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Rotación</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmulas</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Sufijo:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation>Editar ángulo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation>Punto de rotación:</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation>Seleccione punto de rotación</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation>Seleccione punto de rotación que no forma parte de la lista de objetos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
@@ -3592,17 +2854,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation>Configuración</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation>Rutas de Archivos</translation>
     </message>
@@ -3610,107 +2869,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Seleccione primer punto de línea</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Seleccione segundo punto de línea</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Editar largo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Tercer punto:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation>Punto - Longitud a Línea</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Elija un nombre único.</translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -3718,47 +2956,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Coordenadas en la hoja</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Coordenadas</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation>Punto básico</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation>Elija un nombre único.</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation>Coordenada X:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation>Coordenada Y:</translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -3766,148 +2995,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Primer punto</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Segundo punto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Seleccione el último punto de la curva</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>spline no válido</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation>Editar ángulo del primer punto de control</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation>Editar ángulo del segundo punto de control</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation>Editar la longitud del primer punto de control</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation>Editar la longitud del segundo punto de control</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation>Longitud no puede ser negativa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation>Curva - Interactiva</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
@@ -3915,163 +3102,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Lista de puntos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Seleccione el punto de la trayectoria de la curva</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Punto:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation>Primer punto de control</translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation>Segundo punto de control</translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation>Ruta de spline no válida</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Asistente de Fórmula</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo total en una caja de mensajes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation>Editar el ángulo del primer punto de control</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation>Editar el ángulo del segundo punto de control</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation>Editar la longitud del primer punto de control</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation>Editar la longitud del segundo punto de control</translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation>Longitud no puede ser negativa</translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation>No usado</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation>Spline - Interactivo</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation>Ruta:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation>Valor del resultado</translation>
     </message>
@@ -4079,108 +3221,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Campo vacío</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>El valor no puede ser 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Error en análisis: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Primer punto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Segundo punto</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation>Punto más alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation>Punto más bajo</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation>Punto más a la izquierda</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation>Punto más a la derecha</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation>Por longitud</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation>por intersecciones de puntos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation>por primera simetría de borde</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation>por segunda simetría de borde</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation>por el primer ángulo recto del borde</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation>por el segundo ángulo recto del borde</translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Resultado no válido. El valor es infinito o no es numérico. Por favor, revise sus cálculos.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation>El valor no puede ser menor que 0</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation>Valor del resultado</translation>
     </message>
@@ -4188,62 +3300,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Seleccione segundo punto del eje</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Seleccione primer punto</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Seleccione segundo punto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation>Punto - Intersección Eje y Triángulo</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Elija un nombre único.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation>Punto del 1er eje:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation>Punto del 2º eje:</translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -4251,79 +3351,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation>Seleccione el segundo punto base</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation>Seleccione el primer punto de la pinza</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation>Seleccione el segundo punto de la pinza</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation>Seleccione el tercer punto de la pinza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation>1er punto básico:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation>2º punto básico:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation>1er punto de la pinza:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation>2º punto de la pinza:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation>3er punto de la pinza:</translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation>Pinzas Correctas</translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation>Elija un nombre único.</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation>Nombre del punto 1:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation>Nombre del punto 2:</translation>
     </message>
@@ -4331,27 +3414,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Fórmula equivocada</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Deshacer</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Reparar fórmula</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Error al calcular la fórmula. Puede intentar deshacer las últimas operaciones o corregir la fórmula.</translation>
     </message>
@@ -4359,214 +3437,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation>Variables</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation>Filtrar:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation>Lista de filtros por palabra clave</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation>Variables personalizadas</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation>El valor calculado</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation>Fórmula</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation>Mover medida arriba</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Mover medida abajo</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation>Asistente de fórmula</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation>Añadir variable personalizada</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation>Eliminar variable personalizada</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation>Nombre único de variable</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation>Valor calculado:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation>Fórmula:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation>Descripción:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation>Actualizar patrón con todos los cambios realizados</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation>Longitudes de línea</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation>Ángulos de línea</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation>Longitudes de curva</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation>Ángulos de curva</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation>Longitudes de los puntos de control</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation>Radios de arco</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation>Arco</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation>Radios</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation>Campo vacío.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation>Campo vacío</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Resultado no válido. El valor es infinito o no es numérico. Por favor, revise sus cálculos.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Error en análisis: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation>Editar variable</translation>
     </message>
@@ -4574,17 +3600,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation>Herramienta</translation>
     </message>
@@ -4592,148 +3615,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation>Editar fórmula</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation>Medidas</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation>Variables personalizadas</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation>Longitudes de Línea</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation>Ángulos de Línea</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation>Longitudes de Curva</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation>Ángulos de Curva</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation> Longitudes del Puntos de Control</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation>Radios de Arco</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation>Funciones</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation>Fórmula:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation>Borrar fórmula</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation>Restablecer a la fórmula original</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation>Introducir variable en la fórmula</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation>Ocultar variables de medidas que no tienen valor</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation>Ocultar medidas vacías</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation>Nombre completo</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation>Filtrar lista de variables por palabra clave</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation>Filtrar lista por palabra clave</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation>Medida</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation>Variable personalizada</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation>Longitud de línea</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation>Longitud de curva</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation>Ángulo de Línea</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation>Radio del arco</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation>Ángulo de curva</translation>
     </message>
@@ -4741,37 +3734,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation>Añadir Grupo</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation>Nombre único de pieza del patrón</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation>Nombre único del grupo</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
@@ -4779,298 +3765,238 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation>Editar plantilla de etiqueta</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation>Borrar etiqueta actual y comenzar nueva</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation>Importar desde plantilla de etiqueta</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation>Exportar etiqueta como plantilla</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translatorcomment>Formato de fuente</translatorcomment>
         <translation>Negrita</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translatorcomment>Formato de fuente</translatorcomment>
         <translation>Italic</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation>Alinear con el borde izquierdo</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation>Centrar horizontalmente en el espacio disponible</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation>Alinear con el borde derecho</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation>Tamaño de fuente adicional. Úselo para hacer una línea más grande.</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation>Texto:</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation>Línea de texto</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation>Insertar marcadores de posición</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation>Intsertar...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation>Previsualización</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;vacío&gt;</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation>Crear nueva plantilla</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation>Al crear una nueva plantilla se sobrescribirá sobre la actual. ¿Quiere continuar?</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation>Plantilla de etiqueta</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation>Exportar plantilla de etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation>plantilla</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation>No se pudo guardar el archivo</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation>Importar plantilla</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation>Al importar la plantilla sobrescribirá a la actual. ¿Quiere continuar?</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation>Error en archivo.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation>Nombre del patrón</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation>Número de patrón</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation>Nombre de la empresa o nombre del diseñador</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation>Nombre personalizado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation>Extensión de patrón</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation>Nombre del archivo de patrón</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation>Nombre del archivo de medidas</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation>Talla</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation>Altura</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation>Extención de medidas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation>Letra de la pieza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation>Anotación de pieza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation>Orientación de la pieza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation>Rotación de piezas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation>Inclinación de pieza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation>Posición de plegado de la pieza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation>Nombre de pieza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation>Material: Tela</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation>Tela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation>Material: Forro</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation>Forro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation>Material: Entretela</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation>Entretela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation>Material: Entretela</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation>Entretela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation>Palabra: Cortar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation>Plabra: en pliegue</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation>en pliegue</translation>
     </message>
@@ -5078,12 +4004,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation>(planos) archivos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation>archivos</translation>
     </message>
@@ -5091,163 +4015,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation>Exportar Maquetación</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation>Forma binaria</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation>Texto como Rutas</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation>Ruta:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation>Carpeta de destino</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation>Ruta a la carpeta de destino</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation>Seleccione ruta a la carpeta de destino</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation>Navegar...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation>Formato de archivo:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation>Nombre de archivo:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation>Nombre básico del archivo</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation>Calidad (0-100):</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation>Márgenes</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation>Derecha:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation>Izquierda:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation>Arriba:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation>Abajo:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation>Formato de papel</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation>Plantilla: </translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation>Orientación: </translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation>El nombre de archivo básico no coincide con la expresión regular.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation>Seleccione carpeta</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation>Usted intentó usar un formato de número fuera de rango.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation>La selección no presenta formato.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation>El directorio de destino no existe o no es legible.</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation>%1 ya existe.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation>%1 archivos con nombre básico %2 ya existen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation>¿Desea reemplazarlos?</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation>Confirmar Exportación</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation>Exportar archivos:</translation>
     </message>
@@ -5255,23 +4146,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation>Falló la descarga de entrega: %1.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
@@ -5280,7 +4166,6 @@ for writing</source>
 para la escritura</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
@@ -5289,22 +4174,18 @@ Possibly the file is already being downloaded.</source>
 Posiblemente el archivo ya está siendo descargado.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation>Error al descargar el archivo: %1.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation>La descarga ha comenzado, el instalador se abrirá una vez que haya terminado de descargarse</translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation>No hay nuevos actualizaciones disponibles.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation>Una nueva versión %1 está disponible.
@@ -5314,369 +4195,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation>Administrador de Grupo</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation>Mostrar todos los Grupos</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation>Ocultar todos los Grupos</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation>Bloquear todos los grupos</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation>Desbloquear todos los grupos</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation>Agregar un nuevo grupo a la lista</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation>Eliminar grupo activo de la lista</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation>Editar propiedades del grupo</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation>Grupos</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation>Lista de grupos</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation>Lista de objetos de grupo</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation>Objetos</translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation>Al hacer doble clic se amplía el objeto.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation>El nombre ya existe</translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation>La acción no se puede completar porque el nombre del grupo ya existe.</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation>Editar Grupo</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation>Mostrar qué grupos de la lista son visibles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation>Mostrar qué grupos de la lista están bloqueados</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation>Mostrar qué grupos contienen objetos</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation>Objeto desconocido</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation>%1 - Punto base</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation>%1 - Punto a distancia y ángulo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation>Línea %1_%2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation>%1 - Punto en Línea</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation>%1 - Punto Longitud a Línea</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation>%1 - Punto en Perpendicular</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation>%1 - Punto en Bisectriz</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation>%1 - Punto Intersección de Líneas</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation>%1 - Curva Interactiva</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation>%1 - Curva Fija</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation>%1 - Radio y Ángulos del Arco</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation>Arco_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation>%1 - Radio y Longitud del Arco</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation>%1 - Spline Interactivo</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation>SplPath_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation>%1 - Spline Fijo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation>%1 - Punto Intersección Arco y Línea</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation>%1 - Punto Intersección Línea y Perpendicular</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation>%1 - Punto Intersección Eje y Tangente</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation>%1 - Punto Intersección XY</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation>%1 - Punto en Arco</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation>%1 - Punto en Curva</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation>%1 - Punto en Spline</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation>%1 - Punto de Intersección Línea y Eje</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation>%1 - Punto de Intersección Curva y Eje</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation>%1 - Punto Intersección de Arcos</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation>%1 - Punto Intersección de Circulos</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation>%1 - Punto Intersección de Curvas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation>%1 - Punto Intersección de Circulo y Tangente</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation>%1 - Punto Intersección de Arco y Tangente</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation>%1 - Pinza Correcta %2_%3_%4</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation>%1 - Arco Elíptico</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation>ElArco_</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation>%1 - Rotación</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation>%1 - Mover</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation>%1 - Reflejar por Línea</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation>%1 - Reflejar por Eje</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation>Mover Objeto de Grupo</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation>Eliminar Objeto de Grupo</translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation>Color del grupo</translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation>Nombre del grupo</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation>Visible</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation>El grupo es visible</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation>Bloqueado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation>El grupo está bloqueado</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation>El grupo tiene objetos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
@@ -5684,265 +4482,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation>Historia</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation>Buscar:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation>Buscar texto</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation>Identificación</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation>Punto básico</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation>Línea_%1_%2</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation>Línea desde %1 hasta %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation>Punto en Línea %1_%2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation>Punto Longitud a Línea</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation>Punto en Perpendicular %1_%2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation>Punto en Bisectriz %1_%2_%3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation>Punto Intersección de las Líneas %1_%2 y %3_%4</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation>Curva Interactiva</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation>Curva Fija</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation>Arco_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation>Radio y Ángulos del Arco</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation>Radio y Longitud del Arco %1</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation>SplPath_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation>Spline Interactivo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation>Spline Fijo</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation>Punto Intersección del Arco con centro %1 y Línea %2_%3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation>Punto Intersección de Line %1_%2 y Perpendicular %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation>Punto Intersección de Eje %1_%2 y Triángulo puntos %3 y %4</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation>Punto Intersección XY de puntos %1 y %2</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation>Punto en Arco</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation>Punto en Curva</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation>Punto en Spline</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation>%Punto Intersección de Línea %1_%2 y el Eje que pasa por el punto %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation>Punto Intersección Curva y Eje a través del punto%1</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation>Punto Intersección de Arcos</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation>%1 - Punto Intersección de Círculos</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation>Punto Intersección de Curvas</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation>Punto Intersección Círculo y Tangente</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation>Punto Intersección Arco y Tangente</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation>Pinza Correcta %1_%2_%3</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation>ElArco_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation>Arco Elíptico con longitud %1</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation>Rotación alrededor del punto %1. Sufijo %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation>Reflejo por Línea %1_%2. Sufijo %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation>Reflejo por Eje a través de %1 punto. Sufijo %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation>Mover - Rotación alrededor del punto %1. Sufijo %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation>Punto Largo y Ángulo desde el punto %1</translation>
     </message>
@@ -5950,127 +4669,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation>Propiedades de la imagen</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation>Id:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation>Identificación</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation>Imagen de bloqueo:</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation>Cambiar entre unidades px y patrón</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation>PX</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation>Unidad:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation>X Posición:</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation>Y Posición:</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation>Bloquear relación de aspecto</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation>Aspecto de la cerradura:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation>Anchura:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation>Escala X:</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation>Escala Y:</translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation>Rotación:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation>Atributos</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation>Opacidad:</translation>
     </message>
@@ -6078,110 +4768,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation>Cerradura</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation>Order</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation>Pida</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation>Enviar al fondo</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
         <translation> - &lt;b&gt;Relación de aspecto bloqueada&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation>Importar imagen</translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation>No se ha podido cargar la imagen.</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation>No se ha podido leer la imagen.</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation>El archivo puede estar dañado...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation>El archivo puede estar dañado o vacío...</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation>Confirmar la eliminación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>¿Realmente quiere eliminarlo?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation>Las imágenes no se guardarán</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6193,102 +4858,82 @@ Es posible que desee tomar una captura de pantalla del cuadro de diálogo de pro
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation>Pieza:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation>Nodos:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation>Estado:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation>Mensage</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation>Revés</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation>Piquete</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation>Abertura</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation>T - Aplomo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation>U Aplomo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation>VInterno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation>VExterno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation>Castilllo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation>Diamante</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation>No hay nodos seleccionados. Presione Cancelar para continuar</translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation> se invirtió automáticamente.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation> es posible que sea necesario invertirlo manualmente.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation>Insertar Nodos</translation>
     </message>
@@ -6296,12 +4941,10 @@ Es posible que desee tomar una captura de pantalla del cuadro de diálogo de pro
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>El programa se facilita TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUYENDO LAS GARANTÍAS DE DISEÑO, COMERCIALIZACIÓN Y CONVENIENCIA PARA UN PROPÓSITO PARTICULAR.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6329,87 +4972,70 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation>Cojer:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation>Punto central:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation>Punto tangente:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation>Radio:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar el cálculo completo en el cuadro de mensaje&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation>Seleccione el centro de círculo</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation>Editar radio</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation>El radio no puede ser negativo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Punto - Intersección Círculo y Tangente</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Elija un nombre único.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -6417,12 +5043,10 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation>Intersección del Círculo y la Tangente</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;No se puede encontrar el punto de intersección %1 de&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Círculo y tangente&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Se usará punto de origen como marcador de posición hasta que se corrija el patrón.</translation>
     </message>
@@ -6430,110 +5054,82 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation>Coger:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation>Círculo 1</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation>Centro:</translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation>Radio:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation>Asistente de fórmula</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar el cálculo completo en el cuadro de mensaje&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation>Círculo 2</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation>Seleccione el centro del segundo círculo</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation>Editar radio del primer círculo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation>Editar radio del segundo círculo</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation>El radio no puede ser negativo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation>Punto - Intersección de Círculos</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Elija un nombre único.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -6541,12 +5137,10 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;No se puede encontrar el punto de intersección %1 de los círculos&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Se usará el punto de origen como marcador de posición hasta que se corrija el patrón.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation>Punto - Intersección de Círculos</translation>
     </message>
@@ -6554,52 +5148,42 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Plantillas:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Anchura:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Girar pieza de trabajo</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Girar por</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>grado</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Tres grupos: grande, mediano, pequeño</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Dos grupos: grande, pequeño</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>Área descendente</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
@@ -6608,74 +5192,58 @@ Apply settings anyway?</source>
 ¿Aplicar ajustes de todos modos?</translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centímetros</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Pulgadas</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Píxeles</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Auto-cortar longitud no usada</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Unificar páginas (si es posible)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation>Ancho del hueco:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Guardar longitud de la hoja</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Formato de papel</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Izquierda:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Derecha:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Arriba:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Abajo:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Campos erróneos.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6686,83 +5254,66 @@ Apply settings anyway?</source>
 	Área descendente = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation>Opciones de maquetación</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation>Longitud de Cambio/Desplazamiento:</translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation>Regla para elegir la siguiente pieza de trabajo</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation>Dividir en tiras</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation>Multiplicador</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation>Establezca el multiplicador de la longitud de la mayor pieza del maquetación.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation>Habilitar hojas que tienen mayor altura acelerará la creación.</translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Impresora:</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Text</source>
         <translation>Texto</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation>El texto se convertirá en rutas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation>Exportar texto como rutas</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation>Márgenes</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation>Ignorar márgenes</translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation>Configuración de impresión de maquetación</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+246"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation>Milímetros</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation>Ninguno</translation>
@@ -6771,32 +5322,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation>Sin pluma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation>Línea sólida</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation>Guión</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation>Guión Punto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation>Guión Punto Punto</translation>
     </message>
@@ -6804,2660 +5349,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Herramientas para la creación de puntos.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Herramientas para crear líneas.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Herramientas para crear curvas.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Herramientas para crear arcos.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Arco</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Ayuda</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Medidas</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nuevo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Crear un nuevo patrón</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Abrir</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Abrir archivo con patrón</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Guardar patrón</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Guardar &amp;Como...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>El patrón aún no se ha guardao</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Herramientas de puntero</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Historia</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>Sobre &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;Sobre Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>&amp;Salida</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Informar de un error</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Mostrar ayuda en línea</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>Sobre Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>El archivo no se ha guardado</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Error al analizar el archivo.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Error el valor no se puede convertir.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Error parámetro vacío.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Error en la identificación.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Error al analizar el archivo (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Identificación incorrecta.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>Archivo guardado</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>Sin título.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>El patrón ha sido modificado.
 ¿Quiere guardar los cambios?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Deshacer</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Rehacer</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>Este archivo ha sido abierto en otra ventana.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Unidades no son válidas.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>Archivo cargado</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Seamly2D no se cerró correctamente. ¿Quiere volver a abrir archivos (%1) que estaban abiertos?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Volver a abrir archivos.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Maquetación</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation>Imprimir PDF dividido en cuadrículas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation>Imprime el maquetación dividido en hojas pequeñas (para impresoras normales)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation>Previsualizar la impresión</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation>Vista previa de impresión del maquetación original</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation>Exportar como...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation>Modo maquetación</translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation>Cambios sin guardar</translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation>Medidas cargadas</translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation>No puede exportar una escena vacía.</translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation>El archivo de medidas contiene medidas requeridas no válidas.</translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation>El archivo de medidas tiene un formato desconocido.</translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation>Los tipos de archivo de medidas no coinciden.</translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation>No se pudo sincronizar las medidas.</translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation>No se pudieron actualizar las medidas.</translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation>No se ha podido encontrar el archivo de medidas &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation>Cargando archivo de medidas</translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation>No es compatible el valor del talla &apos;%1&apos; para el archivo de patron.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation>No se pudo establecer la talla. El archivo no se abrió.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation>El método %1 no hace nada en el modo de interfaz gráfica</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation>Valor de altura &apos;%1&apos; no soportado para este archivo de patrón.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation>No se pudo establecer la altura. No se abrió el archivo.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation>Por favor, proporcione un fichero de entrada.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation>Imprimir un maquetación original</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation>Vista previa de PDF dividido en cuadrículas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation>Vista previa de impresión del maquetación dividido en cuadrículas</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation>Medidas descargadas</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation>No se pudieron descargar las medidas. Algunas de ellas están utilizadas en el patrón.</translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>Nuevo patrón</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation>Abrir patrón</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation>Crear/Editar medidas</translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>Guardar...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>No guardar</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Archivo de bloqueo</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Este archivo esta abierto en otra ventana. Si desea continuar: Haga click en Ignorar (no recomendado, puede provocar datos erroneos).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Archivo bloqueado, no puede ser mostrado por falta de permisos. Si desea continuar: Haga click en Ignorar (no recomendado, puede provocar errores).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Se produjo un error desconocido, por ejemplo una parte llena impedía escribir el archivo de bloqueo. Ignorelo si desea continuar (no se recomienda, puede provocar errores).</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>No se pudo crear el archivo de bloqueo, por falta de permisos.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Se produjo un error desconocido, por ejemplo una parte llena impedía escribir el archivo de bloqueo.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation>Operaciones</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation>Cerrar patrón</translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation>Herramienta de Puntero</translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation>Zoom original</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Talla:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation>El archivo de medidas &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; podría no ser encontrado. ¿Quiere actualizar la ubicación del archivo?</translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation>Las medidas estaban cambiadas. ¿Quiere sincronizar las medidas ahora?</translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>El escalonado no spoorta pulgadas</translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation>Las medidas han sido sincronizadas</translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation>El documento no tiene permisos de escritura.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>No se pueden establecer permisos a %1 para escribir.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>No se puede guardar archivo.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation>No se puede guardar archivo</translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation>sólo lectura</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation>Cargar medidas individuales</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation>Cargar archivo de medidas individuales</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation>Cargar medidas Multitalla</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation>Cargar archivo de medidas Multitalla</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation>Abrir SeamlyMe</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation>Editar medidas actuales</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation>Editar vínculo a las medidas del patrón</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation>Sincronizar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation>Sincronizar vínculo a las medidas del patrón después del cambio</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation>Descargar medidas actuales</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation>Descargar medidas si éstas no se utilizaron en un archivo de patrón</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation>Medidas individuales</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation>Medidas Multitalla</translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Archivos de patrones</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation>Wikipedia</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation>Foro</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation>El valor calculado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation>Fórmula</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation>Aún no puede usar el modo Maquetación.</translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation>La aplicación no admite tablas de varios tallas en pulgadas.</translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation>No se pudo establecer la talla. Necesita un archivo con las medidas multitalla.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation>No se pudo establecer la altura. Necesita un archivo con las medidas multitalla.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation>Previsualización</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation>Vista</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation>Nombre de puntos</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation>&amp;Herramientas</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation>&amp;Operaciones</translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation>Pieza</translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation>Utilidades</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation>Barra de Herramientas de Archivos</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation>Modo de Barra de Herramientas de Archivos</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation>Barra de Herramientas de Patrón</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation>Editar Barra de Herramientas</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation>Editor de Propiedades</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation>Páginas de Maquetación</translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation>Administrador de Grupos</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation>Barra de Herramientas de Zoom</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation>Barra de Caja de Herramientas</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation>Barra de Herramientas de Puntos</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation>Barra de Herramientas de Líneas</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation>Barra de Herramientas de Curvas</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation>Barra de Herramientas de Arcos</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation>Barra de Herramientas Operaciones</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation>Barra de Herramientas de Piezas</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation>Barra de Herramientas de Detalles</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation>Barra de Herramientas de Maquetación</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation>Barra de Herramientas de Nombre de Puntos</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation>Caja de Herramientas</translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation>Línea entre 2 puntos (Alt+L)</translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation>Herramientas para realizar operaciones de objetos</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation>Girar Objetos Seleccionados (R)</translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation>Exportar Bloques de Borrador (E, D)</translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation>Herramientas para agregar piezas de patrón.</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation>Añadir Detalles</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation>Herramientas para añadir detalles a piezas de patrón</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation>Unir 2 Piezas (U)</translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation>Vista de Barra de Herramientas</translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation>Borrador</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modo para trabajar con bloques de borrador. Estos bloques de borrador son la base para pasar a la siguiente etapa, &quot;Modo Pieza&quot;. Para entrar en &amp;quot;Modo Pieza&amp;quot; se necesita crear al menos una pieza del patrón.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modo para trabajar con piezas de patrón. Para entrar en &amp;quot;Modo Pieza&amp;quot; se necesita crear al menos una pieza de patrón en el &quot;Modo Dibujo&quot;. Las piezas del patrón creadas en esta etapa se utilizarán para crear un maquetación. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation>Nuevo bloque de borrador</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation>Añadir Nuevo bloque de borrador (Control+Mayúsculas+N)</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation>Cambiar nombre de Nuevo bloque de borrador</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation>Cambiar nombre de Nuevo bloque de borrador</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation>Tabla de variables</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modo para crear maquetación de piezas de patrón. Este modo está disponible si ya se creó al menos una pieza de patrón en el &quot;Modo pieza&quot;. El maquetación se puede exportar a su formato de archivo preferido y guardarlo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation>Rotación</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation>Reflejar por Línea</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation>M, L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation>Reflejar por Eje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation>M, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation>Pinzas Correctas</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation>T, D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation>Punto medio</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation>P, S</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation>intersección de XY</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation>X, Y</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation>I, L</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation>Alt+C</translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation>A, X</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation>I, A</translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation>I, C</translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation>C, T</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation>A, T</translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation>A, L</translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation>Herramientas para insertar o modificar imágenes.</translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation>Punto en Curva (O, C)</translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation>Sobre Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation>Salir de la Aplicación</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation>Preferencias de Aplicación...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation>Preferencias de Patrón...</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation>Acercar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation>Dentro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation>Acercar (Control++)</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation>Alejar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation>Fuera</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Fit All</source>
         <translation>Ajustar todo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation>Ajustar</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Report bug...</source>
         <translation>Reportar un error...</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation>Atajos</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation>Última herramienta</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation>Puntos de Control de Curvas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation>Alternar puntos de control y dirección de curva (V, C)</translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation>Cargar multitalla</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation>Abrir la aplicación de medidas SeamlyMe (Control+M)</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation>Exportar Variables a formato CSV</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation>Seleccionado</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation>Editor de plantillas de etiquetas...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation>Previo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation>Zoom para Previo (Control+Izquierda)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation>Ctrl+Left</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation>Área</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation>Pan</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation>Z, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation>Zoom 1:1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation>Zoom al 100 por ciento (Control+0)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation>Ctrl+0</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation>Herramientas de Puntos</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation>Herramientas de Línea</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation>Alt+L</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation>Herramientas de Curva</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation>Herramientas de Arco</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation>Herramientas de Operaciones</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation>Herramientas de Maquetación</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation>Herramientas de pieza</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation>Nueva Pieza de Patrón</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation>N, P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation>Nuevo Maquetación de Impresión</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation>N, L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation>Exportar Maquetación</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation>E, L</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation>Punto de Anclaje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation>A, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation>Ruta Interna</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation>I, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation>Insertar Nodos</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation>I, N</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation>Unir Piezas</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation>Exportar Piezas</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation>E, P</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation>Herramientas de detalle</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation>Texto del nombre del punto</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation>V, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation>Aumentar el tamaño del texto</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation>Aumentar el tamaño del texto (Control+])</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation>Ctrl+]</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation>Disminuir el tamaño del texto</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation>Disminuir el tamaño del texto (Control+[)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation>Ctrl+[</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation>Usar herramienta de color</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation>Usar herramienta de color (T)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation>V, T</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation>Origen del eje </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation>Alternar Origen del Eje (V, A)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation>V, A</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation>Modo de Estructura Alámbrica</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation>Alternar modo de estructura alámbrica (V, W)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation>V, W</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation>Dirección del hilo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation>Alterar Dirección del hilo (V, G)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation>V, G</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation>Etiquetas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation>Alternar etiquetas (V, L)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation>V, L</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation>Calculadora</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation>Ctrl+Shift+C</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation>Gráfico decimal</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation>Ctrl+Shift+D</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation>Exportar bloques de borrador</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation>E, D</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation>Márgenes de costura</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation>V, S</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation>Información del documento...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation>Información del documento</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation>Mostrar información del documento</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation>El archivo de medidas no incluye todas las medidas requeridas.</translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation>&lt;b&gt;Herramienta::Operaciones - Crear Grupo:&lt;/b&gt; Seleccione uno o más objetos - Para seleccionar varios objetos Mantenga presionado &lt;b&gt;%1&lt;/b&gt;Para finalizar la creación del grupo presione&lt;b&gt;ENTER&lt;/b&gt; </translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Herramienta::Operaciones - Rotación:&lt;/b&gt;Seleccione uno o más objetos: mantenga presionado &lt;b&gt;%1&lt;/b&gt; para selecciónar varios objetos. Presione &lt;b&gt;ENTER&lt;/b&gt; para confirmar la selección</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Herramienta::Operaciones - Reflejar por Línea:&lt;/b&gt;Seleccione uno o más objetos: mantenga presionado &lt;b&gt;%1&lt;/b&gt; para selecciónar varios objetos. Presione &lt;b&gt;ENTER&lt;/b&gt; para confirmar la selección</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Herramienta::Operaciones - Reflejar por Eje:&lt;/b&gt;Seleccione uno o más objetos: mantenga presionado &lt;b&gt;%1&lt;/b&gt; para selecciónar varios objetos. Presione &lt;b&gt;ENTER&lt;/b&gt; para confirmar la selección</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Herramienta::Operaciones - Mover:&lt;/b&gt;Seleccione uno o más objetos: mantenga presionado &lt;b&gt;%1&lt;/b&gt; para selecciónar varios objetos. Presione &lt;b&gt;ENTER&lt;/b&gt; para confirmar la selección</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation>&lt;b&gt;Herramienta::Operaciones - Pinzas Correctas:&lt;/b&gt; Seleccione el primer punto de la línea básica</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation>No se ha podido cargar la imagen.</translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation>Bolque de borrador:</translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation>Rotar</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation>Añadir punto de anclaje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation>Crear ruta interna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation>Insertar nodos a la ruta</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation>Herramienta de unión</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation>Exportar Piezas de Patrón</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation>Importar imagen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation>Modo pieza</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation>Aún no puede usar el modo Pieza. Por favor, cree al menos una pieza del patrón.</translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation>Piezas de Patrón</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation>Aún no puede usar el modo Maquetación. Por favor, cree al menos una pieza del patrón.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation>Aún no puede usar el modo Maquetación. Por favor, incluya al menos una pieza del patrón al maquetación.</translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation>Bloque de borrador.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation>El nombre ya existe</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation>La acción no se puede completar porque el nombre del Bloque de Borrador ya existe.</translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation>No tiene piezas para exportar. Por favor, incluya al menos una pieza en el maquetación.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation>Exportar piezas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation>No se pueden exportar piezas.</translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation>&lt;b&gt;Herramienta::Pieza - Añadir Nueva Pieza de Patrón:&lt;/b&gt; Seleccione la ruta principal de los objetos en el sentido de las agujas del reloj.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation>&lt;b&gt;Herramienta::Pieza - Añadir punto de anclaje:&lt;/b&gt; Seleccionar punto de anclaje</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation>&lt;b&gt;Herramienta::Pieza - Ruta Interna:&lt;/b&gt; Seleccione objetos de la ruta, use &lt;b&gt;SHIFT&lt;/b&gt; para invertir la dirección de la curva</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Herramienta::Pieza - Insertar Nodos:&lt;/b&gt;Seleccione uno o más objetos: mantenga presionado &lt;b&gt;%1&lt;/b&gt; para selecciónar varios objetos. Presione &lt;b&gt;ENTER&lt;/b&gt; para confirmar la selección</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation>&lt;b&gt;Herramienta::Detalles - Unión:&lt;/b&gt; Seleccione pieza del patrón</translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation>Bloque de maquetación %1</translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation>Bloque de Maquetación %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation>Punto - En la bisectriz (O, B)</translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation>Punto - Longitud a Línea (P, S)</translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation>Punto - Intersección Arco y Línea (A, L)</translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation>Punto - Intersección Eje y Triángulo (X, T)</translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation>Punto - Intersección XY (X, Y)</translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation>Punto - Línea Intersección y Perpendicular (L, P)</translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation>Punto - Intersección Línea y Eje (L, X)</translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation>Punto - En el perpendicular (O, P)</translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation>Punto - Longitud y Ángulo (L, A)</translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation>Punto - En Línea (O, L)</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation>Punto - Punto Medio de Línea (Mayúsculas+O, Mayúsculas+L)</translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation>Punto - Intersección de Líneas (I, L)</translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation>Curva - Interactiva (Alt+C)</translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation>Spline - Interactivo (Alt+S)</translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation>Curva - Fija (Alt+Mayúsculas+C)</translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation>Spline - Fijo (Alt+Mayúsculas+S)</translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation>Punto - En Spline (O, S)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation>Punto - Intersección de Curvas (I, C)</translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation>Punto - Intersección Curva y Eje (C, X)</translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation>Punto - En curva (O, C)</translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation>Arco - Radio y Ángulos (Alt+A)</translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation>Punto - En Arco (O, A)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation>Punto - Intersección Arco y Eje (A, X)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation>Punto - Intersección de Arcos (I, A)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation>Punto - Intersección de Círculos (Mayúsculas+I, Mayúsculas+C)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation>Punto - Intersección Círculo y Tangente (C, T)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation>Punto - Intersección Arco y Tangente (A, T)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation>Arco - Radio y Longitud (Alt+Mayúsculas+A)</translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation>Arco - Elíptico (Alt+E)</translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation>Reflejar Objetos por Línea (M, L)</translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation>Reflejar Objetos por Eje (M, A)</translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation>Mover Objetos (Alt+M)</translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation>Pinzas Correctos (T, D)</translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation>Aañadir Nueva Pieza de Patrón (N, P)</translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation>Añadir Punto de Anclaje (A, P)</translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation>Insertar Nodos (I, N)</translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation>Añadirr Ruta Interna (I, P)</translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation>Importar imagen (Alt + I)</translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation>Exportar Piezas (E, P)</translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation>Nuevo maquetación de Impresión (N, L)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation>Exportar Maquetación (E, L)</translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation>Contiene información sobre variables personalizadas e internas</translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation>Alt+M</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation>Elíptico</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation>Arco - Elíptico</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation>Alt+E</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation>Punto Medio de Línea</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation>Mayúsculas+O, Mayúsculas+L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation>En Línea</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation>O, L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation>Longitud y Ángulo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation>L, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation>En Perpendicular</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation>O, P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation>En Bisectriz</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation>O, B</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation>Longitud a Línea</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation>Intersección Arco y Línea</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation>Intersección Eje y Triángulo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation>X, T</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation>Intersección de Línea y Perpendicular</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation>L, P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation>Intersección Línea y Eje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation>L, X</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation>Intersección de Líneas</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation>Curva - Interactiva</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation>Punto en Curva</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation>O, C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation>Curva - Fijo</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation>Alt+Mayúsculas+C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation>Spline - Interactivo</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation>Punto en Spline</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation>Punto en Spline (O, S)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation>O, S</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation>Spline - Fijo</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation>Alt+Mayúsculas+S</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation>Intersección de Curvas</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation>Intersección Curva y Eje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation>C, X</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation>Radio y Ángulos</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation>Arco - Radio y Ángulos</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation>Punto en Arco</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation>Punto en Arco (O, A)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation>O, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation>Interseccción Arco y Eje</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation>Interseccción Arco y Eje (A, X)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation>Interseccción de Arcos</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation>Interseccción de Arcos (I, A)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation>Interseccción Círculos</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation>Interseccción Círculos (Mayúsculas+I, Mayúsculas+C)</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation>Mayúsculas+I, Mayúsculas+C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation>Interseccción de Circulo y Tangente</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation>Interseccción de Circulo y Tangente (C, T)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation>Intersección de Arco y Tangente</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation>Intersección de Arco y Tangente (A, T)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation>Radio y Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation>Arco - Radio y Longitud</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation>Alt+Mayúsculas+A</translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation>Activar la última herramienta utilizada (Control+Mayúsculas+L)</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation>Zoom a seleccionado (Control+Derecha)</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation>Zoom al área seleccionada (Control+A)</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation>Área de trabajo panorámica (Z, P)</translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation>Crear nuevo maquetación de impresión (N, L)</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation>Alternar texto de nombre de punto (V, P)</translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation>Herramientas de imágenes</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation>Alinear</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation>Cerradura</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation>Zoom al punto (Control + Alt + P)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation>Ctrl+Alt+P</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation>Alt+I</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation>Por favor, proporcione medidas adicionales: %1</translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation>&lt;b&gt;Herramienta::Punto - Punto Medio en Línea&lt;/b&gt;: Seleccione el primer punto</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation>&lt;b&gt;Herramienta::Punto - Longitud y Ángulo&lt;/b&gt;: Seleccione punto</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation>&lt;b&gt;Herramienta::Punto - En Línea:&lt;/b&gt; Seleccione el primer punto</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Herramienta::Punto - En Perpendicular:&lt;/b&gt; Seleccione el primer punto de la línea</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation>&lt;b&gt;Herramienta::Punto - En Bisectriz:&lt;/b&gt; Seleccione el primer punto del ángulo</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation>&lt;b&gt;Herramienta::Punto - Longitud de Línea:&lt;/b&gt; Seleccione un punto</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección de Arco y Línea:&lt;/b&gt; Seleccione el primer punto de la línea</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección Eje y Triángulo:&lt;/b&gt; Seleccione el primer punto del eje</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección XY&lt;/b&gt; Seleccione el punto para el valor X (vertical)</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation>&lt;b&gt;Herramienta::Punto - Línea Intersección y Perpendicular:&lt;/b&gt; Seleccionar un punto básico</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección Línea y Eje:&lt;/b&gt; Seleccione el primer punto de la línea</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation>&lt;b&gt;Herramienta::Línea:&lt;/b&gt; Seleccione el primer punto</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección de Líneas:&lt;/b&gt; Seleccione el primer punto de la primera línea</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation>&lt;b&gt;Herramienta::Curva - Interactiva:&lt;/b&gt; Seleccione el punto inicial de la curva</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation>&lt;b&gt;Herramienta::Spline - Interactivo:&lt;/b&gt; Seleccione el punto inicial de la spline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation>&lt;b&gt; Herramienta :: Curva - Fija: &lt;/b&gt; Seleccione el primer punto de la curva</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation>&lt;b&gt;Herramienta::Spline - Fijo:&lt;/b&gt; Seleccione el primer punto de la spline</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation>&lt;b&gt;Herramienta::Punto - En Curva:&lt;/b&gt; Seleccione el primer punto de la curva</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation>&lt;b&gt;Herramienta::Punto - En Spline:&lt;/b&gt; Seleccione spline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección de Curvas:&lt;/b&gt; Seleccione la primera curva</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección Curva y Eje:&lt;/b&gt; Seleccione la  curva</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation>&lt;b&gt;Herramienta::Arco - Radio y Ángulos:&lt;/b&gt; Seleccione el punto del centro del arco</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation>&lt;b&gt;Herramienta::Punto - En Arco:&lt;/b&gt; Seleccione arco</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección Arco y Eje:&lt;/b&gt; Seleccione el  arco</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección de Arcos:&lt;/b&gt; Seleccione primero un arco</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección de Círculos:&lt;/b&gt; Seleccione el centro del primer círculo</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección Círculo y Tangente:&lt;/b&gt; Seleccione punto en la tangente</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation>&lt;b&gt;Herramienta::Punto - Intersección Arco y Tangente:&lt;/b&gt; Seleccione punto en la tangente</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation>&lt;b&gt;Herramienta::Arco - Radio y Longitud:&lt;/b&gt; Seleccione el punto del centro del arco</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation>&lt;b&gt;Herramienta::Arco - Elíptico:&lt;/b&gt; Seleccione el punto del centro del arco elíptico</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation>Imágenes</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation>Abrir archivo de imagen</translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation>Zoom al punto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation>Punto:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation>Intersección de Arco y Línea</translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation>Intersección Curva y Eje</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation>Aañadir Objetos al Grupo (G)</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation>Aañadir Objetos al Grupo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation>Añadir Objetos de Grupo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation>El grupo está bloqueado. Desbloquear para añadir objetos</translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation>No se puede guardar el archivo.</translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation>El patrón es de sólo lectura.</translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation>No se pudo bloquear. El archivo con este nombre está abierto en otra ventana.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation>No tiene título</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation>Bloqueo fallido. Este archivo ya esta abierto en otra ventana.Pueden prodicirse  errores al ejecutar 2 copias del programa.</translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation>Barra de Herramientas del lápiz</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-377"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation>Alejar (Control+-)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation>Zoom para ajustar todo (Control+=)</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2659"/>
         <source>Toolbars</source>
         <translation>Barras de Herramientas</translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation>Excepción de archivo.</translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation>Excepción de exportación.</translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>patrón</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation>Nombre base utilizado para los nuevos puntos.</translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
@@ -9465,86 +7351,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>La creación del archivo &apos;%1&apos; falló! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Error crítico!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation>Error de impresión</translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation>No se puede continuar porque no hay impresoras disponibles en su sistema.</translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation>sin nombre</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation>El maquetación es obsoleto.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation>El maquetación no se actualizo desde la última modificación del patrón. ¿Desea continuar?</translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>No se ha podido preparar los datos para la creación del maquetación</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation>No se puede abrir la impresora %1</translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation>Para previsualizar documentos de múltiples páginas todas las hojas deben tener el mismo tamaño.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation>Para imprimir documentos de múltiples páginas todas las hojas deben tener el mismo tamaño.</translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation>Las páginas serán recortadas porque no se ajustan al tamaño de papel de la impresora.</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation>No se pueden introducir márgenes de impresora</translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation>No se puede crear un ruta</translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Patrón</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation>Una o más piezas del patrón son más grandes que el formato de papel que seleccionó. Seleccione un formato de papel más grande.</translation>
     </message>
@@ -9552,148 +7418,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation>Copiar atajos a portapapeles</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation>Exportar Atajos como PDF</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation>Enviar Atajosa la impresora</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation>Exportar PDF</translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation>Archivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation>Control+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation>Abrir individual</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation>Control+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation>Abrir multitalla</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation>Control+Mayúsculas+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation>Control+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation>Control+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation>Control+Mayúsculas+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation>Exportar a CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation>Control+E</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation>Control+Q</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation>Atajos de Teclado</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation>SeamlyMe Atajos</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation>Buscar anterior</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation>Control+Mayúsculas+G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation>Buscar siguiente</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation>Control+G</translation>
     </message>
@@ -9701,139 +7537,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation>Colapsar Todo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation>Expandir Todo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation>Marcar todo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation>Desmarcar todo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Altura Directa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Anchura Directa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Sangría</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Mano</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Pie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Cabeza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Circunferencia y Arco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Vertical</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Horizontal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Busto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Balance</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Hombro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Pierna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Entrepierna y Tira</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Confección para Hombres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
         <translation>Histórico y Especialidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translatorcomment>Sección de medidas</translatorcomment>
@@ -9843,18 +7658,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation>No se pudo encontrar la medida &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation>El nombre de la medida esta vacío!</translation>
     </message>
@@ -9862,37 +7669,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation>Forma</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation> XPos:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation>xpos</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation>YPos:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation>ypos</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation>Unidades:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation>unidades</translation>
     </message>
@@ -9900,12 +7700,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation>mover la primera etiqueta de la pinza</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation>mover la segunda etiqueta de la pinza</translation>
     </message>
@@ -9913,7 +7711,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation>Mover elemento de grupo</translation>
     </message>
@@ -9921,7 +7718,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation>mover etiqueta del punto</translation>
     </message>
@@ -9929,7 +7725,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation>mover etiqueta de punto</translation>
     </message>
@@ -9937,7 +7732,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation>mover un solo punto</translation>
     </message>
@@ -9945,7 +7739,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation>mover spline</translation>
     </message>
@@ -9953,7 +7746,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation>mover ruta de spline</translation>
     </message>
@@ -9961,52 +7753,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>Nuevo archivo de medidas</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Tipo de medida:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Unidad:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Talla base:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Altura base:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Individual</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Multisize</source>
         <translation>Multitalla</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Centimeters</source>
         <translation>Centímetros</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Milímetros</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inches</source>
         <translation>Pulgadas</translation>
     </message>
@@ -10014,87 +7796,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation>Letras</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation>Legal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation>Tabloide</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation>Rollo 24in / 60.96cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation>Rollo 30in / 76.20cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation>Rollo 36in / 91.44cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation>Rollo 42in / 106.68cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation>Rollo 44in / 111.76cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation>Personalizado</translation>
     </message>
@@ -10102,887 +7867,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation>Herramienta de Pieza de Patrón</translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation>Propiedades </translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation>Rutas </translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation>Márgenes de Costura </translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation>Etiquetas </translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation>Anclas </translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation>Dirección del hilo </translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation>Piquetes </translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation>Nombre de la pieza:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation>Pieza de Patrón</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation>El nombre no puede estar vacío</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation>Letra:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation>Letra de pieza de patrón</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation>Cantidad:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation>Ubicación:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation>Lomo</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation>Posición de Lomo:</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation>Indefinido</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation>Arriba abajo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation>Izquierda / Derecha</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation>Orientación:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation>Izquierda</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation>Derecha</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation>Rotación:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation>1-Forma</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation>2-Forma</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation>4-Forma</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation>cualquier</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation>Inclinación:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation>CW X</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation>CCW X</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation>Anotación:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation>Un campo de texto para agregar comentarios</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation>Atributos</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation>Prohibir que la pieza se refleje en un maquetación.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation>valor hexadecimal</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation>Llenar:</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation>Ruta Principal</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation>Todos los objetos en la ruta deben seguir en la direccion de las agujas del reloj.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation>Mover fila al principio de la lista</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation>Mover fila por encima de la fila</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation>Mover fila por debajo de la fila</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation>Mover fila al final de la lista</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation>Estado:</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation>¡Listo!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation>Rutas Internas</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation>El margen de costura es parte de la ruta principal</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation>Construido en</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation>Ocultar la ruta principal si el margen de costura está habilitado</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation>Ancho:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation>Asistente de fórmula</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation>Nodos</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation>Nodo:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation>Antes:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation>Volver al ancho predeterminado</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation>Usar por defecto</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation>Después:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation>Personalizado</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation>Punto de Inicio:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation>Punto Final:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation>Incluir como:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation>Etiqueta de pieza</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation>Editar etiqueta de patrón</translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation>Editar plantilla</translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation>Mostrar etiqueta de pieza</translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation>Puntos de Anclaje</translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation>Etiqueta de patrón</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation>Mostrar etiqueta de patrón</translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation>Mostrar la dirección del hilo</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation>Flechas</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation>Tipo:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation>Piquete:</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation>Abertura</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation>Piquete T</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation>Piquete U</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation>V interno </translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation>V Externo</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation>Castillo</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation>Diamante</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation>Subtipo</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation>Directo</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation>Bisectriz</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation>Seleccione para designar un punto de esquina como piquete</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation>Intersección</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation> Ancho:</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation>  °</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation>Restablecer la longitud del piquete a su valor predeterminado.</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation>Restablecer el piquete a su valor predeterminado.</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation>Restablecer el ángulo del piquete a su valor predeterminado.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation>Contar:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation>Seleccione los objetos de la ruta principal en el sentido de las agujas del reloj. Utilice tecla&lt;b&gt;MAYÚS&lt;/b&gt; para invertir la dirección de la curva o la tecla &lt;b&gt;CTRL&lt;/b&gt; para mantener la dirección de la curva. Presione la tecla &lt;b&gt;ENTER&lt;/b&gt; para finalizar la creación de la pieza </translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation>Presione OK para crear pieza de patrón</translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation>Revés</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation>Duplicado</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation>Piquete</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation>Piquete T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation>Piquete U</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation>VInterno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation>VExterno</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation>Excluido</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation>Error. No se puede guardar la ruta de la pieza.</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation>Resultado infinito/indefinido</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation>La longitud debería de ser positiva</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation>Error en análisis: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation>Editar longitud</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation>Editar ángulo</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation>Editar altura</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation>Editar ancho</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation>Margen de costura actual</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation>Editar ancho de margen de costura</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation>Editar el ancho de margen de costura antes</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation>Editar el ancho de margen de costura después</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation>Dirección de hilo</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation>¡Necesita más puntos!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation>¡Debe elegir puntos en el sentido de las agujas del reloj!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation>¡El primer punto no puede ser el mismo que el último!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation>¡Tiene puntos dobles!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation>¡Cada punto de la ruta debe ser único!</translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation>Vacío</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation>Ruta principal</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation>Personalizar margen de la costura</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation>Ambos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation>Justo delante</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation>Justo detrás</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation>Mostrar el piquete en la línea de corte.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation>Mostrar piquete en la línea de corte</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation>Mostrar piquete en la línea de costura.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation>Mostrar piquete en la línea de costura</translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation>Mostrar línea de corte</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation>Ocultar línea de costura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation>Margen de costura</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation>Rutas</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation>Etiquetas</translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation>Seleccionar el color</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation>Voltear:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation>Prohibir</translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation>Centro:</translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation>Arriba a la izquierda:</translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation>Abajo a la derecha:</translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation>Arriba:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation>Abajo:</translation>
     </message>
@@ -10990,218 +8502,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation>Acual margen de costura</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation>mover etiqueta de pieza de patrón</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation>escalar etiqueta de pieza de patrón</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation>rotar etiqueta de pieza de patrón</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation>mover etiqueta de información del patrón</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation>escalar etiqueta de información del patrón</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation>rotar etiqueta de información del patrón</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation>mover dirección del hilo</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation>escalar dirección del hilo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation>rotar dirección del hilo</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation>Bloquear Pieza de Patrón</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation>Incluir en el maquetación</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation>Prohibir voltear</translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation>Subir al principio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation>Bajar hacia abajo</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation>Ocultar línea de costura</translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation>Mostrar margen de costura</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation>Mostrar la dirección del hilo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation>Mostrar etiqueta de patrón</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation>Mostrar etiqueta de la pieza</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation>Cambiar nombre...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation>Prohibción de voltear ha sido cambiada: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation>Activado</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation>Desactivado</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation>La visibilidad de la línea de costura ha sido cambiada: </translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation>Ocultar</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation>Mostrar márgenes de costura</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation>Visibilidad de márgenes de costura ha sido cambiada: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation>Mostrar la dirección del hilo</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation>Visibilidad de la dirección del hilo ha sido cambiada: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation>Mostrar etiqueta de patrón</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation>La visibilidad de la etiqueta del patrón ha sido cambiada: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation>Mostrar la etiqueta de pieza</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation>La visibilidad de la etiqueta de la pieza ha sido cambiada: </translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation>Nombre de la pieza:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation>Cambiar el nombre de la pieza del patrón</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation>Cambiar nombre de la pieza del patrón</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation>El nombre de pieza se cambió a: </translation>
     </message>
@@ -11209,27 +8669,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation>Color de línea actual</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation>Tipo de línea actual</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation>Peso de línea actual</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation>Restablecer el lápiz actual a los valores predeterminados</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation>Guardar el preajuste actual del lápiz</translation>
     </message>
@@ -11237,77 +8692,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation>Sin relleno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation>Sólido</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation>Densidad 1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation>Densidad 2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation>Densidad 3</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation>Densidad 4</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation>Densidad 5</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation>Densidad 6</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation>Densidad 7</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation>Línea horizontal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation>Línea vertical</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation>Cruz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation>Diagonal Inversa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation>Diagonal de avance</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation>Cruz Diagonal</translation>
     </message>
@@ -11315,139 +8755,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation>Forma</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation>Incluir todas las piezas</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation>Excluir todas las piezas</translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation>Invertir piezas incluidas</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation>Bloquear todas las piezas</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation>Desbloquear todas las piezas</translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation>Invertir piezas bloqueadas</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation>Alternar inclusión de pieza de patrón en el maquetación</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation>Seleccionar el color</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation>Editar las propiedades de la pieza de patrón</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation>Incluido</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation>Pieza patrón se incluye en el diseño</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation>Bloqueado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation>Pieza patrón bloqueada</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation>Color de la pieza patrón</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation>Pieza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation>Letra de la pieza patrón</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation>Nombre de la pieza patrón</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation>Bloqueo del interruptor en la pieza de patrón</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation>Un doble clic abre el selector de color</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation>Al hacer doble clic se abre el cuadro de diálogo de propiedades de la pieza del patrón</translation>
     </message>
@@ -11455,62 +8850,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation>Punto - Intersección XY</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation>1er punto:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation>2do punto:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation>Atributos</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation>Seleccione punto para el valor Y (horizontal)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation>Nombre único</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Elija un nombre único.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
@@ -11518,316 +8901,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation>Intervalo:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>GUI Idioma:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation>Unidad por defecto:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>La unidad predeterminada se ha actualizado y se utilizará para el próximo patrón que cree.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation>Centímetros</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Pulgadas</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation>Edición</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation>Contador de pasos:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation> (0 - infinito)</translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation>Advertencias de edición de patrones</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation>Confirmar eliminación de artículo</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation>Confirmar reescritura de formato</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation>Sufijo predeterminado de operaciones</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation>Reflejar por Eje:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation>Reflejar por Línea:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation>Mover:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation>Rotación:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation>Manejo de Archivos</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation>Copias de seguridad</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation>Crear un archivo de copia de seguridad al convertir</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation>Habilitar guardado automático</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation> min</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation>Cada </translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation>Formato de exportación</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation>Incluir tipo de modo en el nombre del archivo</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation>Guardar último usado</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation>Por defecto:</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation>Separador decimal:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation>_M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation>_MOV</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation>_R</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation>_ROT</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation>_MA</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation>_MBA</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation>_MB</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation>_MBL</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation>milímetros</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation>Sonido de selección</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation>Sonido:</translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation>Información para diseñadores</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation>Empresa / Información para diseñadores</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation>Empresa / Diseñador:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation>Contacto:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>City:</source>
         <translation>Ciudad:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation>Estado:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation>Código postal:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation>País:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation>Teléfono:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation>Fax:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation>Correo electrónico:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation>Página web:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation>Verificación del correo electrónico</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-184"/>
         <source>Address:</source>
         <translation>:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-38"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation>Localización del usuario</translation>
     </message>
     <message>
-        <location line="-110"/>
         <source>Email format is not valid.</source>
         <translation>El formato del correo electrónico no es válido.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1031"/>
         <source>Startup</source>
         <translation>Puesta en marcha</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation>Bienvenido</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation>No mostrar la pantalla de bienvenida</translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation>Texto del nombre del punto:</translation>
     </message>
@@ -11835,583 +9152,415 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation>Apariencia</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation>Barras de Herramientas</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation>La etiqueta de texto aparece por debajo del ícono (recomendado para principiantes)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation>Mostrar barras de herramientas</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation>Caja de Herramientas</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation>Arco</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation>Operaciones</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation>Pieza</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation>maquetación</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation>Salida gráfica</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation>Usar suavizado</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation>Fuentes</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation>Fuente:</translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation>Talla:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation>6</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation>7</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation>8</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation>9</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation>10.5</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation>11</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation>12</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation>13</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation>14</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation>15</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation>16</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation>18</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation>20</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation>22</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation>24</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation>26</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation>28</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation>32</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation>36</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation>40</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation>44</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation>48</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation>54</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation>60</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation>66</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation>72</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation>80</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation>96</translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation>El rápido zorro marrón salta sobre el perro perezoso</translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation>Nombres de puntos</translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation>GUI</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation>Colores</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation>Banda elástica de zoom</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation>Positivo:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation>Negativo:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation>Por defecto:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation>Flotar</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation>Dibujo</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation>Origen del eje</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation>Primario:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation>Secundario:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation>Terciario:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation>Navegación</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation>Barras de desplazamiento</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation>Mostrar barras de desplazamiento</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation>Anchura:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation> px</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation>Duración:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation>Duración de la animación de desplazamiento</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Update interval:</source>
         <translation>Intervalo de
 actualización:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation>Tiempo en milisegundos entre cada actualización de la animación</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation>Velocidad:</translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation>Usar CTRL modificador</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation>Comportamiento</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation>Restricciones</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation>Paso de ángulo:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation> grados</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation>Zoom a lo seleccionado con doble clic</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation>Panorámica activa mientras está presionda la tecla Espacio</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
         <translation>Calidad:</translation>
     </message>
     <message>
-        <location line="-723"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation> ms</translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation>Rutas que utiliza Seamly2D</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Ruta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation>Abrir Directorio</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation>Mis medidas individuales</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>Mis Medidas Multitalla</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation>Mis imágenes</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation>Mis Copias de seguridad</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation>Mis Patrones</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation>Mis Maquetaciones</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation>Mis Plantillas</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation>Mis Plantillas de Etiquetas</translation>
     </message>
@@ -12419,272 +9568,202 @@ actualización:</translation>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation>Prohibir giro</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation>Por defecto olvidar voltear todos los nuevos trabajos</translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation>Por defecto, oculta la ruta principal si el margen de costura está habilitado</translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation>Márgenes de costura</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation>Valor por defecto:</translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation>Fecha:</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation>Editar formatos</translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation>Hora:</translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation>Pieza de Patrón</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation>Piquetes</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation>Mostrar el piquete tanto en el margen de costura como en la línea de costura.</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation>Tipo:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation>Ancho:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation>Dirección de hilo</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation>Mostrar Dirección de Hilo</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation>x 3</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation>Rutas</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation>Línea de costura</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation>Grosor de línea</translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation>Línea de corte</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation>Recortes</translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation>Etiquetas</translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation>Datos de etiqueta (formato de fecha/hora)</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation>Abertura</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation>Piquete T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation>Piquete U</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation>V Interno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation>V Externo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation>Castillo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation>Diamante</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation>Atributos</translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation>Mostrar etiquetas de patrón</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation>Mostrar etiquetas de pieza</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation>Ancho</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation>Alto</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation>Plantillas</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation>Etiqueta de patrón:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation>Etiqueta de pieza:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation>Plantilla de etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation>Importar plantilla</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation>Mostrar el piquete en la línea de corte</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation>Mostrar el piquete en la línea de costura</translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation>Internos</translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation>Mostrar línea de corte</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation>Ocultar línea de costura</translation>
     </message>
@@ -12692,7 +9771,6 @@ actualización:</translation>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>Basado en Qt %1 (%2, %3 bit)</translation>
     </message>
@@ -12700,156 +9778,125 @@ actualización:</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Crear nueva pieza de patrón para comenzar a trabajar.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>pulg</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translatorcomment>El texto que aparece en el encabezado de la primera columna.</translatorcomment>
         <translation>Propiedad</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation>añadir nodo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation>Cambios aplicados.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Nombre de etiqueta incorrecto &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation>No se puede convertir al parámetro UIntel</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation>No se puede convertir al parámetro toBool</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation>Se obtuvo un parámetro vacío</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation>No se puede convertir al parámetro toDouble</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation>Se obtuvo un identificador de parámetro incorrecto. Solo es necesario identificador &gt; 0.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation>Tela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation>Forro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation>Entretela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation>Entretela de forro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation>Lomo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation>Unión de piezas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation>Mover Pieza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation>Línea sólida</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation>Guión</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation>Guión Punto</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation>Guión Punto Punto</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation>Sin pluma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
@@ -12857,15 +9904,11 @@ actualización:</translation>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation>muy pocos argumentos para la función sum.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation>muy pocos argumentos para la función min.</translation>
@@ -12874,217 +9917,181 @@ actualización:</translation>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Símbolo inesperado &quot;$TOK$&quot; encontrado en la posición $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Error interno</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Función inválida-, variable- o constante con nombre: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Identificador de operador binario no válido: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>identificador de operador infijo no válido: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>identificador de operador posfijo no válido: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Puntero inválido a función callback.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>La expresión está vacía.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Puntero inválido a variable.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Operador &quot;$TOK$&quot; inesperado en posición $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Fin de expresión inesperada en posición $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Separador de argumentos inesperado en posición $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Paréntesis &quot;$TOK$&quot; inesperada en posición $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Función &quot;$TOK$&quot; inesperada en posición $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Valor &quot;$TOK$&quot; inesperado en posición $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Variable &quot;$TOK$&quot; inesperada en posición $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Argumentos de función usados sin una función (posición: $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Faltan paréntesis</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Demasiados parámetros para la función &quot;$TOK$&quot; en la posición de la expresión $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Muy pocos parámetros para la función &quot;$TOK$&quot; en la expresión de la posición $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>División por cero</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Error de dominio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Conflicto en nombre</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>Valor invalido para el operador (debe ser mayor o igual a cero).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>el operador binario definido por el usuario &quot;$TOK$&quot; entra en conflicto con un operador interno.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Cadena de símbolo inesperada encontrada en la posición $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Cadena de caracteres no terminada comenzando en la posición $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>Función de cadena de caracteres llamada con un argumento que no se una cadena de caracteres.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>Valor de cadena de caracteres usado cuando se esperaba un argumento numérico.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>No hay una sobrecarga de operador adecuada para &quot;$TOK$&quot; en la posición $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>El resultado de la función es una cadena.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Error en análisis.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>El separador decimal es idéntico al separador de argumentos de funciones.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>El operador &quot;$TOK$&quot; tiene que estar precedido de paréntesis cerrados.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>El operador If-then-else no encuentra una cláusula else</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Dos puntos mal ubicados en la posición $POS$</translation>
@@ -13093,7 +10100,6 @@ actualización:</translation>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation>Eliminar elemento de grupo</translation>
     </message>
@@ -13101,7 +10107,6 @@ actualización:</translation>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation>Cambiar nombre de pieza del patrón</translation>
     </message>
@@ -13109,12 +10114,10 @@ actualización:</translation>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation>Pulse &lt;b&gt;CTRL&lt;/b&gt; para escalar alrededor del centro - &lt;b&gt; Relación de aspecto bloqueada &lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation>Pulse &lt;b&gt;CTRL&lt;/b&gt; para escalar alrededor del centro, &lt;b&gt;SHIFT&lt;/b&gt; para escalar uniformemente.</translation>
     </message>
@@ -13122,7 +10125,6 @@ actualización:</translation>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation>guardar opción de detalle</translation>
     </message>
@@ -13130,7 +10132,6 @@ actualización:</translation>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation>guardar opciones de ruta</translation>
     </message>
@@ -13138,7 +10139,6 @@ actualización:</translation>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation>guardar opción de herramienta</translation>
     </message>
@@ -13146,88 +10146,70 @@ actualización:</translation>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>GUI Idioma:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation>Sistema de creación de patrones</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation>Sistema:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation>Autor:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation>Libro:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation>Edición de medidas</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation>Reiniciar advertencias</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation>Barra de Herramientas</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation>El texto aparece por bajo del icono (recomendado para principiantes).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation>Altura y talla predeterminados</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation>Talla:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation>Puesta en marcha</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation>No mostrar la pantalla de bienvenida</translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation>Separador decimal:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation>Localización del usuario</translation>
     </message>
@@ -13235,52 +10217,42 @@ actualización:</translation>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Ruta</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation>Abrir Directorio</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation>Mis medidas individuales</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>Mis Medidas Multitalla</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation>Mis Plantillas</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation>Rutas que utiliza SeamlyME</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation>Mis escáneres corporales</translation>
     </message>
@@ -13288,57 +10260,46 @@ actualización:</translation>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Bienvenido</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation>Bienvenido a SeamlyME</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation>Usuarios de 3D Look</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation>Para utilizar un escaneado corporal 3D Look es necesario convertir el archivo al formato SeamlyME. </translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation>Adjunte su archivo 3DLook a un correo electrónico y envíelo a convert@seamly.io.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Recibirá un correo electrónico con el archivo convertido, que podrá cargar en SeamlyME como de costumbre.</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation>Elija las unidades, el separador decimal y el idioma que prefiera. (Puede cambiarlos más adelante.)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation>Unidades:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Establece las unidades por defecto para un nuevo archivo de medición.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Separador decimal:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
@@ -13347,46 +10308,36 @@ Si está marcada, se utiliza el separador de la configuración regional del usua
 Si no se selecciona, se utiliza el punto.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation>Si esta opción está seleccionada, no se mostrará la ventana de bienvenida. 
 Puede cambiar esta configuración en las preferencias de SeamlyMe.</translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation>GUI Idioma:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation>Establece el idioma utilizado para SeamlyMe.</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation>No volver a mostrar</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Localización del usuario</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Centímetros</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Milímetros</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Pulgadas</translation>
     </message>
@@ -13394,81 +10345,64 @@ Puede cambiar esta configuración en las preferencias de SeamlyMe.</translation>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Bienvenido</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation>Bienvenido a Seamly2D</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation>Unidades:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Establece las unidades por defecto para un nuevo archivo de medición.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Separador decimal:</translation>
     </message>
     <message>
-        <location line="+239"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation>Si esta opción está seleccionada, no se mostrará la ventana de bienvenida. 
 Puede cambiar esta configuración en las preferencias de Seamly2D.</translation>
     </message>
     <message>
-        <location line="-190"/>
         <source>GUI language:</source>
         <translation>GUI Idioma:</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Do not show again</source>
         <translation>No volver a mostrar</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Localización del usuario</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Centímetros</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Pulgadas</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation>Establece el idioma utilizado para Seamly2D.</translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation>Elija las unidades, el separador decimal, el idioma y el sonido de selección que prefiera. (Puede cambiarlos más adelante.)</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
@@ -13477,12 +10411,10 @@ Si está marcada, se utiliza el separador de la configuración regional del usua
 Si no se selecciona, se utiliza el punto.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation>Sonido:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation>Establece el sonido del clic de selección del nodo.</translation>
     </message>
@@ -13490,12 +10422,10 @@ Si no se selecciona, se utiliza el punto.</translation>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation>Cambiar color de pieza</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation>El color de la pieza cambiado: </translation>
     </message>
@@ -13503,1071 +10433,854 @@ Si no se selecciona, se utiliza el punto.</translation>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation>Copiar atajos de teclado a portapapeles</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation>Exportar Atajosde teclado en formato PDF</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation>Enviar Atajos de teclado a la impresora</translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation>Seamly2D Atajos de teclado</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation>Archivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation>Control+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation>Control+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation>Control+W</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation>Control+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation>Control+Mayúsculas+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation>Control+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation>Preferencias de patrón</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation>Control+Mayúsculas+Comma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation>Información del documento</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation>Control+I</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation>Control+Q</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation>Control+Z</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation>Rehacer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation>Control+Y</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation>Vista</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation>Modo Borrador</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation>Mayúsculas+D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation>Modo Pieza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation>Modo maquetación</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation>Control+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation>Acercar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation>Control++</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation>Alejar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation>Control+-</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation>Zoom 1:1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation>Control+0</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation>Zoom al punto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation>Control+Alt+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation>Ajustar todo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation>Control+=</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation>Previo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation>Control+Izquierda</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation>Seleccionado</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation>Control+Derecha</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation>Área</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation>Control+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation>Pan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation>Z, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation>Mostrar texto del nombre</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation>V, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation>Aumentar el tamaño del texto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation>Control+]</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation>Disminuir el tamaño del texto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation>Control+[</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation>Usar herramienta de color</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation>Marco de Alambre</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation>V, W</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation>Puntos de control de curvas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation>V, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation>Origen del eje</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation>V, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation>Márgenes de costura</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation>V, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation>Dirección del hilo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation>V, G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation>Etiquetas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation>V, L</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation>Medidas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation>Abrir SeamlyMe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation>Control+M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation>Tabla de Variables</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation>Control+T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation>Exportar Tabla de Variables a CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation>Control+E</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation>Herramientas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation>Nuevo bloque de borrador</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation>Control+Mayúsculas+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation>Cambiar nombre de Nuevo bloque de borrador</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation>F2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation>Longitud y Ángulo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation>L, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation>En Línea</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation>O, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation>En Perpendicular</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation>O, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation>En Bisectriz</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation>O, B</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation>Longitud a Línea</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation>P, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation>Intersección de Arco y Línea</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation>A, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation>Intersección Eje y Triángulo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation>X, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation>intersección de XY</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation>X, Y</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation>Intersección de Línea y Perpendicular</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation>L, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation>Intersección Línea y Eje</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation>L, X</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation>Punto Medio de Línea</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation>Mayúsculas+O, Mayúsculas+L</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation>Alt+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation>Punto - Intersección de Líneas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation>I, L</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation>Curvas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation>Curva - Interactiva</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation>Alt+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation>Spline - Interactivo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation>Curva - Fijo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation>Alt+Mayúsculas+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation>Spline - Fijo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation>Alt+Mayúsculas+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation>Punto - En curva</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation>O, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation>Punto - En Spline	</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation>O, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation>Punto - Intersección de Curvas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation>I, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation>Punto - Intersección Curva y Eje</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation>C, X</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation>Arcos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation>Arco - Radio y Ángulos</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation>Arco - Radio y Longitud</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation>Alt+Mayúsculas+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation>Punto - En Arco</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation>O, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation>Punto - Intersección Arco y Eje</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation>A, X</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation>Punto - Intersección de Arcos</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation>I, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation>Punto - Intersección de Círculos</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation>Mayúsculas+I, Mayúsculas+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Punto - Intersección Círculo y Tangente</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation>C, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Punto - Intersección Arco y Tangente</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation>A, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation>Arco Elíptico</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation>Alt+E</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation>Operaciones</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation>Aañadir Objetos al Grupo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation>Rotación</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation>Reflejar por Línea</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation>M, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation>Reflejar por Eje</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation>M, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation>Alt+M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation>Pinzas Correctas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation>T, D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation>Exportar bloques de borrador</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation>E, D</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation>Imágenes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation>Importar imagen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation>Alt + I</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation>Pieza de Patrón</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation>Nueva Pieza de Patrón</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation>N, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation>Punto de Anclaje</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation>A, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation>Ruta Interna</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation>I, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation>I, N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation>Editar Propiedades</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation>Interruptor de bloqueo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation>Control+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation>Incluir en el maquetación</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation>Prohibir voltear</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation>Traer al Frente</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation>Control+Inicio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation>Bajar al Fondo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation>Control+Fin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation>Suprimir</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation>Unir piezas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation>Exportar Piezas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation>E, P</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation>Maquetación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation>Nuevo Maquetación</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation>N, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation>Exportar maquetación</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation>E, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation>Última Herramienta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation>Control+Mayúsculas+L</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation>Historia</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation>Control+H</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation>Utilidades</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation>Calculadora</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation>Control+Mayúsculas+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation>Gráfico decimal</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation>Control+Mayúsculas+D</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation>Atajos de Teclado</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation>Mayúsculas+P</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation>Exportar PDF</translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation>Insertar nodos</translation>
     </message>
@@ -14575,12 +11288,10 @@ Si no se selecciona, se utiliza el punto.</translation>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation>Seleccione el primer punto de la pinza</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation>Seleccione el segundo punto de la pinza</translation>
     </message>
@@ -14588,42 +11299,34 @@ Si no se selecciona, se utiliza el punto.</translation>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation>Información del documento</translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation>Copiar información al portapapeles</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation>Exportar información en formato PDF</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation>Enviar información a la impresora</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation>&lt;estilo de tabla=tamaño de fuente:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Empresa: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt; b&gt;Cliente: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Nombre del patrón:&lt;/b&gt;&lt;/td&gt;&lt;td&gt; %3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;N.º de patrón: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Versión: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Unidades: &lt;/b&gt;&lt;/td&gt; &lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Medidas:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt; tr&gt;&lt;td align = right&gt;&lt;b&gt;Descripción: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notas: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Imagen: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10 &lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation>Archivos de información</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation>Exportar PDF</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation>_información</translation>
     </message>
@@ -14631,7 +11334,6 @@ Si no se selecciona, se utiliza el punto.</translation>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation>Seleccione punto visible</translation>
     </message>
@@ -14639,7 +11341,6 @@ Si no se selecciona, se utiliza el punto.</translation>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation>Seleccione punto visible</translation>
     </message>
@@ -14647,808 +11348,617 @@ Si no se selecciona, se utiliza el punto.</translation>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Seleccione Nuevo para crear un archivo de medidas.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation>Valor calculado</translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Fórmula</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Valor base</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>En tallas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>En alturas</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Fórmula:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation>Valor base:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation>En tallas:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation>En alturas:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Descripción:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation>Mover medida arriba</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Mover medida abajo</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Valor calculado:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation>Nombre completo:</translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Tipo:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation>Tipo de medida</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Ruta:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Mostrar en el Explorador</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Talla base:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation>Valor del talla base</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Altura base:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation>Valor de la altura base</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Apellidos:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation>Fecha de nacimiento:</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>Correo electrónico:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>Notas:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>Archivo</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Ventana</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Medidas</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation>Menú</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation>Escalado</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation>Abrir individual ...</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation>Guardar como...</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>Sobre &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>Sobre SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation>Añadir conocido</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation>Añadir personalizado</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation>Solo lectura</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>Base de datos</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation>Mostrar información sobre todas las medidas conocidas</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation>sin titulo %1</translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>Este archivo ha sido abierto en otra ventana.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Error en archivo.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>No se ha guardado archivo</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation>&amp;Nueva Ventana</translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation>Editar medida</translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Campo vacío.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Error en análisis: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Medidas individuales</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>Sin título</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation>Cambios sin guardar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Las medidas han sido modificadas. ¿ Quiere guardar los cambios?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Campo vacío</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation>Importar desde un patrón</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation>Unidad del patrón:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Buscar:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation>Buscar Anterior</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation>Buscar Siguiente</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation>Error al bloquear. Este archivo ya está abierto en otra ventana.</translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation>El archivo contiene medida(s) conocidas inválidas.</translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation>El archivo tiene un formato desconocido.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Nombre completo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation>¡El archivo &apos;%1&apos; no existe!</translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation>Está prohibido cambiar el nombre de las medidas conocidas.</translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation>No se pudo encontrar la medida &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation>Está prohibido cambiar el nombre completo de una medida conocida.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation>Asistente de funciones</translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation>Mover medida arriba al principio</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation>Mover medida al final</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation>Borrar medida</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translatorcomment>género</translatorcomment>
         <translation>desconocido</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translatorcomment>género</translatorcomment>
         <translation>hombre</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translatorcomment>género</translatorcomment>
         <translation>mujer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation>Género:</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation>Sistema de patronaje:</translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation>Crear desde existente ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation>Crear desde archivo existente</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation>Seleccione archivo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation>Diagrama de la medida</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Medida desconocida&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Medida desconocida&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>Sobre Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>El archivo aún no se guardó .</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation>Nombre de la medida en una fórmula</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation>Nombre de la medida en la fórmula.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation>Nombre de la medida legible por humanos.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>Guardar...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>No guardar</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Archivo de bloqueo</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>No se pudo crear el archivo de bloqueo, por falta de permisos.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Ocurrió un error desconocido, por ejemplo, una partición completa impedido escribir el archivo de bloqueo.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation>Exportar a CSV</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Mostrar en el Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation>Nombre del cliente</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation>Apellido del cliente</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation>Email del cliente</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Talla:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation>Todos los archivos</translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation>El documento de medidas no tiene permisos de escritura.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>No se pueden establecer permisos de escritura para %1 .</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>El archivo no ha podido guardarse .</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation>El archivo no ha podido guardarse</translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation>sólo lectura</translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation>Medidas Multitalla</translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Resultado no válido. El valor es infinito o no numérico. Por favor, revise sus cálculos.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation>Vacío</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation>Abrir multitalla ...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation>No se admite la exportación desde medidas multitalla.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation>Ctrl+Shift+O</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation>Ctrl+,</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation>Atajos de teclado</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation>No se pudo bloquear. Este archivo ya está abierto en otra ventana. Puede producirse colapso al ejecutar 2 copias del programa.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation>Número</translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation>Copiar al portapapeles</translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation>Abrir plantilla ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation>Ctrl+Alt+O</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation>Archivos de patrones</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Este archivo esta abierto en otra ventana. Si desea continuar: Haga click en Ignorar (no recomendado, puede provocar datos erroneos).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Archivo bloqueado, no puede ser mostrado por falta de permisos. Si desea continuar: Haga click en Ignorar (no recomendado, puede provocar errores).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Se produjo un error desconocido, por ejemplo una parte llena impedía escribir el archivo de bloqueo. Ignorelo si desea continuar (no se recomienda, puede provocar errores).</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation>Importar escáner corporal como</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation>3D Measure Up</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation>3D Look</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2716"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
@@ -15457,7 +11967,6 @@ Do you want to save your changes?</source>
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15467,14 +11976,12 @@ load in SeamlyME as usual.
 </translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation>Para utilizar un escaneado corporal 3D Look es necesario convertir el archivo al formato SeamlyME.
 </translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Convert 3DLook file:</source>
         <translation>Convertir archivo 3DLook:</translation>
     </message>
@@ -15482,22 +11989,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation>Pieza en Lista de Maquetación</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation>Incluir pieza en el maquetación modificado: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation>Incluir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation>Excluir</translation>
     </message>
@@ -15505,22 +12008,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation>Bloqueo pieza de patrón</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation>Bloqueo de pieza cambiado: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation>Bloqueado</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation>Desbloqueado</translation>
     </message>
@@ -15528,47 +12027,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation>Primer punto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation>Segundo punto</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation>Punto más alto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation>Punto más bajo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation>Punto más a la izquierda</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation>Punto más a la derecha</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation>Eje vertical</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation>Eje horizontal</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation>Línea_</translation>
     </message>
@@ -15576,47 +12066,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation>Herramienta de unión</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;¿Desea unir los detalles?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation>Conservar las piezas originales</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation>Seleccione primer punto</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation>La pieza del patrón debe tener al menos dos puntos y tres objetos</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation>Seleccione segundo punto</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation>Seleccione un punto único</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation>Selecciona una pieza</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation>Seleccione un punto en el borde</translation>
     </message>
@@ -15624,7 +12105,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation>Unión de piezas</translation>
     </message>
@@ -15632,17 +12112,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>No preguntar de nuevo</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>&amp;No preguntar de nuevo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>&amp;No mostrar de nuevo</translation>
     </message>
@@ -15650,57 +12127,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>No se pudo obtener información de la versión.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>Demasiadas etiquetas &lt;%1&gt; en el archivo.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Versión &quot;%1&quot; no válida.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Versión &quot;0.0.0&quot; no válida.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Versión no válida. Versión mínima soportada es %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Versión no válida. Versión máxima soportada es %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Error de identificador no único.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>No se pudo cambiar la versión.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation>Error al crear una copia de reserva: %1.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Versión inesperada &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation>Error al abrir un archivo temporal: %1.</translation>
     </message>
@@ -15708,7 +12174,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation>No se puede cortar este spline</translation>
     </message>
@@ -15716,22 +12181,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation>Confirmar la reescritura del formato</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation>Este archivo utiliza la versión v%1 del formato anterior. La actual es v%2. Si guarda el archivo con esta versión de la aplicación, se actualizará la versión de formato de este archivo. Esto puede impedir que pueda abrir el archivo con versiones anteriores de la aplicación. ¿Realmente desea continuar?</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation>Valores separados por comas</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation>Exportar a CSV</translation>
     </message>
@@ -15739,13 +12200,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
@@ -15753,23 +12211,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>No se encuentra herramienta en la tabla.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation>Error al crear o actualizar el grupo</translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>Nuevo grupo</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation>Nuevo grupo 2</translation>
     </message>
@@ -15777,7 +12230,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation>Pieza</translation>
     </message>
@@ -15785,12 +12237,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -15798,283 +12248,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Confirmar la eliminación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>¿Realmente quiere eliminarlo?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation>Editar fórmula errónea</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation>Azul</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation>Rojo oscuro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation>Verde oscuro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation>Azul oscuro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation>Amarillo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation>Salmón Claro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation>Dorado oscuro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation>Naranja</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation>Rosa profundo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation>Violeta</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation>Violeta oscuro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation>Verdoso claro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation>Lima</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation>Azul claro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation>Azul aciano</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation>Negro</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation>Dorado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation>Verde bosque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation>Verde fosforito</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation>Lima verde</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation>Amarillo verdoso</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation>Beige anaranjado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation>Naranja rojizo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation>Granate</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation>Rosa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation>Rosa fosforito</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation>Lila</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation>Rosa oscuro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation>Indigo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation>Morado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation>Ciruela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation>Turquesa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation>Turquesa claro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation>Azul grisáceo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation>Azul muy claro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation>Azul Marino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation>Verde oscuro grisáceo</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation>Gris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation>Gris claro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation>Verde azulado oscuro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation>Gris muy claro</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation>Azul grisáceo muy claro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation>Biege</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation>Lila muy claro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation>Plata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation>Gris blanquecino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation>Blanco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation>Gris oscuro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation>Gris verdoso</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation>Caqui oscuro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation>beige oscuro</translation>
     </message>
@@ -16082,302 +12475,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation>Ruta al archivo de medidas personalizado (modo de exportación).</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation>El archivo de medidas</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation>Formato numérico</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation>Formato numérico</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>El ancho de página</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation>La unidad de medida</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation>Recortar automáticamente la longitud no utilizada(modo de exportación).</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation>Unidades del maquetación (como uno de papel, excepto px, modo de exportación).</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation>La unidad</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation>Ancho de abertura</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation>Tipo de agrupamiento</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation>No se pueden utilizar el formato y explícitos unidades/tamaño de página juntos.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation>La altura, el ancho y las unidades de la página deben usarse las 3 a la vez.</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation>Valor de rotación invalido . Utilice algunos de los valores predeterminados.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation>Plantilla de página seleccionada desconocida.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation>Medidas de papel no soportadas.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation>Unidades del maquetación no soportadas.</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation>Las opciones de exportación se pueden utilizarse solamente con un único archivo de entrada.</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation>La opción de prueba solo puede usarse con un solo archivo de entrada.</translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation>El nombre básico de los archivos de maquetación exportados. Úselo para habilitar el modo de exportación de la consola.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation>El nombre de archivo básico de los archivos de maquetación</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>La carpeta de destino</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation>El valor de la talla</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation>El valor de la altura</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>El ancho de página en las unidades actuales como 12.0 (no puede usarse con &quot;%1&quot;, modo de exportación).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>El largo de página en las unidades actuales como 12.0 (no puede usarse con &quot;%1&quot;, modo de exportación).</translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation>Valor del la talla de escalado invalido.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation>Valor del altura de escalado invalido.</translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Programa está generando patrón.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Archivo de patrón.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation>El ancho del salto debe usarse en conjunto con las unidades de desplazamiento.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation>El margen izquierdo debe usarse en conjunto con las unidades de página.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation>El margen derecho debe usarse en conjunto con las unidades de página.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation>El margen superior debe usarse en conjunto con las unidades de página.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation>El margen inferior debe usarse en conjunto con las unidades de página.</translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation>La ruta a la carpeta de destino de la salida. De forma predeterminada el directorio en donde se inició la aplicación.</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation>Las unidades de ancho/largo de página (no pueden usarse con &quot;%1&quot;, modo de exportación). Valores válidos: %2.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation>Ignorar margenes de impresión (modo de exportación) . Deshabilita claves de valores: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Establece todos los margenes a 0.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Margen izquierdo de página en las unidades actuales como 3.0 (modo de exportación). Si no se establece se usará el valor de la impresora predeterminada. O 0 si no se encuentra ninguna impresora. El valor se ignorará si se usa la clave &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Margen derecho de página en las unidades actuales como 3.0 (modo de exportación). Si no se establece se usará el valor de la impresora predeterminada. O 0 si no se encuentra ninguna impresora. El valor se ignorará si se usa la clave &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Margen superior de página en las unidades actuales como 3.0 (modo de exportación). Si no se establece se usará el valor de la impresora predeterminada. O 0 si no se encuentra ninguna impresora. El valor se ignorará si se usa la clave &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Margen inferior de página en las unidades actuales como 3.0 (modo de exportación). Si no se establece se usará el valor de la impresora predeterminada. O 0 si no se encuentra ninguna impresora. El valor se ignorará si se usa la clave &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation>Rotación en grados (uno de los predefinidos, modo de exportación) El valor predeterminado es 180. 0 significa no rotar. Valores válidos: %1. Cada valor muestra cuantas veces los detalles serán rotados. Por ejemplo  360 significará dos veces (360/180=2) por 180 grados.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation>Unir las páginas, si es posible (modo de exportación). Valor máximo limitado por QImage que soporta solo un máximo de 32768x32768 píxeles de imagen.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation>Guardar el largo de la hoja, si está establecido (modo de exportación). Esta opción indica al programa que aproveche el ancho de la hoja lo máximo posible. La calidad del maquetación puede empeorar cuando se usa esta opción.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation>Ancho del salto del maquetación x2, medido en las unidades del maquetación. (modo de exportación). Establece la distancia entre los detalles y entre un detalle y la hoja.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation>Establece casos de agrupación de maquetación (modo de exportación): %1.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation>Ejecuta el programa en modo de prueba. El programa en este modo carga un solo archivo de patrón y sale silenciosamente sin mostrar la ventana principal. La clave tiene prioridad antes que la clave &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation>Longitud del desplazamiento del maquetación medido en unidades del maquetación (modo de exportación). La opción muestra cuantos puntos a lo largo del límite serán usados para crear un maquetación.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation>Longitud de Cambio/Desplazamiento</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation>La longitud de compensación/desplazamiento debe usarse en conjunto con las unidades del desplazamiento.</translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation>Número correspondiente a formato de producción (por defecto = 0, modo de exportación):</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation>Número correspondiente a plantilla de página (por defecto = 0, modo de esportación):</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Desactive escalado. Elija esta opción si tiene problemas con el escalado (de forma predeterminada, el escalado está habilitado). Como alternativa, puede utilizar la variable de entorno %1.</translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation>Exportar dxf en formato binario.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation>Exportar texto como rutas.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation>Exportar sólo detalles. Exporte los detalles tal como se ubicaron en el modo  Detalle. Se ignorarán todas las opciones relacionadas con el maquetación.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation>Establezca el valor de la talla en un archivo de patrón que se abrió con medidas  multitalla (modo de exportación). Valores válidos: %1cm.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation>Establezca el valor de altura en un archivo de patrón que se abrió con medidas multitalla (modo de exportación). Valores válidos: %1cm.</translation>
     </message>
@@ -16385,43 +12718,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation>medidas</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation>individuales</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation>Multitalla</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation>Plantillas</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation>imágenes</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation>Plantillas de la etiqueta</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation>copias de seguridad</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation>escaneos corporales</translation>
     </message>
@@ -16429,55 +12753,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>El objeto no se encuentra</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation>No se puede convertir el objeto</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation>El objeto no se encuentra. El tipo no coincide.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation>Número de ID gratuito está agotado.</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation>No se puede crear una curva con el tipo &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation>El objeto no encontrado: </translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation>La pieza no encontrada: </translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation>La ruta no encontrada: </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation>El número id del objeto no encontrado: </translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation>No se puede emitir el objeto.</translation>
     </message>
@@ -16485,12 +12796,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation>No hay suficientes puntos para crear la spline.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation>Esta spline no existe.</translation>
     </message>
@@ -16498,52 +12807,42 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>No se pudo abrir el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>No se pudo abrir el archivo de esquema %1:
 %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation>Error de validación en el archivo %3 en la línea %1 columna %2</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation>Error analizando el archivo %3 en la línea %1 columna %2</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation>No se pudo obtener nodo</translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>Este identificador no es único.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation>No se puede cargar el archivo de esquema &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation>Escritura fallida de Canonical XML.</translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;vacío&gt;</translation>
     </message>
@@ -16551,27 +12850,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation>Mostrar Nombre del Punto</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation>Añadir Objetos de Grupo</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation>Eliminar Objeto de Grupo</translation>
     </message>
@@ -16579,7 +12873,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation>Excepción: %1</translation>
     </message>
@@ -16587,11 +12880,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
@@ -16599,7 +12887,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation>Fórmula:</translation>
     </message>
@@ -16607,7 +12894,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation>La pieza %1 no tiene forma.</translation>
     </message>
@@ -16615,7 +12901,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation>Mostrar Nombre del Punto</translation>
     </message>
@@ -16623,12 +12908,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>Verdadero</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>Falso</translation>
     </message>
@@ -16636,12 +12919,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Directorio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Abrir archivo</translation>
     </message>
@@ -16649,335 +12930,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Error al analizar el archivo.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Error: no se puede convertir el valor.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Error: parámetro vacío.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Error en la identificación.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Error al analizar archivo (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Error al crear o actualizar punto sencillo</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Error al crear o actualizar el punto de final de línea</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Error al crear o actualizar el punto largo de la línea</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Error al crear o actualizar el punto del hombro</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation>Error al crear o actualizar el punto de normal</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Error al crear o actualizar el punto del bisectriz</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Error al crear o actualizar el punto de contacto</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation>Error al crear o actualizar el punto de modelado</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Error al crear o actualizar la altura</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Error al crear o actualizar el triángulo</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation>Error al crear o actualizar el punto de corte de spline</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation>Error al crear o actualizar el punto de ruta de corte de spline</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation>Error al crear o actualizar el punto de corte de arco</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation>Error al crear o actualizar el punto de intersección de línea y eje</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation>Error al crear o actualizar el punto de intersección curva y eje</translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Error al crear o actualizar la línea</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Error al crear o actualizar la curva simple</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Error al crear o actualizar el trazado de la curva</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation>Error al crear o actualizar la transformación de la curva simple</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation>Error al crear o actualizar la transformación de trazado de la curva</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Error al crear o actualizar el arco simple</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation>Error al crear o actualizar la transformación del arco</translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation>Error al crear o actualizar el punto de intersección de arcos</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation>Error al crear o actualizar el punto de intersección de circulos</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation>Error al crear o actualizar el punto del círculo y tangente</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation>Error al crear o actualizar el punto del arco y tangente</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation>Error al crear o actualizar las pinzas correctas</translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Nombre de etiqueta incorrecto &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation>Tipo de punto desconocido &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation>Tipo de spline desconocido &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation>Tipo de arco desconocido &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation>Tipo de herramienta desconocido &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation>Error identificador no único.</translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation>Error al crear o actualizar el punto de intersección de curvas</translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation>Error al crear o actualizar el spline interactivo simple</translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation>Error al crear o actualizar el trazado de simple interactivo</translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation>Error al crear o actualizar la curva de Bézier cúbica</translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation>Error al crear o actualizar el trazado de curva bezier cúbica</translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation>Error al crear o actualizar la operación de rotación</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation>Tipo de operación desconocida &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation>Error al crear o actualizar la oparación de movimiento</translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation>Error al crear o actualizar el punto de intersección de líneas</translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation>Error al crear o actualizar el arco elíptico simple</translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation>Tipo de arco elíptico &apos;%1&apos; desconocido.</translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation>Error al crear o actualizar la transformación del arco elíptico</translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation>Ruta sin nombre</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation>Error al crear o actualizar la ruta de la pieza</translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation>Error al crear o actualizar el punto de anclaje</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation>Error al crear o actualizar la intersección de XY</translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation>Error al crear o actualizar la operación de reflejo por línea</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation>Error al crear o actualizar la operación de reflejo por eje</translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation>Pieza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation>Blanco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation>sin cepillo</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation>Error al crear o actualizar la pieza</translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation>Error al crear o actualizar la unión de piezas</translation>
     </message>
@@ -16985,17 +13177,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation>Red ( %1 , %2 )</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation>Página %1 de %2</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation>Hoja %1 de %2</translation>
     </message>
@@ -17003,12 +13192,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation>Patrones</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation>maquetación</translation>
     </message>
@@ -17016,14 +13203,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>No hay suficientes puntos para crear la spline.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>Esta spline no existe.</translation>
     </message>
@@ -17031,17 +13214,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -17049,27 +13229,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation>Ángulo de princpio</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation>     Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation>     Radio</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Ángulo del final</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation>      Etiqueta</translation>
     </message>
@@ -17077,37 +13252,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation>Ángulo de princpio</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation>     Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation>     Radio</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Ángulo del final</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation>      Nombre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation>      Herramienta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation>Arco - Radio y Longitud</translation>
     </message>
@@ -17115,7 +13283,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -17123,12 +13290,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;No se puede crear el punto de intersección %1 desde el punto %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;a la curva %3 con un ángulo de eje de %4°&lt;/big&gt; &lt;/b&gt;&lt;br&gt;&lt;br&gt;Use el punto de origen como marcador de posición hasta que se corrija el patrón.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation>Punto de Intersección Curva y Eje</translation>
     </message>
@@ -17136,32 +13301,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation>Arco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation>Ángulo de princpio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation>Ángulo del final</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation>radio</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation>etiqueta</translation>
     </message>
@@ -17169,18 +13328,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>longitud</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation>etiqueta</translation>
     </message>
@@ -17188,18 +13343,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>longitud</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation>etiqueta</translation>
     </message>
@@ -17207,7 +13358,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -17215,28 +13365,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation>Ángulo inicial</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation>     Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation>    Radio</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Ángulo final</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation>      Etiqueta</translation>
     </message>
@@ -17244,17 +13388,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -17262,12 +13403,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
@@ -17275,7 +13414,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -17283,27 +13421,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;No se puede encontrar el punto de intersección %1 de&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Línea y Eje&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Use punto de origen como marcador de posición hasta que se corrija el patrón.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation>Intersección Línea y Eje</translation>
     </message>
@@ -17311,17 +13444,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -17329,7 +13459,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation>Punto de orgien</translation>
     </message>
@@ -17337,12 +13466,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation>Primer punto de línea</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation>Segundo punto de línea</translation>
     </message>
@@ -17350,27 +13477,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Punto central</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation>Punto de rotación</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation>Ángulo de rotación</translation>
     </message>
@@ -17378,714 +13500,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Punto base</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation>Pinzas Correctas</translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation>Punto base:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation>Punto central:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation>Radio:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation>Primer ángulo:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Segundo ángulo:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation>Tercer punto:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Etiqueta del punto 1:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation>Etiqueta del punto 2:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation>Primer punto base:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation>Segundo punto base:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation>Primer punto de la pinza:</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation>Arco:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation>Primer punto de línea:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Segundo punto de línea:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Centro del arco:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation>Primer arco:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation>Segundo arco:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation>Coger:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation>Primera curva:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation>Segunda curva:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation>Punto  de tangente:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation>Radio del círculo:</translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>C1: ángulo:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation>C1: longitud:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>C2: ángulo:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation>C2: longitud:</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation>Punto del eje:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation>Sufijo:</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation>Punto de origen:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation>Tipo de eje:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation>Ángulo de rotación:</translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation>Cuarto punto:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation>Punto - Intersección XY</translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation>Rotación</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation>Punto de rotación:</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation>Reflejar por Línea</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation>Reflejar por Eje</translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation>Coordenadas</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation>Punto - longitud y ángulo</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation>Punto - En Línea</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation>Arco - Radio y Ángulos</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation>Arco - Radio y Longitud</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation>Punto - En Bisectriz</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation>Segundo punto de la pinza:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation>Tercer punto de la pinza:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation>Punto - En Arco</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation>Punto - En curva</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation>Punto - En Spline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation>Punto - Intersección de Línea y Perpendicular</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation>Punto - Intersección de Líneas</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation>Primera línea</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation>Segunda línea</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation>Punto - En Perpendicular</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation>Rotación:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation>Punto - Intersección Arco y Línea</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation>Punto de primera línea:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation>Punto de segunda línea:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation>Punto - Intersección de Arcos</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation>Punto - Intersección de Círculos</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation>Primer círculo::</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation>Centro:</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation>Segundo círculo:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation>Punto - Intersección de Curvas</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation>Eje vertical:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation>Eje horizontal:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Punto - Intersección Círculo y Tangente</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Punto - Intersección Arco y tangente</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation>Punto - Longitud a Línea</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation>Curva - Interactiva</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation>Curva - Fija</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation>Spline - Interactivo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation>Spline - Fijo</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation>Punto - Intersección Eje y Tangente</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation>Punto del 1er eje:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation>Punto del 2do eje:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation>Punto - Intersección Línea y Eje</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation>Punto - Intersección Curva y Eje</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation>Arco - Elíptico</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation>Arco_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation>Spline_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation>TrazoSpline_</translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation>Línea_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Punto central</translation>
     </message>
@@ -18093,12 +13899,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;No se puede encontrar el punto de intersección %1 de&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 y la tangente&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt; Use el punto de origen como marcador de posición hasta que se corrija el patrón.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation>Intersección Arco y Tangente</translation>
     </message>
@@ -18106,17 +13910,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -18124,12 +13925,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;No se puede encontrar el punto de intersección %1 de los arcos&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Utilize el punto de origen como marcador de posición hasta que se corrija el patrón.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation>Punto Intersección de Arcos</translation>
     </message>
@@ -18137,12 +13936,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;No se puede encontrar el punto de intersección %1 de las curvas&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Utilize el punto de origen como marcador de posición hasta que se corrija el patrón.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation>Punto Intersección de Curvas</translation>
     </message>
@@ -18150,12 +13947,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation>  Punto de origen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation>Ángulo de rotación</translation>
     </message>
@@ -18163,17 +13958,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Ángulo</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -18181,1404 +13973,1198 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Bunka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Bunka Fashion College</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Fundamentals of Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Barnfield y Richard</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Jo Barnfield y Andrew Richards</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Pattern Making Primer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Friendship/Mujer</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Elizabeth Friendship</translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Morris, K.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Karen Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Sewing Lingerie that Fits</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Lucia Mors de Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Patternmaking in Practic</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Kim &amp; Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autores</translatorcomment>
         <translation>Injoo Kim y Mykyung Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation>Apparel Making in Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Norah Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Corsets and Crinolines</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Frances Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Fashions of the Gilded Age</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Thornton&apos;s International System</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>The Great War: Styles and Patterns of the 1910s</translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Hillhouse &amp; Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autores</translatorcomment>
         <translation>Marion S. Hillhouse y Evelyn A. Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Dress Design: Draping and Flat Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Esther Kaplan Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>How to Design Beautiful Clothes: Designing and Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Minister &amp; Son</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Edward Minister &amp; Son, ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>The Complete Guide to Practical Cutting (1853)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Gertrude Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>A Tailoring Manual</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translatorcomment>System name</translatorcomment>
         <translation>Loh &amp; Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>May Loh and Diehl Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Patternless Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Morris, F. R.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>F. R. Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Ladies Garment Cutting and Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Gertrude Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Gertrude Mason&apos;s Patternmaking Book</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>K. Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Master Designer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation>The Master Designer (Chicago, IL)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Master Designer&apos;s System of Designing, Cutting and Grading</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Kopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>How to Draft Basic Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Doris Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Slacks Cut-to-Fit for Your Figure</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Sarah J. Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Sarah&apos;s Key to Pattern Drafting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Karla J. Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Design and Sew Jeans</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Lady Boutique magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>M. Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Dorothy Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Bina Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Integrating Draping, Drafting and Drawing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Sue S. Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Dressmaking International magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Mabel D. Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation>Practical Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>E. L. G. Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>Principles of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Elizabeth M. Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>European Cut</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Donald H. McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>How to Make Your Own Sewing Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Zarapkar System of Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Philip Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Jack Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>R. I. Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Jason MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>The Victorian Tailor: An Introduction to Period Tailoring</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Helen Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Patternmaking for Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Supreme System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Frederick T. Croonberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Sugino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Dressmaking</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Pattern Drafting Vols. I, II, III (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation>Centre Point System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Louis Devere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>The Handbook of Practical Cutting on the Centre Point System</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Aldrich/Hombre</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Winifred Aldrich</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Metric Pattern Cutting for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Aldrich/Mujer</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Metric Pattern Cutting for Women&apos;s Wear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Gareth Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Patternmaking for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Teresa Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Pattern-Drafting for Fashion: The Basics</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Dennic Chunman Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Pattern Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Dress Pattern Designing: The Basic Principles of Cut and Fit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Knowles/Hombre</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Lori A. Knowles</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>The Practical Guide to Patternmaking for Fashion Designers: Menswear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Friendship/Hombre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Pattern Cutting for Men&apos;s Costume</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>P. Clement Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Art in Dress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation>Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Jno. J. Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>GOST 17917-86</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Ministerio de industria de consumo de la URSS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Standard figure boys</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Eddy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>Josephine F. Eddy y Elizabeth C. B. Wiley</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Pattern and Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Knowles/Mujer</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translatorcomment>Nombre del libro</translatorcomment>
         <translation>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>American Garment Cutter</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translatorcomment>Nombre del sistema</translatorcomment>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translatorcomment>Nombre de autor</translatorcomment>
         <translation>El equipo de Seamly2D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation>Estándar interno de Seamly2D</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translatorcomment>centimeter</translatorcomment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translatorcomment>millimeter</translatorcomment>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translatorcomment>pulgada</translatorcomment>
         <translation>pulg</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translatorcomment>No agregue el símbolo _ al final del nombre</translatorcomment>
         <translation>SplPath</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translatorcomment>No agregue el símbolo _ al final del nombre</translatorcomment>
         <translation>Angle1SplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translatorcomment>No agregue el símbolo _ al final del nombre</translatorcomment>
         <translation>Angle2SplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translatorcomment>Segmento. Símbolo izquierdo _ en el nombre</translatorcomment>
         <translation>Seg_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translatorcomment>No agregues espacios entre palabras.</translatorcomment>
         <translation>LongitudActual</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>talla</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>altura</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translatorcomment>No agregue el símbolo _ al final del nombre</translatorcomment>
         <translation>C1LengthSplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translatorcomment>No agregue el símbolo _ al final del nombre</translatorcomment>
         <translation>C2LengthSplPath</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation>MargenDeCosturaActual</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>hora</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>nombrePatrón</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>patrónNúmero</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>autor</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>cliente</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>pExt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>pNombreArchivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>mNombreArchivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>mExt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>pLetra</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>pAnotación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>pOrientación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>pRotación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>pInclinación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>pPosiciónPliegue</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>pNombre</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>pCantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>mTela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>mForro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>mEntretela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>mEntretelaForro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>wCorte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translatorcomment>marcador de posición</translatorcomment>
         <translation>wLomo</translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
@@ -19586,7 +15172,6 @@ Usage: degTorad(angle θ in degrees)</comment>
         <translation></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
@@ -19594,7 +15179,6 @@ Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
@@ -19602,7 +15186,6 @@ Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
@@ -19610,7 +15193,6 @@ Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
@@ -19618,7 +15200,6 @@ Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
@@ -19626,7 +15207,6 @@ Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
@@ -19634,7 +15214,6 @@ Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
@@ -19642,7 +15221,6 @@ Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
@@ -19650,7 +15228,6 @@ Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
@@ -19658,7 +15235,6 @@ Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
@@ -19666,7 +15242,6 @@ Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
@@ -19674,7 +15249,6 @@ Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
@@ -19682,7 +15256,6 @@ Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
@@ -19690,7 +15263,6 @@ Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
@@ -19698,7 +15270,6 @@ Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
@@ -19706,7 +15277,6 @@ Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
@@ -19714,7 +15284,6 @@ Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
@@ -19722,7 +15291,6 @@ Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
@@ -19730,7 +15298,6 @@ Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
@@ -19738,7 +15305,6 @@ Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
@@ -19746,7 +15312,6 @@ Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
@@ -19754,7 +15319,6 @@ Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
@@ -19762,7 +15326,6 @@ Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
@@ -19770,7 +15333,6 @@ Usage: ln(x)</comment>
         <translation>in</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
@@ -19778,7 +15340,6 @@ Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
@@ -19786,7 +15347,6 @@ Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
@@ -19794,7 +15354,6 @@ Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
@@ -19802,7 +15361,6 @@ Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
@@ -19810,7 +15368,6 @@ Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
@@ -19818,7 +15375,6 @@ Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
@@ -19826,7 +15382,6 @@ Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
@@ -19834,7 +15389,6 @@ Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
@@ -19842,7 +15396,6 @@ Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
@@ -19850,109 +15403,91 @@ Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>M_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Variable_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Línea_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>AngleLine_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Arco_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>ElArco_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>RadiusArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Radius1ElArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Radius2ElArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Angle1Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Angle2Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Angle1ElArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Angle2ElArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Angle1Spl_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Angle2Spl_</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>C1LengthSpl_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>C2LengthSpl_</translation>
@@ -19961,17 +15496,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation>&lt;b&gt;Trazado de curva&lt;/b&gt;: seleccione siete o más puntos</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation>&lt;b&gt;Trazado de curva&lt;/b&gt;: seleccione más puntos para completar el  segmento</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Trazado de curva&lt;/b&gt;: seleccione siete o más puntos, presione &lt;b&gt;ENTER&lt;/b&gt; para finalizar la creación</translation>
     </message>
@@ -19979,7 +15511,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation>&lt;b&gt;Intersección Curva y Eje &lt;/b&gt;: ángulo = %1°, mantenga presionado &lt;b&gt;SHIFT&lt;/b&gt; para fijar el próximo ángulo recto o su mitad. Presione &lt;b&gt;ENTER&lt;/b&gt; para finalizar la creación </translation>
     </message>
@@ -19987,7 +15518,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Punto a Distancia y Ángulo&lt;/b&gt;: ángulo = %1°, longitud = %2%3; Mantenga presionada la tecla &lt;b&gt;SHIFT&lt;/b&gt; para fijar el próximo ángulo recto o su mitad. Presione &lt;b&gt;ENTER&lt;/b&gt; para finalizar la creación</translation>
     </message>
@@ -19995,7 +15525,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Intersección Línea y Eje&lt;/b&gt;: ángulo = %1°, mantenga presionado &lt;b&gt;SHIFT&lt;/b&gt; para fijar el próximo ángulo recto o su mitad. Presione &lt;b&gt;ENTER&lt;/b&gt; para finalizar la creación de la herramienta</translation>
     </message>
@@ -20003,12 +15532,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation>Longitud = %1%2, ángulo = %3°, &lt;b&gt;Shift&lt;/b&gt; para fijar el próximo ángulo recto o su mitad &lt;b&gt;Clic del ratón&lt;/b&gt; - para finalizar la selección de una posición</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation>Longitud = %1%2, ángulo = %3°, ángulo de rotación = %4° Mantenga presionado &lt;b&gt;SHIFT&lt;/b&gt;para fijar el próximo ángulo recto o su mitad,&lt;b&gt;CTRL&lt;/b&gt; - cambie el punto de origen de la rotación, &lt;b&gt; clic del ratón&lt;/b&gt; - terminar la creación</translation>
     </message>
@@ -20016,7 +15543,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation>Ángulo de rotación = %1°, mantenga presionado &lt;b&gt;SHIFT&lt;/b&gt; para fijar el próximo ángulo recto o su mitad, &lt;b&gt;clic del ratón&lt;/b&gt; - finalizar la creación</translation>
     </message>
@@ -20024,7 +15550,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation>Mantenga presionada la tecla &lt;b&gt;SHIFT&lt;/b&gt;para fijar el próximo ángulo recto o su mitad</translation>
     </message>
@@ -20032,17 +15557,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Trazado de Curva&lt;/b&gt;: seleccione tres o más puntos</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Trazado de Curva&lt;/b&gt;: seleccione tres o más puntos, presione &lt;b&gt;ENTER&lt;/b&gt; para finalizar la creación</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation>Utilice &lt;b&gt;SHIFT&lt;/b&gt;para fijar el próximo ángulo recto o su mitad</translation>
     </message>
@@ -20050,47 +15572,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>DEPURAR:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>ADVERTENCIA:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>CRÍTICO:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>INFORMACIÓN:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation>Advertencia</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation>Error Crítico</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation>Error Fatal</translation>
     </message>
@@ -20098,47 +15611,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>DEPURAR:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>ADVERTENCIA:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>CRÍTICO:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>INFORMACIÓN:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation>Advertencia</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation>Error Crítico</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation>Error Fatal</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>Tietoja Seamly2Dsta</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Kotisivu: %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Oletus selaimen aukaiseminen epäonnistui</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Käännetty %3 klo %2 {1 ?}</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Jäsentämis virhe tiedostossa. Ohjelma lopetetaan.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Väärä id. Ohjelma lopetetaan.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Arvoa ei voi muuttaa. Ohjelma lopetetaan.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Tyhjä parametri. Ohjelma lopetetaan.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Väärä id. Ohjelma lopetetaan.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Joku on vialla!!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Jäsentämis virhe tiedostossa. Ohjelma lopetetaan.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Väärä id. Ohjelma lopetetaan.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Arvoa ei voi muuttaa. Ohjelma lopetetaan.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Tyhjä parametri. Ohjelma lopetetaan.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Väärä id. Ohjelma lopetetaan.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Joku on vialla!!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Käännös versio: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Oletus selaimen aukaiseminen epäonnistui</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Käännetty %3 klo %2 {1 ?}</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Kotisivu: %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Valitse viivan toinen piste</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Säde ei voi olla negatiivinen</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Yhtäsuuret kulmat</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Keskipiste:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Säde ei voi olla negatiivinen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Keskipiste:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Valiste kulman toinen piste</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Valitse kulman kolmas piste</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation type="unfinished">Lista pisteistä</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Polku:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Valitse Akselipiste</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation>Keskipiste:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Säde ei voi olla negatiivinen</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished">Yhtäsuuret kulmat</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Valitse viivan ensimmäinen piste</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Valitse viivan toinen piste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished">Polku</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Saumavara</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Leveys:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished">Oletus</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished">Tyyppi</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Käännä päinvastoin</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Ei voitu luoda dataa somittelun luomiseen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Valitse toinen piste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Viiva_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Ensimmäinen viiva</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Toinen viiva</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Valitse ensimmäisen viivan toinen piste</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Valitse toisen viivan ensimmäinen piste</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Valitse toisen viivan toinen piste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Viivan ensimmäinen piste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Valitse viivan toinen piste</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Valitse Akselipiste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Akselipiste</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Viivan toinen piste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Mitat</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Keskipiste</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Mittayksiköt:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Senttimetriä</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Tuumaa</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Valitse viivan toinen piste</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Kaavan kuvaus</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Pituudet ja koot</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Kaikki pituudet (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Kaikki koot (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Korkeus:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation type="unfinished">nimetön</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation type="unfinished">Polku:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Kaava</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Valitse kaaren keskipiste</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Valitse viivan toinen piste</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Kaava</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Asetukset</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Asetukset</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Valitse viivan ensimmäinen piste</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Valitse viivan toinen piste</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Arkin koordinaatit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Koordinaatit</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Alkupiste</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Ensimmäinen piste</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Toinen piste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Valitse käyrän viimeinen piste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Lista pisteistä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Valitse käyrän piste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Polku:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Tyhjä sarake</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Arvo ei voi olla 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Jäsentämis virhe: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Ensimmäinen piste</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Toinen piste</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Valitse akselin toinen piste</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Valitse ensimmäinen piste</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Valitse toinen piste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Virheellinen matemaattinen kaava</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Peru</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Korjaa matemaattinen kaava</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Peru</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">Laskettu arvo</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Matemaattinen kaava</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Yksityiskohdat</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Viiva</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Kulma</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Käyrä</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Kaari</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Säde</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Tyhjä sarake</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Jäsentämis virhe: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Työkalu</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Muuta matemaattista kaavaa</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Mitat</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Lisää muuttuja kaavaan</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Piilota tyhjät mittaukset</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Viivan pituus</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Käyrän pituus</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Viiva kulma</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished">Muokkaa</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished">Tiedostoa ei voitu tallentaa</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">Tiedostovirhe.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Koko</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Polku:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - Alkupiste</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Kaari_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished">Muokkaa</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">Historia</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Alkupiste</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Kaari_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Kuvaus</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">pikseliä</translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Leveys:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Korkeus:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished">Varmista poistaminen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Haluatko todella poistaa?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Käännä päinvastoin</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Ohjelma on saatavilla sellaisena kuin se on ilman mitään takuita, mukaan lukien suunnitelun, kaupallisuuden tai tiettyyn tarkoitukseen sopivuuden suhteen.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished">Keskipiste:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Säde ei voi olla negatiivinen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Näytä koko laskenta ikkunassa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Säde ei voi olla negatiivinen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Mallit:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Leveys:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Korkeus:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Käännä kaavaa</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Käännä</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>aste</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Kolme ryhmää: iso, keskikokoinen, pieni</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Kaksi ryhmää: iso, pieni</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>Laskeva alue</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Senttimetriä</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Tuumaa</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Pikseliä</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6623,84 +5191,67 @@ Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6708,32 +5259,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6741,2660 +5286,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Työkaluja pisteiden luomiseen.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Piste</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Työkaluja viivojen luomiseen.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Viiva</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Työkaluja käyrien luomiseen.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Käyrä</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Työkaluja kaarien luomiseen.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Kaari</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;Tiedosto</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Apua</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Mitat</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Uusi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Uusi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Luo uusi kaava</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Avaa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Avaa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Avaa tiedosto kaavan kanssa</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Talenna</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Tallenna</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Tallenna kaava</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Tallenna &amp;nimellä...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Tallenna tallentamaton kaava</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Yksityiskohdat</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Osointin työkalut</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Historia</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>Tietoja &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;Tietoja Seamly2Dsta</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>L&amp;opeta</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Ilmoita ohjelmistovirheestä</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Näytä online apu</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>Tietoja Qt:stä</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Talenna nimellä</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Tiedostoa ei voitu tallentaa</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Avaa tiedosto</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Virhe tiedoston jäsennyksessä.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Virhe: arvoa ei voi muuntaa.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Virhe: tyhjä parametri.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Virhe: väärä id.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Virhe tiedoston (std::bad_alloc) jäsennyksessä.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Väärä id.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>Tiedosto tallennettu</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>nimetön.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>Kaavaa on muutettu
 Haluatko tallentaa muutokset?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Peru</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Tee uudelleen</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>Tämä tiedosto on jo avattu toiseen ikkunaan.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Väärät yksiköt.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>Tiedosto ladattu</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Seamly2D ei sulkeutunut oikein. Haluatko uudelleen avata tiedostot (%1)?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Avaa uudelleen tiedosto.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Sommittelu</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation type="unfinished">Korkeus:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation type="unfinished">Yksilölliset mitat</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Kaava tiedostot</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished">Laskettu arvo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished">Matemaattinen kaava</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished">Muokkaa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">Tietoja Seamly2Dsta</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">nimetön</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>kaava</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished">Oletus</translation>
     </message>
@@ -9402,86 +7288,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Tiedoston &apos;%1&apos; luonti epäonnistui! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Kriittinen virhe!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Ei voitu luoda dataa somittelun luomiseen</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Kaava</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9489,148 +7355,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Uusi</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Talenna</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Talenna nimellä</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9638,123 +7474,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
@@ -9763,18 +7578,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9782,37 +7589,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Mittayksiköt:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9820,12 +7620,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9833,7 +7631,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9841,7 +7638,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9849,7 +7645,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9857,7 +7652,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9865,7 +7659,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9873,7 +7666,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9881,52 +7673,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Yksilö</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Senttimetriä</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Tuumaa</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9934,87 +7716,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10022,887 +7787,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished">Oletus</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Leveys:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished">Korkeus:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished">Tyyppi</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Käännä päinvastoin</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Asetukset</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Jäsentämis virhe: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Polut</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10910,218 +8422,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11129,27 +8589,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11157,77 +8612,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11235,139 +8675,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11375,62 +8770,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished">Valitse piste Y arvolle (vaakasuora)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
@@ -11438,316 +8821,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished">Väli:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished">Kieli</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation type="unfinished">Senttimetriä</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished">Tuumaa</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished">Peru</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11755,582 +9072,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Piste</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Viiva</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Käyrä</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Kaari</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Yksityiskohdat</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished">Sommittelu</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished">Graafinen tulos</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Leveys:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished">Tyyppi</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Polku</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation type="unfinished">Oletus</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished">Muokkaa</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished">Avaa kansio</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12338,272 +9487,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Saumavara</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Leveys:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Polut</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Leveys</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12611,7 +9690,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>Käännetty käyttäen Qt %1 (%2, %3 bit)</translation>
     </message>
@@ -12619,155 +9697,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Aloita luomalla uusi kaava.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>m</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>tuuma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Ominaisuus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation>pikseliä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished">Ei voi muuntaa toUInt parametriä</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished">Ei voi muuntaa toBool parametriä</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished">Tyhjä parametri</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished">Ei voinut muuntaa toDouble parametriä</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished">Väärä parametri id. Täytyy olla id &gt; 0.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12775,15 +9822,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
@@ -12792,217 +9835,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Odottomaton ilmimuoto &quot;$TOK$&quot;  paikassa $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Sisäinen virhe</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Väärä funktio, muuttuja tai vakio nimeltä:  &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Väärä binäärinen operaatio: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Väärä infix operaattori: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Väärä postfix operaattori: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Väärä osoitin palautus funktioon.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>Kaava on tyhjä.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Väärä osoitin muuttujaan.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Yllättävä operaattori &quot;$TOK$&quot; kohdassa $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Yllättävä lopetus kaavalle kohdassa $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Yllättävä argumentin erotin kohdassa $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Yllätävä sulku &quot;$TOK$&quot; kohdassa $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Yllättävä funktio &quot;$TOK$&quot; kohdassa $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Yllättävä arvo &quot;$TOK$&quot; kohdassa $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Yllättävä muuttuja &quot;$TOK$&quot; kohdassa $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Funktion argumentteja käytetty ilman funktiota (kohdassa $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Sulkeet puuttuvat</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Liian monta parametriä funktiossa &quot;$TOK$&quot; kohdassa $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Liian vähän parametrejä funktiossa &quot;$TOK$&quot; kohdassa $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Nollalla jakaminen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Domain virhe</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Nimikonflikti</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>Väärä operaattorin prioriteetti arvo (täytyy olla suurempi tai yhtä suuri kuin nolla).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Käyttäjän asettama binääri operaattori &quot;$TOK$&quot; on konfliktissa ohjelman operaattorin kanssa.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Yllättävä merkki kohdassa $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Tekstistä puuttuu sulku kohdassa $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>Tekstityypin funktio kutsuttu ei-teksti muuttujalla.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>Tekstityyppiä käytetty numeerisen argumentin sijaan.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Yllättävä operaattori &quot;$TOK$&quot; kohdassa $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>Funktion tulos on tekstiä.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Jäsentämis virhe.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>Desimaalierotin on sama funktion argumentti erottimen kanssa.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>&quot;$TOK$&quot; operaattorin edessä pitää olla sulku.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>If-then-else operattorista puuttuu else osa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Kaksoispiste väärässä paikassa $POS$</translation>
@@ -13011,7 +10018,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13019,7 +10025,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13027,12 +10032,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13040,7 +10043,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13048,7 +10050,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13056,7 +10057,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13064,88 +10064,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Kieli</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Korkeus:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13153,52 +10135,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished">Tyyppi</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Polku</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished">Oletus</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished">Muokkaa</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished">Avaa kansio</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13206,102 +10178,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished">Mittayksiköt:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Senttimetriä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Tuumaa</translation>
     </message>
@@ -13309,92 +10260,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished">Mittayksiköt:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Senttimetriä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Tuumaa</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13402,12 +10334,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13415,1071 +10345,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Uusi</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished">Avaa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Talenna</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Talenna nimellä</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished">Muokkaa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished">Peru</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Mitat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Piste</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Viiva</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Yksityiskohdat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished">Sommittelu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">Historia</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14487,12 +11200,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14500,42 +11211,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14543,7 +11246,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14551,7 +11253,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14559,818 +11260,625 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Matemaattinen kaava</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Alkuarvo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>Koossa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>Pituudessa</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Yksityiskohdat</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Nmi:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Polku:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Etunimi:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Sukunimi:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Ikkuna</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Mitat</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Talenna</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>Tietoja &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Uusi</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>Tämä tiedosto on jo avattu toiseen ikkunaan.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Tiedostovirhe.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Tiedostoa ei voitu tallentaa</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Talenna nimellä</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Jäsentämis virhe: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Yksilölliset mitat</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>nimetön</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Tyhjä sarake</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Arvo</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Avaa tiedosto</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>Mies</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>Nainen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>Tietoja Qt:stä</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation type="unfinished">Korkeus:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation>Kaava tiedostot</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15378,7 +11886,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15386,22 +11893,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15409,22 +11912,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15432,47 +11931,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">Ensimmäinen piste</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Toinen piste</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Viiva_</translation>
     </message>
@@ -15480,47 +11970,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Unioni työkalu</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Valitse toinen piste</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Valitse yksikäsitteinen piste</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished">Valitse reunapiste</translation>
     </message>
@@ -15528,7 +12009,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15536,17 +12016,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Älä kysy uudelleen</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Älä kysy &amp;uudelleen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>Älä näytä &amp;uudelleen</translation>
     </message>
@@ -15554,57 +12031,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Versiotietoja ei voitu palattaa.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>Liian monta merkkiä &lt;%1&gt; tiedostossa.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Versio &quot;%1&quot; väärä.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Versio &quot;0.0.0&quot; väärä.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Väärä versio. Pienin tuettu versio on %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Väärä versio. Suurin tuettu versio on %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Virhe: id ei ole yksikäsitteinen.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>Versiota ei voitu vaihtaa.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation type="unfinished">Yllättävä versio &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15612,7 +12078,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15620,22 +12085,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15643,13 +12104,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
@@ -15657,23 +12115,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>Työkalua ei löydy taulukosta.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15681,7 +12134,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15689,12 +12141,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
@@ -15702,283 +12152,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Varmista poistaminen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Haluatko todella poistaa?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished">Muutit väärää kaavaa</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15986,302 +12379,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Kulma</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Kaavan luonti ohjelma.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Kaava tiedosto.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16289,43 +12622,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16333,55 +12657,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>Objektia ei löydy</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation>Ei voi luoda objektia</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation>Objektia ei löydy. Tyypin yhteensopimattomuus.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16389,12 +12700,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation>Pisteitä ei ole tarpeeksi splinin luomiseen.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation>Tämä splini ei ole olemassa.</translation>
     </message>
@@ -16402,52 +12711,42 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>Tiedostoa %1 ei voitu avata:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Skeematiedostoa %1 ei voitu avata.
 %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation>Tarkastus virhe tiedostossa %3 rivillä %1 kohdassa %2</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation>Jäsentämis virhe tiedostossa %3 rivillä %1 kohdassa %2</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation>Solmua ei voitu palauttaa</translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>Tämä id ei ole yksikäsitteinen.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16455,27 +12754,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16483,7 +12777,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16491,11 +12784,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
@@ -16503,7 +12791,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16511,7 +12798,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16519,7 +12805,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16527,12 +12812,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>Tosi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>Epätosi</translation>
     </message>
@@ -16540,12 +12823,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Kansio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Avaa Tiedosto</translation>
     </message>
@@ -16553,335 +12834,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Virhe tiedoston jäsennyksessä.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Virhe: arvoa ei voi muuntaa.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Virhe: tyhjä parametri.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Virhe: väärä id.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Virhe tiedoston (std::bad_alloc) jäsennyksessä.</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Virhe luodessa tai päivittäessä yksi piste</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Virhe luodessa tai päivittäessä päätepiste</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Virhe luodessa tai päivittäessä piste viivalla</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Virhe luodessa tai päivittäessä olkapääpiste</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation>Virhe luodessa tai päivittäessä normaalipiste</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Virhe luodessa tai päivittäessä jakopiste</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Virhe luodessa tai päivittäessä kontaktipiste</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation>Virhe luodessa tai päivittäessä mallinnuspiste</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Virhe luodessa tai päivittäessä pituus</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Virhe luodessa tai päivittäessä kolmio</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation>Virhe luodessa tai päivittäessä leikatessa splinipiste</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation>Virhe luodessa tai päivittäessä leikatessa polun piste</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation>Virhe luodessa tai päivittäessä kaaren leikkauspiste</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation>Virhe luodessa tai päivittäessä akselin ja viivan leikkauspiste</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation>Virhe luodessa tai päivittäessä akselin ja käyrän leikkauspiste</translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Virhe luodessa tai päivittäessä viivaa</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Virhe luodessa tai päivittäessä yksinkertaista viivaa</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Virhe luodessa tai päivittäessä käyräpolku</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation>Virhe luodessa tai päivittäessä yksinkertaista mallinnus käyrää</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation>Virhe luodessa tai päivittäessä mallinnus käyrää</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Virhe luodessa tai päivittäessä yksinkertaista kaarta</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation>Virhe luodessa tai päivittäessä mallinnuskaarta</translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16889,17 +13081,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16907,12 +13096,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16920,14 +13107,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>Pisteitä ei ole tarpeeksi splinin luomiseen.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>Tämä splini ei ole olemassa.</translation>
     </message>
@@ -16935,17 +13118,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Kulma</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
@@ -16953,27 +13133,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16981,37 +13156,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17019,7 +13187,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
@@ -17027,12 +13194,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17040,32 +13205,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Kaari</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17073,18 +13232,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Käyrä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17092,18 +13247,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Käyrä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17111,7 +13262,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
@@ -17119,28 +13269,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17148,17 +13292,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Kulma</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
@@ -17166,12 +13307,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Kulma</translation>
     </message>
@@ -17179,7 +13318,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
@@ -17187,27 +13325,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Kulma</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17215,17 +13348,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Kulma</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
@@ -17233,7 +13363,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17241,12 +13370,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">Viivan ensimmäinen piste</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Viivan toinen piste</translation>
     </message>
@@ -17254,27 +13381,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Keskipiste</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Kulma</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17282,714 +13404,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Alkupiste</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Keskipiste:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Koordinaatit</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Viiva</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">Ensimmäinen viiva</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Toinen viiva</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Origin point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Kaari_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Viiva_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Keskipiste</translation>
     </message>
@@ -17997,12 +13803,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18010,17 +13814,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Kulma</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
@@ -18028,12 +13829,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18041,12 +13840,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18054,12 +13851,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18067,17 +13862,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Pituus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Kulma</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
@@ -18085,1552 +13877,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>m</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>tuuma</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished">SplPath</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Viiva_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">KulmaViiva_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Kaari_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19639,17 +15174,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19657,7 +15189,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19665,7 +15196,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19673,7 +15203,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19681,12 +15210,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19694,7 +15221,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19702,7 +15228,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19710,17 +15235,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Käyräpolku&lt;/b&gt;: valitse ainakin kolme pistettä</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19728,47 +15250,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19776,47 +15289,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>À propos de Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Site web : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Impossible d&apos;ouvrir votre navigateur par défaut</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Compilé le %1 à %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Vérifier les Mises à Jour</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished">inconnu</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>Ajouter groupe</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>Ajouter un objet</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished">Point :</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Erreur d&apos;interprétation du fichier. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Erreur d&apos;identifiant. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Erreur : valeur non convertissable. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Erreur : paramètre vide. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Erreur : mauvais identifiant. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Quel que chose ne va pas!!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Erreur dans l&apos;interprétation: %1 va quitter.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Erreur : %1. Fin du programme.</translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Erreur d&apos;interprétation du fichier. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Erreur d&apos;identifiant. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Erreur : valeur non convertissable. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Erreur : paramètre vide. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Erreur : mauvais identifiant. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Quelque chose ne va pas!!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Erreur dans l&apos;interprétation: le programme %1 va quitter.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Erreur d&apos;exception : %1. Fin du programme.</translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation>L&apos;éditeur de mesures Seamly2D.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation>Le fichier de mesures.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation>La hauteur de base</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation>La taille de base</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation>Choisir l&apos;unité du patron: cm, mm, pouces.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation>L&apos;unité du patron</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation>Unité de travail invalide: doit être cm, mm ou pouces.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation>Ne peut être à l&apos;écoute des connexions entrantes de %1</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation>Le mode test ne supporte pas l&apos;ouverture de plusieurs fichiers.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation>Merci de choisir un fichier.</translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation>Ouverture avec la taille de base. Valeur attendue: %1cm.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation>Stature de base incorrecte. Doit être: %1cm.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation>Taille de base incorrecte. Doit être: %1cm.</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation>Ouverture avec la stature de base. Valeur attendue: %1cm.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation>À utiliser pour tests. Exécutez le programme et ouvrir un fichier sans le voir dans la fenêtre principale.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>supprimer groupe</translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>Outil de suppression</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>Outil de suppression</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">A propos de SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished">Version de SeamlyMe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Version compilée: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished">Ce programme fait partie du projet Seamly2D.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Vérifier les Mises à Jour</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Impossible d&apos;ouvrir votre navigateur par défaut</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Compilé le %1 à %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Site web : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished">inconnu</translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Choisir le deuxième point d&apos;une ligne</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Editer longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>Premier point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>Premier point de la ligne</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Deuxième point:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Deuxième point de la ligne</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>La valeur en radians ne peut pas être négative</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Les angles valent</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Editer le rayon</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Editer le premier angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Editer le deuxième angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Rayon:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>Premier angle:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Deuxième angle:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Point central:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Choisir le point central de l&apos;arc</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Couleur:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul entier dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Editer le rayon</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Editer le premier angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Éditer la longueur de l&apos;arc</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Le rayon ne peut pas être négatif</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>La longueur ne peut pas être égale à 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Rayon:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>Premier angle:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Point central:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Couleur:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Choisir le deuxième point de l&apos;angle</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Choisir le troisième point de l&apos;angle</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Editer longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>Premier point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Deuxième point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Troisième point:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Couleur :</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Nom :</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>Premier point :</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Deuxième point :</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Troisième point :</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Quatrième point:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Choisir le deuxième point de la courbe</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Choisir le troisième point de la courbe</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Choisir le quatrième point de la courbe</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>Spline invalide</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Point :</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>Liste de points</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Couleur :</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Nom :</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation>Trajectoire de spline invalide</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Chemin:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Montrer le calcul complet dans une boite de dioalogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Choisir un point d&apos;axe</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Éditer l&apos;angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Point d&apos;axe :</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Courbe:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Éditer longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Arc:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Éditer longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Courbe:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Éditer longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Courbe:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation>Rayon1 :</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation>Rayon2 :</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation>Premier angle :</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation>Deuxième angle :</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation>Angle de rotation :</translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation>Point central :</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation>Choisir le point central de l&apos;arc</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation>Couleur :</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Le rayon ne peut pas être négatif</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Les angles se valent</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation>Modifier rayon1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation>Modifier rayon2</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Modifier le premier angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Modifier le deuxième angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation>Modifier l&apos;angle de rotation</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Éditer l&apos;angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Éditer longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Point de départ:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Options d&apos;exportation</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>Avec en-tête</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation>Codec :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Séparateur</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation>Tabulation</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>Virgule</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>Point-virgule</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Espace</translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Choisir le premier point de la ligne</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Choisir le deuxième point de la ligne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Point de départ:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished">Chemin</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished">Chemin sans nom</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished">Créer un nom pour votre chemin</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished">Prêt!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Marge de couture</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Largeur :</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Assistant Formule</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Valeur</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished">Nœuds</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished">Nœud:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished">Avant:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished">Retourner à la largeur par défaut</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished">Après:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished">Repères de montage</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished">Repère de montage :</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">Longueur:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Inverser</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Marge de couture actuelle</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Editer la largeur de la marge de couture</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Editer la largeur de la marge de couture avant</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Editer la largeur de la marge de couture après</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished">Chemin interne</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished">Personnaliser la marge de couture</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished">Vous avez besoin de plus de points!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished">Le premier point de la &lt;b&gt;marge de couture personnalisée&lt;/b&gt; ne peut être identique au dernier!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Vous avez des points en double!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Impossible de préparer les données pour la création du plan de coupe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Créer un plan de coupe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation>Tri des pièces: %1 à %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Choisir le deuxième point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>Premier point:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Deuxième point:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Ligne_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Première ligne</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Deuxième ligne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Choisir le deuxième point de la première ligne</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Choisir le premier point de la deuxième ligne</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Choisir le deuxième point de la deuxième ligne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>Premier point:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Deuxième point:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Premier point de la ligne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Choisir le deuxième point d&apos;une ligne</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Choisir origine de l&apos;axe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Origine de la droite</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Deuxième point de la ligne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Éditer l&apos;angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Point d&apos;axe :</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Mesures</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished">Rechercher:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished">Rechercher</translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished">Point d&apos;axe :</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished">Type d&apos;axe :</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Axes verticaux</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Axes horizontaux</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished">Point de la première ligne:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation>Suffixe :</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation>Editer l&apos;angle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Editer la longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished">Point d&apos;origine:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Point central</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Unités:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Centimètres</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Pouces</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Nom unique de pièce de patron</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Choisir un nom unique pour la pièce de patron.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>Nouveau patron</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished">Millimètres</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul entier dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Choisir le second point de la ligne</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Editer longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>Premier point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Deuxième point:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Description du patron</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Longueurs et tailles</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Toutes les longueurs (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Toutes les tailles (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Taille et stature par défaut</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Personnalisé</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Hauteur:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Taille:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Sécurité</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Ouverture en lecture seule</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation>Menu contextuel pour edition</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>Image absente</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Effacer image</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Changer d&apos;image</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Enregistrer image</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Voir image</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation>Image du patron</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Images</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>sans titre</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Chemin:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Explorer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;vide&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>Fichier non sauvegardé.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Révéler dans le finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Nom du patron :</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Numéro de patron :</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Nom de Société/Modéliste :</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Nom du client :</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Patron</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Choisir un arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Point de la tangente:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Arc:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Prendre:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul entier dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Choisir le point central de l&apos;arc</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Choisir le second point d&apos;une ligne</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Editer le rayon</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Rayon:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation>Centre de l&apos;arc:</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation>Choisir un deuxième arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>Premier arc:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Deuxième arc:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Prendre:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>Première courbe:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Seconde courbe:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Choisir une seconde courbe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Patron</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished">Général</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Rotation</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Suffixe:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation>Editer l&apos;angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Préférences</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Configuration</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul entier dans une boite de dialogue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Sélectionnez le premier point de la ligne</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Choisir le second point d&apos;une ligne</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Editer longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>Premier point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Deuxième point:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Troisième point:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Coordonnées sur la feuille</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Coordonnées</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Point de base</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Premier point</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Deuxième point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Choisir le dernier point de la courbe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Couleur:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>Premier point :</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Deuxième point :</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Nom :</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>Spline invalide</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul complet dans une boite&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation>Editer le premier point de contrôle d&apos;angle</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation>Editer le second point de contrôle d&apos;angle</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation>Editer le premier point de contrôle de longueur</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation>Editer le second point de contrôle de longueur</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation>Une longueur ne peut être négative</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Liste des points</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Choisir un point sur la trajectoire de la courbe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Couleur:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Point :</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation>Premier point de contrôle</translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation>Second point de contrôle</translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Nom :</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation>Trajectoire de spline invalide</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Longueur:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Assistant Formule</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voir le calcul complet dans une boite&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation>Editer le premier point de contrôle d&apos;angle</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation>Editer le premier point de contrôle d&apos;angle</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation>Editer le premier point de contrôle de longueur</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation>Editer le second point de contrôle de longueur</translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation>Une longueur ne peut être négative</translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation>Non utilisé</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Chemin:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Champ vide</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>La valeur ne peut pas être 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Erreur d&apos;analyse : %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Premier point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Deuxième point</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation>Point le plus haut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation>Point le plus bas</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation>Point le plus à gauche</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation>Point le plus à droite</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation>Par longueur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation>Par points d&apos;intersections</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Choisir le deuxième point de l&apos;axe</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Choisir le premier point</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Choisir le deuxième point</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>Premier point:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Deuxième point:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation>Choisir le deuxième point de base</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation>Choisir le premier point de la pince</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation>Choisir le deuxième point de la pince</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation>Choisir le troisième point de la pince</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Formule incorecte</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Annuler</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Corriger la formule</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Annuler</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Erreur pendant le calcul. Essayer d&apos;annuler la précedente opération ou modifier la formule.</translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filtrer la liste par mot-clefs</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">Valeur calculée</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Formule</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished">Déplacer la mesure vers le haut</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished">Déplacer la mesure vers le bas</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Assistant Formule</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Valeur calculée:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished">Formule:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished">Description:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished">Actualiser</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Ligne</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Courbe</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Rayon</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished">Champ vide.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Champ vide</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Valeur</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Erreur d&apos;analyse : %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Outil</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Modifier la formule</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Mesures</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished">Fonction</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished">Formule:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Valeur</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Insérer une variable dans la formule</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Masquer les mesures vides</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished">Nom complet</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filtrer la liste par mot-clefs</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Longueur de ligne</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Longueur de courbe</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Angle de Ligne</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished">Rayon de l&apos;arc</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished">Angle de la courbe</translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Nom unique de pièce de patron</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">Erreur de fichier.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Taille</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Hauteur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished">Tissu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished">Lin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished">Interfaçage</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished">Interlignage</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished">Coupure</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Chemin:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished">Le dossier de destination</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished">Emplacement du dossier de destination</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished">Sélectionnez un emplacement pour le dossier de destination</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished">Parcourir...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished">Format du fichier:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished">Nom du fichier:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished">Nom du fichier de base</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished">Droite:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished">Gauche:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished">Haut:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished">Bas:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished">Format du papier</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished">Le nom du fichier de base ne correspond pas à une expression régulière.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished">Sélectionner un dossier</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished">Nombre au delà de la plage de valeur.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished">Format sélectionné, absent.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation>Flux de téléchargement interrompu: %1.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished">Groupes</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - Point de départ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">Historique</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished">Rechercher:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Point de base</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Description du patron</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished">Unité:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation>Aspect de la serrure:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Largeur :</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished">Confirmer la suppression</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Voulez vous vraiment supprimer?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Inverser</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished">Repère de montage</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Ce programme est distribué dans l&apos;espoir qu&apos;il sera utile, mais SANS AUCUNE GARANTIE ; sans même une garantie implicite de COMMERCIALITÉ ou DE CONFORMITÉ A UNE UTILISATION PARTICULIÈRE.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished">Prendre:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Point de la tangente:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Rayon:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Valeur</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished">Choisir le centre du cercle</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished">Editer le rayon</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished">Prendre:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation>Centre:</translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Rayon:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Valeur</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Assistant Formule</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished">Choisir le centre du deuxième cercle</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished">Editer le rayon du premier cercle</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished">Editer le rayon du deuxième cercle</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Modèles:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Largeur :</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Hauteur:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Tourner pièce en cours</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Tourner</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>degré</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Trois groupes : grand, moyen, petit</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Deux groupes : grand, petit</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>Surface décroissante</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centimètres</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Pouces</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Points</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Couper automatiquement la longueur non utilisée</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Rassembler les pages (si possible)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation>Largeur d&apos;espacement :</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Sauvegarder la longueur de la feuille</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Format du papier</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Gauche:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Droite:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Haut:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Bas:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Mauvais champs.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6626,84 +5194,67 @@ Apply settings anyway?</source>
 ⇥Ordre décroissant = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation>Options du plan de coupe</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation>Longueur de décalage:</translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation>Règle pour choisir la pièce suivante</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation>Diviser en bandes</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation>Multiplicateur</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation>Régle le multiplicateur pour la longueur de la plus grande pièce dans le plan de coupe.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation>Le choix d&apos;un format plus grand accélère la création.</translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Imprimante :</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation>Rien</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation>Texte</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished">Millimètres</translation>
     </message>
@@ -6711,32 +5262,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,2660 +5289,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Outils pour créer des points.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Point</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Outil pour créer des lignes.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Ligne</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Outil pour créer des courbes.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Courbe</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Outils pour créer des arcs.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Arc</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>Aid&amp;e</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Mesures</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nouveau</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Créer un nouveau patron</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Ouvrir</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Ouvrir un fichier de patron</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Sauver</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Enregistrer le patron</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Enregistrer &amp;sous...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Enregistrer le patron en cours</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Isolation</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Outil pointeur</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Historique</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>À propos de &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>À propos de &amp;Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Préférences</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>rapport de plantage</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Afficher l&apos;aide en ligne</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>À propos de Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Enregistrer sous</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>le fichier n&apos;a pas pu etre enregistré</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Ouvrir fichier</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Erreur d&apos;interprétation de fichier.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Erreur : valeur non convertissable.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Erreur : paramètre vide.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Erreur : mauvais id.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Erreur d&apos;interprétation de fichier.(std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Mauvais id.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>Fichier sauvegardé</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>sanstitre.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>Le patron a été changé.
 Voulez-vous sauvegarder les changements?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Annuler</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Rétablir</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>Ce fichier est déjà ouvert dans une autre fenêtre.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Mauvaises unités de mesure.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>Fichier chargé</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Seamly2D ne s&apos;est pas fermé correctement. Voulez vous ré-ouvrir le fichier %1 que vous aviez ouvert?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Re-ouvrir fichier.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Plan de coupe</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation>Imprimer</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation>Imprimer PDF trié et assemblé</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation>Découpe et imprime le plan de coupe en pages plus petite (imprimantes courantes)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation>Aperçu d&apos;impression</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation>Enregistre l&apos;aperçu du plan de coupe original</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation>Exporter en...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation>Mode plan de coupe</translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation>Changements non enregistrés</translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation>Mesures chargées</translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation>Impossible d&apos;exporter un fichier vide.</translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation>Le tableau de mesure contient une ou plusieur valeurs connuse vides.</translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation>Le tableau de mesure est de format inconnu.</translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation>Les tableaux de mesure ne correspondent pas.</translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation>Impossible de synchroniser les mensurations.</translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation>Impossible de mettre à jour les mensurations.</translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation>Le tableau de mesure &apos;%1&apos; est introuvable.</translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation>Lecture du tableau de mesure</translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation>Valeur de taille non supportée &apos;%1&apos; pour ce patron.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation>Impossible de régler la taille. le fichier n&apos;a pas été ouvert.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation>La méthode %1 n&apos;a aucun effet dans ce mode d&apos;interface</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation>Valeur de taille &apos;%1&apos; non supportée pour ce patron.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation>Impossible de régler la stature. le fichier n&apos;a pas été ouvert.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation>Merci de choisir un fichier.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation>Imprime le plan de coupe original</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation>Aperçu du PDF trié et assemblé</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation>Imprime le plan de coupe trié et assemblé</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation>Mensurations oubliées</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation>Impossible d&apos;oublier les mensurations. Certaines d&apos;entre elles sont utilisées dans le patron courant.</translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>Nouveau patron</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation>Ouvrir le patron</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation>Créer/éditer un tableau de mesure</translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>Sauvegarder ...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Ne pas sauvegarder</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Verrouiller le fichier (en lecture seule)</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Le fichier est déjà ouvert dans une autre fenêtre. Ignorer pour continuer (déconseillé car pouvant causer une corruption de données).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Le fichier en lecture seule ne peut être créer par manque de permission. Ignorer pour continuer (déconseillé car pouvant causer une corruption de données).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Une erreur inconnue s&apos;est produite, par exemple une partition pleine empêche d&apos;écrire le fichier en lecture seule. Ignorer pour continuer (déconseillé car pouvant causer une corruption de données).</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Le fichier en lecture seule ne peut être créer par manque de permission.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Une erreur inconnue s&apos;est produite, par exemple une partition pleine empêche d&apos;écrire le fichier en lecture seule.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation>Opérations</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation>Fermer le patron</translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation>Pointeur</translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation>Zoom par défaut</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Stature:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Taille :</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation>Le tableau de mesure &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt;est introuvable. Voulez-vous le rechercher?</translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation>Lecture seule</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation type="unfinished">Mesures individuelles</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Fichier de patron</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished">Valeur calculée</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished">Formule</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">À propos de Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished">K</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished">Exporter</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished">Images</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished">Point :</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">sans titre</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation type="unfinished">patron</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9405,86 +7291,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Création du fichier &apos;%1&apos; A échoué ! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Erreur critique!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation>Erreur d&apos;impression</translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation>Impossible de continuer car il n&apos;y a aucune imprimantes disponibles.</translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation>Non nommé</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation>Le plan de coupe est figée.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation>Le plan de coupe n&apos;a pas été mise à jour depuis la dernière modification du patron. Voulez-vous continuer ?</translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>La préparation des données pour la création du plan de coupe a échoué</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation>Impossible d&apos;utiiser l&apos;imprimante %1</translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation>Pour avoir un aperçu d&apos;un document multipages, toutes les feuilles doivent faire la même taille.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation>Pour imprimer un document multipages, toutes les feuilles doivent faire la même taille.</translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation>Les pages vont être tronquées du fait de la taille du papier de l&apos;imprimante.</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Patron</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9492,148 +7358,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished">Fichier</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Nouveau</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished">Ctrl+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished">Ctrl+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Imprimer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished">Ctrl+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Enregistrer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished">Ctrl+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Enregistrer sous</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished">Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Exporter vers CVS</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished">Ctrl+Q</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished">Aide</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished">K</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished">Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished">Ctrl+G</translation>
     </message>
@@ -9641,123 +7477,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished">Tout replier</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished">Tout déplier</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished">Tout cocher</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished">Tout décocher</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Hauteur directe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Largeur directe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Cambrure</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Main</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Pied</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Tête</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Circonférence et arc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Vertical</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Horizontal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Poitrine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Équilibre</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Bras</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Jambe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Entrejambe et montant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Hommes &amp; Tailleurs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Historiques &amp; Spécialisés</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Mesures de patronnage</translation>
@@ -9766,18 +7581,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation>Impossible de trouver la mesure &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation>Le nom de mesure est vide !</translation>
     </message>
@@ -9785,37 +7592,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished">Formulaire</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Unités:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9823,12 +7623,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation>Déplacer la première étiquette de la pince</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation>Déplacer la seconde étiquette de la pince</translation>
     </message>
@@ -9836,7 +7634,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9844,7 +7641,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation>Déplace l&apos;étiquette de point</translation>
     </message>
@@ -9852,7 +7648,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished">Déplace l&apos;étiquette de point</translation>
     </message>
@@ -9860,7 +7655,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation>Déplacer un point</translation>
     </message>
@@ -9868,7 +7662,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation>Déplacer la spline</translation>
     </message>
@@ -9876,7 +7669,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation>Déplacer le trajet de la spline</translation>
     </message>
@@ -9884,52 +7676,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>Nouveau fichier de mesures</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Type de mesures:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Unité:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Taille de base:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Hauteur de base:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Individuel</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Centimètres</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Pouces</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished">Millimètres</translation>
     </message>
@@ -9937,87 +7719,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished">Lettre</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished">Légal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished">Tabloïde</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished">Roulleau 24po / 60.96cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished">Rouleau de 30po / 76.20cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished">Rouleau de 36po / 91.44cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished">Rouleau de 42po / 106.68cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished">Rouleau de 44poin / 111.76cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished">Personnalisé</translation>
     </message>
@@ -10025,887 +7790,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished">La valeur Nom ne peut pas être vide</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished">Lettre :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished">Lettre de l&apos;élément de patron</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished">Placement:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished">Forbid piece be mirrored in a layout.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished">Tous les objets du chemin doivent se suivre dans le sens des aiguilles d&apos;une montre.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished">Prêt!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Largeur :</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Valeur</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Assistant Formule</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished">Nœuds</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished">Nœud:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished">Avant:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished">Retourner à la largeur par défaut</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished">Après:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished">Personnalisé</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Longueur:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished">Repère de montage :</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Inverser</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished">Repère de montage</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Options</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished">Résultat infini ou non défini</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished">La longueur doit être positive</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Erreur d&apos;analyse : %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Marge de couture actuelle</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Editer la largeur de la marge de couture</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Editer la largeur de la marge de couture avant</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Editer la largeur de la marge de couture après</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished">Droit-fil</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished">Vous avez besoin de plus de points!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Vous avez des points en double!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished">Vide</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished">Chemin principal</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished">Les deux</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished">Juste le devant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished">Juste l&apos;arrière</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Chemins</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation>Centre:</translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation>Haut à gauche:</translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation>Bas à droite:</translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation>Haut:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation>Bas:</translation>
     </message>
@@ -10913,218 +8425,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Marge de couture actuelle</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished">déplace l&apos;étiquette de pièce de patron</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished">redimensionne l&apos;étiquette de pièce de patron</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished">tourne l&apos;étiquette de pièce de patron</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished">déplace l&apos;étiquette d&apos;information du patron</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished">redimensionne l&apos;étiquette d&apos;information du patron</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished">tourne l&apos;étiquette d&apos;information du patron</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished">déplacer le droit-fil</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished">redimensionner le droit-fil</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished">Interdire le retournement</translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11132,27 +8592,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11160,77 +8615,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11238,139 +8678,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished">Formulaire</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11378,62 +8773,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished">Choisir point pour la valeur de Y (horizontal)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11441,316 +8824,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished">Intervalle :</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished">Langue</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">Langue de l&apos;interface:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished">Unité par défaut:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished">L&apos;unité par Défaut a été mise à jour et sera utilisée par défaut pour le prochain patron créé.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimètres</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished">Pouces</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished">Séparateur décimal :</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished">Millimètres</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished">Le son:</translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished">Email:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished">Localité de l&apos;utilisateur</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished">Bienvenue</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11758,582 +9075,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Ligne</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Courbe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished">Opérations</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished">Plan de coupe</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished">Sortie graphique</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Largeur :</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished">Exporter</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Chemin</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished">Ouvrir un dossier</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12341,272 +9490,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished">Interdire le retournement</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Marge de couture</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished">Repères de montage</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished">Type:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">Longueur:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Largeur :</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Chemins</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Largeur</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Hauteur</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished">Modèles</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12614,7 +9693,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>S&apos;appuie sur Qt %1 (%2, %3 bit)</translation>
     </message>
@@ -12622,155 +9700,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>créer un nouvel élément de patron pour commencer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>Pouce</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Propriété</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation>Ajouter un nœud</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation>Changements appliqués.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished">Mauvais nom de tag &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished">Conversion du paramètre impossible vers toUInt</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished">Conversion du paramètre impossible vers toBool</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished">Paramètre vide</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished">Conversion du paramètre impossible vers toDouble</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished">Mauvais id . Seul les id &gt; 0 sont autorisés.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished">Tissu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished">Lin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished">Interfaçage</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished">Interlignage</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished">Coupure</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12778,15 +9825,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation>manque d&apos;argument pour le fonction somme.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation>manque d&apos;argument pour la fonction soustraction.</translation>
@@ -12795,217 +9838,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Symbole &quot;$TOK$&quot; inattendu à l&apos;emplacement $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Erreur interne</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Nom invalide : fonction, variable, ou constante &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>L&apos;identifiant d&apos;opération binaire &quot;$TOK$&quot; est invalide.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>L&apos;identifiant de l&apos;opérateur infixe &quot;$TOK$&quot; est invalide.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>L&apos;identifiant de l&apos;opérateur postfixe &quot;$TOK$&quot; est invalide.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Le pointeur de fonction de rappel est invalide.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>Champ vide.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Le pointeur de variable est invalide.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Opérateur &quot;$TOK$&quot; inattendu à l&apos;emplacement $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Fin inattendue d&apos;expression à l&apos;emplacement $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Séparateur d&apos;arguments inattendu à l&apos;emplacement $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Parenthèse &quot;$TOK$&quot; inattendue à l&apos;emplacement $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Fonction &quot;$TOK$&quot; inattendue à l&apos;emplacement $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Valeur &quot;$TOK$&quot; inattendue à l&apos;emplacement $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Variable &quot;$TOK$&quot; inattendue à l&apos;emplacement $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Pas de fonction spécifiée pour les arguments (emplacement : $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Oubli de parenthèse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Trop d&apos;arguments pour la fonction &quot;$TOK$&quot; à l&apos;emplacement $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Pas assez d&apos;arguments pour la fonction &quot;$TOK$&quot; à l&apos;emplacement $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Division par zéro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Erreur de domaine</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Conflit de nom</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>La valeur de priorité de l&apos;opérateur est invalide. (Elle doit être supérieure ou égale à zéro).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>L&apos;opérateur binaire &quot;$TOK$&quot; défini par l&apos;utilisateur est en conflit avec un opérateur intrinsèque.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Chaîne de caractères inattendue à l&apos;emplacement $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>La chaîne de caractères commençant à la position $POS$ n&apos;est pas terminée.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>Fonction de chaîne de caractères appelée pour un argument d&apos;un autre type.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>Un argument numérique est attendu ici, pas une chaîne de caractères.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>L&apos;opérateur &quot;$TOK$&quot; à la position $POS$ n&apos;est pas défini pour des arguments de ce type.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>Le résultat de la fonction est une chaîne de caractère.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Erreur d&apos;analyse syntaxique.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>Le séparateur des décimales est le même que le séparateur des arguments de fonction.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>L&apos;opérateur &quot;$TOK$&quot; doit être précédé d&apos;un crochet fermant.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>Il manque une condition &quot;sinon&quot; dans l&apos;opérateur si-alors-sinon</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Deux-points &quot; : &quot; mal placés à l&apos;emplacement $POS$</translation>
@@ -13014,7 +10021,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13022,7 +10028,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished">renommer la pièce de patron</translation>
     </message>
@@ -13030,12 +10035,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13043,7 +10046,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished">sauvegarder les options de la pièce de patron</translation>
     </message>
@@ -13051,7 +10053,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13059,7 +10060,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation>options d&apos;outil de Sauvegarde</translation>
     </message>
@@ -13067,88 +10067,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Langue</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">Langue de l&apos;interface:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished">Programme de réalisation de patrons</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished">Système:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">Auteur:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished">Livre:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished">Barre d&apos;outils</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished">Le texte apparait sous l&apos;icone (recommandé pour les débutants).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished">Taille et stature par défaut</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Stature:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished">Taille:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished">Séparateur décimal :</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished">Localité de l&apos;utilisateur</translation>
     </message>
@@ -13156,52 +10138,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Chemin</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished">Ouvrir un dossier</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13209,102 +10181,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Bienvenue</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation>Bienvenue à SeamlyME</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation>Utilisateurs de 3D Look</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation>Pour utiliser un scan du corps 3D Look, le fichier doit être converti au format SeamlyME. </translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation>Joignez votre fichier 3DLook à un courriel et envoyez-le à convert@seamly.io.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Vous recevrez un e-mail avec le fichier converti, que vous pourrez ensuite charger dans SeamlyME comme d&apos;habitude.</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation>Veuillez choisir les unités, le séparateur décimal et la langue que vous préférez. (Vous pourrez les modifier ultérieurement.)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation>Unités:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Définit les unités par défaut pour un nouveau fichier de mesure.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Séparateur décimal :</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation>Langue de l&apos;interface:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation>Définit la langue utilisée pour SeamlyMe.</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation>Ne plus montrer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Localité de l&apos;utilisateur</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Centimètres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Millimètres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Pouces</translation>
     </message>
@@ -13312,92 +10263,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Bienvenue</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation>Bienvenue à Seamly2D</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation>Unités:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Définit les unités par défaut pour un nouveau fichier de mesure.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Séparateur décimal :</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation>Langue de l&apos;interface:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation>Ne plus montrer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Localité de l&apos;utilisateur</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Centimètres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Millimètres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Pouces</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation>Définit la langue utilisée pour Seamly2D.</translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation>Veuillez choisir les unités, le séparateur décimal, la langue et le son de sélection que vous préférez. (Vous pourrez les modifier ultérieurement.)</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation>Le son:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation>Définit le son du clic de sélection du nœud.</translation>
     </message>
@@ -13405,12 +10337,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13418,1071 +10348,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished">Fichier</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Nouveau</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished">Ctrl+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished">Ouvrir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished">Ctrl+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Enregistrer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished">Ctrl+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Enregistrer sous</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished">Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Imprimer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished">Ctrl+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished">Ctrl+Q</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Mesures</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Point</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Ligne</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished">Opérations</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished">Images</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished">Interdire le retournement</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished">Renommer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Supprimer</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished">Plan de coupe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">Historique</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished">Aide</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished">K</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14490,12 +11203,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14503,42 +11214,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14546,7 +11249,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14554,7 +11256,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14562,819 +11263,626 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Sélectionnez Nouveau pour créer un fichier de mesures.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation>Valeur calculée</translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Valeur de départ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>En taille</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>En hauteur</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Détails</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Nom:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Formule:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation>Valeur de départ:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation>En taille:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation>En hauteur:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Description:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation>Déplacer la mesure vers le haut</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Déplacer la mesure vers le bas</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Valeur calculée:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation>Nom complet:</translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Type:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation>Type de mesures</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Chemin:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Montrer dans l&apos;Explorer</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Taille de base:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation>Valeur de taille de base</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Hauteur de base:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation>Valeur de hauteur de base</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Prénom:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Nom de famille:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation>Date de naissance:</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>Email:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>Notes:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>Fichier</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Fenêtre</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Mesures</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation>Menu</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation>Gradation</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation>Ouvrir individuelles ...</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation>Enregistrer sous ...</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>À propos de &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>A propos de SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation>Ajouter connue</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation>Ajouter personnalisé</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation>Lecture seulement</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>Base de données</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation>Voir les Information pour toutes les mensurations connues</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Préférences</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation>sans titre %1</translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>Ce fichier est déjà ouvert dans une autre fenêtre.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Erreur de fichier.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Le fichier n&apos;a pas pu etre enregistré</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Enregistrer sous</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation>&amp;Nouvelle Fenêtre</translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation>Editer les mesures</translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Champ vide.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Erreur d&apos;analyse : %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Mesures individuelles</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>sans titre</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation>Changements non enregistrés</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Les mesures ont été modifiées.
 Voulez-vous enregistrer les changements?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Champ vide</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Ouvrir fichier</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation>Importer depuis un patron</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation>Unité du patron:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Rechercher:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation>Trouver le précédent</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation>Trouver le suivant</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation>Impossible à verrouiller. Le fichier est déjà ouvert dans une autre fenêtre.</translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation>Le fichier contient une ou des mensurations connues invalides.</translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation>Format de fichier inconnu.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Nom complet</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation>Le fichier &apos;%1&apos; n&apos;existe pas!</translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation>Il n&apos;est pas possible de changer le nom de mesures connues.</translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation>Impossible de trouver la mesure &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation>Il n&apos;est pas possible de changer le nom complet de mesures connues.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation>Assistant fonction</translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation>Déplace la mesure en haut</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation>Bouton de déplacement de mesure</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation>Supprimer la mesure</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation>inconnu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>homme</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>femme</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation>Genre:</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation>Méthode:</translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation>Créer à partir de ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation>Créer à partir d&apos;un fichier existant</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation>Sélectionner un fichier</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation>Diagramme des mesures</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Mesure inconnue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Mesure inconnue&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>À propos de Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>En cours de sauvegarde.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation>Nom de la mesure dans la formule</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation>Nom de la mesure dans la formule.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation>Nom de la mesure compréhensible par l&apos;humain.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>Sauvegarder ...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Ne pas sauvegarder</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Verrouiller le fichier (lecture seule)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Le fichier en lecture seule ne peut être créer par manque de permission.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Une erreur inconnue s&apos;est produite, par exemple une partition pleine empêche d&apos;écrire le fichier en lecture seule.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation>Exporter vers CVS</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Révéler dans le finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation>Nom du client</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation>Nom de famille du client</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation>Adresse email du client</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Stature:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Taille :</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation>Tous les fichiers</translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation>Lecture seule</translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished">Vide</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation>Ctrl+,</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation>Imprimer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation>Ouvrir modèle ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation>Ctrl+Alt+O</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation>Fichier de patron</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Le fichier est déjà ouvert dans une autre fenêtre. Ignorer pour continuer (déconseillé car pouvant causer une corruption de données).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Le fichier en lecture seule ne peut être créer par manque de permission. Ignorer pour continuer (déconseillé car pouvant causer une corruption de données).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Une erreur inconnue s&apos;est produite, par exemple une partition pleine empêche d&apos;écrire le fichier en lecture seule. Ignorer pour continuer (déconseillé car pouvant causer une corruption de données).</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15382,7 +11890,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15390,22 +11897,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15413,22 +11916,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15436,47 +11935,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">Premier point</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Deuxième point</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished">Point le plus haut</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished">Point le plus bas</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished">Point le plus à gauche</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished">Point le plus à droite</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Axes verticaux</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Axes horizontaux</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Ligne_</translation>
     </message>
@@ -15484,47 +11974,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Outil d&apos;assemblage</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voulez-vous vraiment rassembler les pièces de patron?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished">Mémoriser les pièces originales</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Choisir un deuxième point</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Choisir point unique</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished">Choisir un point de bordure</translation>
     </message>
@@ -15532,7 +12013,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15540,17 +12020,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Ne plus demander</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Ne plus &amp;demander</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>Ne plus &amp;montrer</translation>
     </message>
@@ -15558,57 +12035,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Impossible d&apos;obtenir les Information de version.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>Trop d&apos;étiquettes &lt;%1&gt; dans le fichier.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Version &quot;%1&quot; invalide.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Version &quot;0.0.0&quot; invalide.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Version non valide. La version minimale supportée est  %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Version non valide. La version maximale supportée est  %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Erreur : id non unique.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>La version n&apos;a pas pu être changée.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation>Erreur lors de la création d&apos;un copie de réserve: %1.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Version inattendue &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15616,7 +12082,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation>Impossible de couper la ligne</translation>
     </message>
@@ -15624,22 +12089,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Exporter vers CVS</translation>
     </message>
@@ -15647,13 +12108,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
@@ -15661,23 +12119,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>L&apos;outil n&apos;a pas été trouvé dans la table.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation>Erreur lors de la création ou la mise à jour du groupe</translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>Nouveau groupe</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15685,7 +12138,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15693,12 +12145,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
@@ -15706,283 +12156,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Confirmer la suppression</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Voulez vous vraiment supprimer?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished">Editer la formule erronée</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15990,302 +12383,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation>Chemin vers le fichier de mesures personnalisé (mode export).</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation>Le fichier de mesure</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation>Numéro de format</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation>Numéro de modèle</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>La largeur de page</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation>L&apos;unité de mesure</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Angle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation>Couper automatiquement la longueur non utilisée (mode expert).</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation>Dimensions du plan de coupe (equivalent à celles du papier hors px, mode export).</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation>L&apos;unité</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation>Largeur d&apos;espacement</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation>Type de groupes</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation>On ne peut utiliser un format de page et une longueur/largeur explicite.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation>Hauteur, largeur de page et unités doivent être utilisés ensembles.</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation>Valeur de rotation invalide. Utilisez les valeurs prédéfinies.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation>Modèle de page inconnu.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation>Dimensions de papier non supportées.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation>Dimensions du plan de coupe non supportées.</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation>Les options d&apos;export ne peuvent être utilisé qu&apos;avec un fichier d&apos;entrée simple.</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation>Les options de test ne peuvent être utilisé qu&apos;avec un fichier d&apos;entrée simple.</translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation>Le nom d&apos;export du fichier de plan de coupe. À n&apos;utiliser que dans le cas d&apos;un mode export console.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation>Le nom de fichier du plan de coupe</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>Le dossier de destination</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation>Valeur de taille de base</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation>Valeur de hauteur de base</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Largeur de page en unité courante, ex. 12.0 (ne peut pas être utilisé avec &quot;%1&quot;, mode exportation).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Hauteur de page en unité courante, ex. 12.0 (ne peut pas être utilisé avec &quot;%1&quot;, mode exportation).</translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation>Valeur de gradation incorrecte.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation>Valeur de stature incorrecte.</translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Programme de réalisation de patrons.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Fichier Patron.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation>Largeur d&apos;espacement devant être utilisé avec les largeurs de décalage.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation>la marge gauche doit être spécifiée dans l&apos;unité de la page.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation>la marge droite doit être spécifiée dans l&apos;unité de la page.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation>la marge haute doit être spécifiée dans l&apos;unité de la page.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation>la marge basse doit être spécifiée dans l&apos;unité de la page.</translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation>Emplacement du dossier de destination. Par défaut, le répertoire est celui de l&apos;application.</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation>Unité de mesure des hauteur/largeur de la page (&quot;%1&quot; ne peut pas être utilisé, mode exportation). Valeur valide: %2.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation>Ignorer les marges d&apos;impression (mode export). Inactive les valeurs clés: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Règle les marge à 0.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Marge gauche de la page en unité courante, ex. 3.0 (mode exportation).   Si non renseigné, la valeur par défaut de l&apos;imprimante sera utilisé. Ou 0 si aucune imprimante n&apos;a été trouvé. La valeur sera ignorée si &quot;%1&quot; est utilisé.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Marge droite de la page en unité courante, ex. 3.0 (mode exportation).   Si non renseigné, la valeur par défaut de l&apos;imprimante sera utilisé. Ou 0 si aucune imprimante n&apos;a été trouvé. La valeur sera ignorée si &quot;%1&quot; est utilisé.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Marge haute de la page en unité courante, ex. 3.0 (mode exportation).   Si non renseigné, la valeur par défaut de l&apos;imprimante sera utilisé. Ou 0 si aucune imprimante n&apos;a été trouvé. La valeur sera ignorée si &quot;%1&quot; est utilisé.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Marge basse de la page en unité courante, ex. 3.0 (mode exportation).   Si non renseigné, la valeur par défaut de l&apos;imprimante sera utilisé. Ou 0 si aucune imprimante n&apos;a été trouvé. La valeur sera ignorée si &quot;%1&quot; est utilisé.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation>Rotation en degrés (un des prédéfinis, mode export). La valeur par défaut est 180. 0 pour aucune rotation. Les valeurs possibles : %1. Chaque valeur indique combien de fois la pièce de patron tournera. par exemple 18 veut dire 2 fois (360/180=2) par 180 degrés.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation>Page unique si possible (mode export). La valeur maximum est limité par QImage qui ne supporte que des images d&apos;un maximun 32768x32768 px.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation>Sauvegarder la longueur de la feuille si réglée (mode export). Cette option demande au logiciel d&apos;utiliser la feuille au maximum en largeur. La qualité du plan de coupe peut être moindre si cette option est choisie.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation>La largeur d&apos;espacement entre pièces x2, mesurée en fonction des dimensions du plan de coupe (mode export). Réglage de la distance entre les pièces de patron et une pièce de patron et le bord de la feuille.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation>Réglage des cas de regroupement de plan de coupe (mode export): %1.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation>Lance le logiciel en mode test. Dans ce mode, le logiciel charge un fichier de patron simple puis quitte sans afficher la fenêtre principale. La clé a priorité sur la clé &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation>Décalage mesuré en fonction des dimensions du plan de coupe (mode export). Cette option affiche le nombre de point, le long d&apos;une arête, qui seront utilisé pour créer le plan de coupe.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation>Longueur de décalage</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation>la longueur de décalage doit être spécifiée dans l&apos;unité de décalage.</translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation>Numéro correspondant au format de sortie (défaut=0, mode export) :</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation>Numéro correspondant au modèle de page (défaut=0, mode export) :</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16293,43 +12626,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation>mesures</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation>Individuel</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation>multi-tailles</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16337,55 +12661,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>Objet non trouvé</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation>Ne peut convertir l&apos;objet</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation>impossible de trouver l&apos;objet. Le type ne correspond pas.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation>Le nombre de ID libre est épuisé.</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation>Impossible de créer une courbe de type &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16393,12 +12704,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation>Pas assez de point pour créer la spline.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation>Cette spline n&apos;existe pas.</translation>
     </message>
@@ -16406,51 +12715,41 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>impossible d&apos;ouvrir le fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Erreur d&apos;ouverture du fichier de schéma %1: %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation>Erreur de validation : fichier %3, ligne %1, colonne %2</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation>Erreur d&apos;interprétation : fichier %3, ligne %1, colonne %2</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation>Noeud innacessible</translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>Cet identifiant n&apos;est pas unique.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation>Impossible de lire le schéma de fichier &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16458,27 +12757,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16486,7 +12780,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16494,11 +12787,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
@@ -16506,7 +12794,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished">Formule:</translation>
     </message>
@@ -16514,7 +12801,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16522,7 +12808,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16530,12 +12815,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>Vrai</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>Faux</translation>
     </message>
@@ -16543,12 +12826,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Dossier</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Ouvrir fichier</translation>
     </message>
@@ -16556,335 +12837,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Erreur d&apos;interprétation de fichier.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Erreur : valeur non convertissable.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Erreur : paramètre vide.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Erreur : mauvais id.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Erreur d&apos;interprétation de fichier. (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Erreur lors de la création ou de la mise à jour d&apos;un point seul</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Erreur lors de la création ou de la mise à jour d&apos;un point de fin de ligne</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Erreur lors de la création ou de la mise à jour d&apos;un point de la ligne</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Erreur lors de la création ou mise à jour du point d&apos;épaule</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation>Erreur lors de la création ou de la mise à jour d&apos;un point de la normale</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Erreur lors de la création ou mise à jour du point de bisection</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Erreur lors de la création ou mise à jour du point de contact</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation>Erreur lors de la création ou mise à jour du point de modélisation</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Erreur lors de la création ou mise à jour de la taille</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Erreur lors de la création ou de la mise à jour d&apos;un triangle</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation>Erreur lors de la création ou mise à jour du point de découpe de crannelure</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation>Erreur lors de la création ou mise à jour de la trajectoire de la spline</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation>Erreur lors de la création ou de la mise à jour d&apos;un point de découpe d&apos;arc</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation>Erreur lors de la création ou mise à jour du point d&apos;intersection de ligne et d&apos;axe</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation>Erreur lors de la création ou mise à jour du point d&apos;intersection de courbe et d&apos;axe</translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Erreur lors de la création ou de la mise à jour de la ligne</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Erreur lors de la création ou de la mise à jour de la courbe</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Erreur lors de la création ou de la mise à jour du chemin de la courbe</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation>Erreur lors de la création ou de la mise à jour de la courbe simple</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation>Erreur lors de la création ou de la mise à jour de la trajectoire de la courbe</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Erreur lors de la création ou mise à jour d&apos;un arc simple</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation>Erreur lors de la création ou mise à jour d&apos;un arc modelé</translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation>Erreur lors de la création ou mise à jour du point d&apos;intersection d&apos;arcs</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation>Erreur lors de la création ou mise à jour du point d&apos;intersection de cercles</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation>Erreur lors de la création ou mise à jour du point d&apos;intersection de cercle et tangente</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation>Erreur lors de la création ou mise à jour du point d&apos;intersection de l&apos;arc et la tangente</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation>Erreur lors de la création de vraies pinces ou de leur mise à jour</translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Mauvais nom de tag &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation>Point de type inconnu &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation>Spline inconnue de type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation>Courbe inconnue de type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation>Outil inconnu de type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation>Erreur, Id. non unique.</translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation>Erreur lors de la création ou mise à jour du point d&apos;intersection de courbes</translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation>Erreur lors de la création ou de la mise à jour de la spline interactive simple</translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation>Erreur lors de la création ou mise à jour du point de découpe de la trajectoire de la spline interactive</translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation>Erreur lors de la création ou de la mise à jour de la courbe cubique de bezier</translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation>Erreur lors de la création ou de la mise à jour de la trajectoire de la courbe de bezier</translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation>Erreur lors de la création ou mise à jour de l&apos;opération de rotation</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation>Opération inconnue de type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation>Chemin sans nom</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16892,17 +13084,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16910,12 +13099,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16923,14 +13110,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>Pas assez de poins pour créer une spline.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>La spline n&apos;existe pas.</translation>
     </message>
@@ -16938,17 +13121,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
@@ -16956,27 +13136,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16984,37 +13159,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17022,7 +13190,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
@@ -17030,12 +13197,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17043,32 +13208,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Arc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17076,18 +13235,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Courbe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17095,18 +13250,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Courbe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17114,7 +13265,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
@@ -17122,28 +13272,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17151,17 +13295,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
@@ -17169,12 +13310,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
@@ -17182,7 +13321,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
@@ -17190,27 +13328,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17218,17 +13351,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
@@ -17236,7 +13366,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17244,12 +13373,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">Point de la première ligne</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Point de deuxieme ligne</translation>
     </message>
@@ -17257,27 +13384,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Point central</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17285,714 +13407,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Point de départ</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation>Pinces réelles</translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished">Point de départ:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Longueur:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Rayon:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished">Premier point de base :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished">Second point de base :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished">Premier point de la pince :</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished">Arc:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished">Courbe:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished">Point de la première ligne:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished">Centre de l&apos;arc:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished">Premier arc:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished">Deuxième arc:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished">Prendre:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished">Première courbe:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished">Seconde courbe:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Point de la tangente:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished">Point d&apos;axe :</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation type="unfinished">Point d&apos;origine:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation type="unfinished">Type d&apos;axe :</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation type="unfinished">Angle de rotation :</translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished">Quatrième point:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordonnées</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished">Deuxième point de la pince :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished">Troisième point de la pince :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Ligne</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">Première ligne</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Deuxième ligne</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotation:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation>Centre:</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Ligne_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Point central</translation>
     </message>
@@ -18000,12 +13806,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18013,17 +13817,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
@@ -18031,12 +13832,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18044,12 +13843,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18057,12 +13854,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18070,17 +13865,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Longueur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
@@ -18088,1552 +13880,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation>Bunka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation>Bunka Fashion College</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation>Fundamentals of Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation>Barnfield and Richard</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation>Jo Barnfield and Andrew Richards</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation>Pattern Making Primer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation>Friendship/Women</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation>Elizabeth Friendship</translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation>Morris, K.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation>Karen Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation>Sewing Lingerie that Fits</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation>Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation>Lucia Mors de Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation>Patternmaking in Practic</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation>Kim &amp; Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation>Injoo Kim and Mykyung Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation>Apparel Making in Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation>Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation>Norah Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation>Corsets and Crinolines</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation>Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation>Frances Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation>Fashions of the Gilded Age</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation>Thornton&apos;s International System</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation>The Great War: Styles and Patterns of the 1910s</translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation>Hillhouse &amp; Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation>Marion S. Hillhouse and Evelyn A. Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation>Dress Design: Draping and Flat Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation>Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation>Esther Kaplan Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation>How to Design Beautiful Clothes: Designing and Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation>Minister &amp; Son</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>Edward Minister &amp; Son, ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation>The Complete Guide to Practical Cutting (1853)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation>Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation>Gertrude Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation>A Tailoring Manual</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation>Loh &amp; Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation>May Loh and Diehl Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternless Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation>Morris, F. R.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation>F. R. Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation>Ladies Garment Cutting and Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation>Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation>Gertrude Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation>Gertrude Mason&apos;s Patternmaking Book</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation>Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation>K. Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation>Master Designer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation>The Master Designer (Chicago, IL)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation>Master Designer&apos;s System of Designing, Cutting and Grading</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation>Kopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation>How to Draft Basic Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation>Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation>Doris Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation>Slacks Cut-to-Fit for Your Figure</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation>Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation>Sarah J. Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation>Sarah&apos;s Key to Pattern Drafting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation>Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation>Karla J. Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation>Design and Sew Jeans</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Lady Boutique magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation>Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation>M. Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation>Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation>Dorothy Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation>Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation>Bina Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation>Integrating Draping, Drafting and Drawing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation>Sue S. Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Dressmaking International magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation>Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation>Mabel D. Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation>Practical Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation>Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation>E. L. G. Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>Principles of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation>Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation>Elizabeth M. Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation>European Cut</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation>McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation>Donald H. McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation>How to Make Your Own Sewing Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation>Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation>Zarapkar System of Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation>Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation>Philip Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation>Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation>Jack Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation>Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation>R. I. Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation>MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation>Jason MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation>The Victorian Tailor: An Introduction to Period Tailoring</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation>Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation>Helen Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation>Supreme System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation>Frederick T. Croonberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation>Sugino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation>Dressmaking</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting Vols. I, II, III (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation>Centre Point System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation>Louis Devere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation>The Handbook of Practical Cutting on the Centre Point System</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation>Aldrich/Men</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation>Winifred Aldrich</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation>Aldrich/Women</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Women&apos;s Wear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation>Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation>Gareth Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation>Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation>Teresa Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation>Pattern-Drafting for Fashion: The Basics</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation>Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation>Dennic Chunman Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation>Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation>Dress Pattern Designing: The Basic Principles of Cut and Fit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation>Knowles/Men</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation>Lori A. Knowles</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation>The Practical Guide to Patternmaking for Fashion Designers: Menswear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation>Friendship/Men</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting for Men&apos;s Costume</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation>Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation>P. Clement Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation>Art in Dress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation>Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation>Jno. J. Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation>GOST 17917-86</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation>Ministry of consumer industry of the USSR</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation>Standard figure boys</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation>Eddy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation>Josephine F. Eddy and Elizabeth C. B. Wiley</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation>Créations de patrons et de robes</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation>Knowles / Femmes</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation>American Garment Cutter</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation>Vide</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation>La team Seamly2D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation>Standard interne à Seamly2D</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>in</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>SplPath</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Angle1SplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Angle2SplPath</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation>Seg_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation>CurrentLength</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation>taille</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation>stature</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Ligne_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">AngleLine_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Spl_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">RadiusArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle1Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle2Arc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle1Spl_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Angle2Spl_</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19642,17 +15177,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation>&lt;b&gt;Trajectoire de courbe&lt;/b&gt; : sélectionner au moins sept points</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation>&lt;b&gt;Trajectoire de courbe&lt;/b&gt; : sélectionner plus de points pour compléter le segment</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19660,7 +15192,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19668,7 +15199,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19676,7 +15206,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19684,12 +15213,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19697,7 +15224,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19705,7 +15231,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19713,17 +15238,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Trajectoire de courbe&lt;/b&gt; : sélectionner au moins trois points</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19731,47 +15253,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>DEBUGAGE :</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>AVERTISSEMENT:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>CRITIQUE:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19779,47 +15292,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>DEBUGAGE :</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>AVERTISSEMENT:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>CRITIQUE:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished">Attention</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>לבחור נקודה ראשונה</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">למחוק</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>לבחור נקודה שנייה</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>נקודה ראשונה בשורה</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>נקודה שנייה בשורה</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>נקודת מרכז</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>סנטימטרים</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>לבחור נקודה ראשונה</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>נקודה ראשונה</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>נקודה שנייה</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>נקודה ראשונה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>נקודה שנייה</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>לבחור נקודה ראשונה</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>לבחור נקודה שנייה</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">הערך המחושב</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">קו</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">עקומה</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">רדיוס</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">כלי</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">אורך הקו</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">אורך העקומה</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">למחוק</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">למחוק</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">למחוק</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>סנטימטרים</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6623,84 +5191,67 @@ Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6708,32 +5259,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6741,2659 +5286,2000 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>ולנטינה</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>נקודה</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>כלים ליצירת קווים.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>קו</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>עקומה</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>חדש</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>יצירת תבנית חדשה</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>שמור</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>שמירת תבנית</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>שמירה בשם</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>שגיאה חסר פרמטר.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished">הערך המחושב</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">למחוק</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9401,86 +7287,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9488,148 +7354,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished">קובץ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">חדש</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">שמור</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">שמירה בשם</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9637,123 +7473,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
@@ -9762,18 +7577,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9781,37 +7588,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9819,12 +7619,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9832,7 +7630,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9840,7 +7637,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9848,7 +7644,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9856,7 +7651,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9864,7 +7658,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9872,7 +7665,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9880,52 +7672,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>סנטימטרים</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9933,87 +7715,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10021,887 +7786,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">למחוק</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">אפשרויות</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10909,218 +8421,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">למחוק</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11128,27 +8588,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11156,77 +8611,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11234,139 +8674,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11374,62 +8769,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11437,316 +8820,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation type="unfinished">סנטימטרים</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11754,582 +9071,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">נקודה</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">קו</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">עקומה</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12337,272 +9486,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">רוחב</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12610,7 +9689,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12618,155 +9696,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12774,15 +9821,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
@@ -12791,217 +9834,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
@@ -13010,7 +10017,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13018,7 +10024,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13026,12 +10031,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13039,7 +10042,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13047,7 +10049,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13055,7 +10056,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13063,88 +10063,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13152,52 +10134,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13205,102 +10177,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">סנטימטרים</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13308,92 +10259,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">סנטימטרים</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13401,12 +10333,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13414,1071 +10344,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished">קובץ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">חדש</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">שמור</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">שמירה בשם</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">נקודה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">קו</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">למחוק</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14486,12 +11199,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14499,42 +11210,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14542,7 +11245,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14550,7 +11252,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14558,818 +11259,625 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>קובץ</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>שמור</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>חדש</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>שמירה בשם</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+217"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-368"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+802"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15377,7 +11885,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15385,22 +11892,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15408,22 +11911,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15431,47 +11930,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">נקודה ראשונה</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">נקודה שנייה</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15479,47 +11969,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15527,7 +12008,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15535,17 +12015,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15553,57 +12030,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15611,7 +12077,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15619,22 +12084,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15642,13 +12103,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
@@ -15656,23 +12114,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15680,7 +12133,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15688,12 +12140,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15701,283 +12151,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15985,302 +12378,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16288,43 +12621,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16332,55 +12656,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16388,12 +12699,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16401,50 +12710,40 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16452,27 +12751,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>למחוק</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16480,7 +12774,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16488,11 +12781,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16500,7 +12788,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16508,7 +12795,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16516,7 +12802,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16524,12 +12809,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16537,12 +12820,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16550,335 +12831,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>שגיאה חסר פרמטר.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16886,17 +13078,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16904,12 +13093,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16917,14 +13104,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16932,17 +13115,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16950,27 +13130,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16978,37 +13153,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17016,7 +13184,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17024,12 +13191,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17037,32 +13202,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17070,18 +13229,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">עקומה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17089,18 +13244,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">עקומה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17108,7 +13259,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17116,28 +13266,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17145,17 +13289,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17163,12 +13304,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17176,7 +13315,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17184,27 +13322,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17212,17 +13345,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17230,7 +13360,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17238,12 +13367,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17251,27 +13378,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>נקודת מרכז</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17279,714 +13401,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">קו</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Origin point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>נקודת מרכז</translation>
     </message>
@@ -17994,12 +13800,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18007,17 +13811,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18025,12 +13826,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18038,12 +13837,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18051,12 +13848,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18064,17 +13859,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">אורך</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18082,1552 +13874,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19636,17 +15171,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19654,7 +15186,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19662,7 +15193,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19670,7 +15200,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19678,12 +15207,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19691,7 +15218,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19699,7 +15225,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19707,17 +15232,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19725,47 +15247,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19773,47 +15286,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>Mengenai Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Situs web : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Tidak dapat membuka peramban bawaan Anda</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Dibuat pada %3 at %2 {1 ?}</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Tidak dapat membuka peramban bawaan Anda</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Dibuat pada %3 at %2 {1 ?}</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Situs web : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan penuh perhitungan dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Pilih titik kedua dari garis</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan perhitungan penuh dalam kotak pesa&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Titik tengah:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan perhitungan  penuh dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation type="unfinished">Titik tengah:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan penuh perhitungan dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Pilih titik kedua dari sudut</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Pilih titik ketiga dari garis</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan penuh perhitungan dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>pilih titik sumbu</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan perhitungan penuh dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan perhitungan  penuh dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan perhitungan  penuh dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation type="unfinished">Titik tengah:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan perhitungan  penuh dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Pilih titik kedua dari garis</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">kampuh</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">hapus</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan perhitungan  penuh dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Titik pertama dari baris</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Pilih titik kedua dari garis</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>pilih titik sumbu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>titik kedua dari baris</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>pengukuran</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Titik tengah</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Centimeter</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Inchi</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan perhitungan  penuh dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Pilih titik kedua dari garis</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Keterangan Pola</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Pola</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan perhitungan  penuh dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>pilih titik tengah dari busur</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Pilih titik kedua dari garis</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Pola</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Konfigurasi</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tampilkan perhitungan  penuh dalam kotak pesan&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Pilih titik kedua dari garis</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Titik pertama</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>titik kedua</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Titik pertama</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>titik kedua</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Batalkan</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">rumus</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">sudut</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">kurva</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">busur</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Radius</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">edit rumus</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">pengukuran</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">sisipkan variabel ke dalam rumus</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Sembunyikan pengukuran kosong</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">hapus</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">hapus</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">hapus</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation>Titik tengah:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centimeter</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Inchi</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6623,84 +5191,67 @@ Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6708,32 +5259,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6741,2660 +5286,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>kurva</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>busur</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>pengukuran</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Buka File</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>File telah disimpan</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>tanpajudul.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>Pola telah dimodiikasi
 Apakah anda ingin menyimpan perubahan anda?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished">rumus</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">Mengenai Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">hapus</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>pola</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9402,86 +7288,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Pola</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9489,148 +7355,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Simpan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9638,123 +7474,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
@@ -9763,18 +7578,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9782,37 +7589,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9820,12 +7620,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9833,7 +7631,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9841,7 +7638,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9849,7 +7645,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9857,7 +7652,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9865,7 +7659,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9873,7 +7666,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9881,52 +7673,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Centimeter</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Inchi</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9934,87 +7716,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10022,887 +7787,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">hapus</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">pilihan</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10910,218 +8422,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">hapus</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11129,27 +8589,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11157,77 +8612,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11235,139 +8675,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11375,62 +8770,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11438,316 +8821,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished">Selang waktu:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished">Bahasa</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimeter</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished">Inchi</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11755,582 +9072,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">kurva</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">busur</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12338,272 +9487,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">kampuh</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">lebar</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12611,7 +9690,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12619,155 +9697,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12775,15 +9822,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
@@ -12792,217 +9835,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
@@ -13011,7 +10018,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13019,7 +10025,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13027,12 +10032,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13040,7 +10043,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13048,7 +10050,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13056,7 +10057,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13064,88 +10064,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Bahasa</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13153,52 +10135,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13206,102 +10178,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimeter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Inchi</translation>
     </message>
@@ -13309,92 +10260,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimeter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Inchi</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13402,12 +10334,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13415,1071 +10345,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Simpan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">pengukuran</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">hapus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14487,12 +11200,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14500,42 +11211,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14543,7 +11246,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14551,7 +11253,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14559,818 +11260,625 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>rumus</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>pengukuran</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+217"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Buka File</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-368"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+802"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15378,7 +11886,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15386,22 +11893,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15409,22 +11912,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15432,47 +11931,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">Titik pertama</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">titik kedua</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15480,47 +11970,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15528,7 +12009,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15536,17 +12016,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15554,57 +12031,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15612,7 +12078,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15620,22 +12085,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15643,13 +12104,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
@@ -15657,23 +12115,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15681,7 +12134,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15689,12 +12141,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
@@ -15702,283 +12152,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15986,302 +12379,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>sudut</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Program pembuat pola.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Berkas pola.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16289,43 +12622,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16333,55 +12657,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16389,12 +12700,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16402,50 +12711,40 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16453,27 +12752,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>hapus</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16481,7 +12775,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16489,11 +12782,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16501,7 +12789,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16509,7 +12796,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16517,7 +12803,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16525,12 +12810,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16538,12 +12821,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16551,335 +12832,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16887,17 +13079,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16905,12 +13094,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16918,14 +13105,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16933,17 +13116,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">sudut</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
@@ -16951,27 +13131,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16979,37 +13154,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17017,7 +13185,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
@@ -17025,12 +13192,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17038,32 +13203,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">busur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17071,18 +13230,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">kurva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17090,18 +13245,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">kurva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17109,7 +13260,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
@@ -17117,28 +13267,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17146,17 +13290,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">sudut</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
@@ -17164,12 +13305,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">sudut</translation>
     </message>
@@ -17177,7 +13316,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
@@ -17185,27 +13323,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">sudut</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17213,17 +13346,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">sudut</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
@@ -17231,7 +13361,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17239,12 +13368,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17252,27 +13379,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Titik tengah</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">sudut</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17280,714 +13402,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation>Titik tengah:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Origin point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Titik tengah</translation>
     </message>
@@ -17995,12 +13801,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18008,17 +13812,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">sudut</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
@@ -18026,12 +13827,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18039,12 +13838,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18052,12 +13849,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18065,17 +13860,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">panjang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">sudut</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Nama</translation>
     </message>
@@ -18083,1552 +13875,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19637,17 +15172,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19655,7 +15187,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19663,7 +15194,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19671,7 +15201,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19679,12 +15208,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19692,7 +15219,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19700,7 +15226,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19708,17 +15233,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19726,47 +15248,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19774,47 +15287,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>Progetto Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Sito web : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Non è possibile aprire il browser predefinito</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Aumentato dall&apos; %1 al %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Controlla gli aggiornamenti</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished">sconosciuto</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>aggiungi gruppo</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>Aggiungi oggetto</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished">Punto:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Errore file di analisi. Il programma verrà terminato.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Errore id scorretto. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Errore impossibile convertire errore. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Errore parametro vuoto. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Errore id scorretto. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Qualcosa non va!!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Errore codifica:%1. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Eccezione generata:%1. Il programma verrà terminato.</translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Errore file di analisi. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Errore id non valida. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Errore impossibile convertire errore. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Errore parametro vuoto. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Errore id scorretto. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Qualcosa non va!!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Errore codifica:%1. Il programma verrà interrotto.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Eccezione generata:%1. Il programma verrà terminato.</translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation>Editor delle misure di Seamly2D.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation>Il file delle misure.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation>Altezza base</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation>Taglia base</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation>Imposta l&apos;unità di misura del file di pattern: cm, mm, pollici.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation>Unità del pattern</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation>Dimensione di base non valida. Deve essere cm, mm o pollici.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation>Impossibile iniziare a registrare le connessioni in entrata sul nome &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation>La modalità di prova non supporta l&apos;apertura di più file.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation>Si prega di fornire un file di input.</translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation>Aprire con taglia base. Valori validi: %1cm.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation>Altezza base non valida. Deve essere %1cm.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation>Dimensione di base non valida. Deve essere %1cm.</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation>Aprire con altezza base. Valori validi: %1cm.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation>Utilizzare per testare l&apos;unità. Eseguire il programma e aprire un file senza mostrare la finestra.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>Elimina gruppo</translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>Elimina strumento</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>cancella strumento</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">Informazioni su nastro</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished">Versione nastro</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Costruisci revisione: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished">Questo programma è parte del progetto Seamly2D.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Controlla gli aggiornamenti</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Non è possibile aprire il browser predefinito</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Aumentato dall&apos; %1 al %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Sito web : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished">sconosciuto</translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Seleziona il secondo punto della linea</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Modifica lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calcolo</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>Primo punto:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>Primo punto della linea</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Secondo punto :</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Secondo punto della linea</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Il raggio non può essere negativo</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Angoli uguali</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Modifica raggio</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Modifica primo angolo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Modifica secondo angolo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Raggio:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>Primo angolo:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Calcolo</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Secondo angolo:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Punto centrale:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Seleziona il punto al centro dell&apos;arco</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Colore:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Modifica raggio</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Modifica primo angolo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Modifica la lunghezza dell&apos;arco</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Il raggio non può essere negativo</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>La lunghezza non può essere 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Raggio:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>valore</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>calcolo</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>Primo angolo:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Punto centrale:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Colore:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Seleziona il secondo punto di un angolo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Seleziona il terzo punto di un angolo</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Modifica lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>calcolo</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>Primo punto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Secondo punto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Terzo punto:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Colore:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>Primo punto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Secondo punto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Terzo punto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Quarto punto:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Seleziona il secondo punto della curva</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Seleziona il terzo punto della curva</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Seleziona il quarto punto della curva</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>spline non valida</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Punto:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>Lista di punti</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Colore:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Seleziona punto dell&apos;asse</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Modifica angolo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Angolo:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Punto dell&apos;asse:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Modifica lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>calcolo</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Arco:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo intero nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Modifica lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calcolo</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Modifica lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>calcolo</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula magica</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation type="unfinished">Calcolo</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation type="unfinished">Primo angolo:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation type="unfinished">Secondo angolo:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation type="unfinished">Punto centrale:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished">Seleziona il punto al centro dell&apos;arco</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Il raggio non può essere negativo</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished">Angoli uguali</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished">Modifica primo angolo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished">Modifica secondo angolo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Modifica angolo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Modifica lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Calcolo</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Angolo:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Punto base:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Esporta opzioni</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>Con intestazione</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation>Codec:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Separatore</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>Virgola</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>Semicolonna</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Spazio</translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Seleziona il primo punto della linea</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Seleziona il secondo punto della linea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Punto base:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished">Primo punto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished">Percorso</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished">Tipo:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished">Pronto!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Margine di cucitura</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Larghezza:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula magica</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished">Angolo:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">Lunghezza:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Invertire</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished">Hai bisogno di più punti!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Hai doppi punti!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Impossibile preparare i dati per la creazione del layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Crea un layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation>Pezzi disposti: %1 da %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Seleziona il secondo punto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>Primo punto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Secondo punto:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Linea_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Primo punto</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Seconda linea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Seleziona il secondo punto della prima linea</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Seleziona il primo punto della seconda linea</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Seleziona il secondo punto della seconda linea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>Primo punto:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Secondo punto:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Primo punto della linea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Seleziona il secondo punto della linea</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Seleziona punto dell&apos;asse</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Punto dell&apos;asse</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Secondo punto della linea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Modifica angolo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Angolo:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Punto dell&apos;asse:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished">Primo punto:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Misure</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished">Trova:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished">Cerca</translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished">Punto dell&apos;asse:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffisso:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished">Primo punto della linea:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished">Secondo punto della linea:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffisso:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation type="unfinished">Angolo:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula magica</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation type="unfinished">Lunghezza:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffisso:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation type="unfinished">Modifica angolo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished">Modifica lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished">Punto d&apos;origine:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Punto centrale</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Unità:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Centimetri</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Pollici</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Nome unico del pezzo del modello</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Scegli nome del pezzo del modello unico.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>Nuovo pattern</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished">Millimetri</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Seleziona il secondo punto della linea</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Modifica lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calcolo</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>Primo punto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Secondo punto:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Descrizione modello</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Altezze e Taglie</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Tutte le altezze (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Tutte le taglie (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Altezza e taglia di default</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Personalizzato</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Altezza:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Taglia:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Sicurezza</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Apri solo per lettura</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>Nessuna immagine</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Cancella immagine</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Cambia immagine</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Salva immagine in file</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Mostra immagine</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation>Immagine per modello</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Immagini</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Salva File</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>senza titolo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Percorso:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Mostra in Explorer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;Empty&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>Il file non è stato ancora salvato.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Mostra nella barra di ricerca</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Nome modello:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Numero modello:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Nome Azienda/Stilista:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Nome cliente:</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Seleziona un arco</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Punto tangente:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Arco:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Prendi:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Seleziona il punto al centro dell&apos;arco</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Seleziona il secondo punto della linea</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Modifica raggio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Raggio:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Calcolo</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation>Centro dell&apos;arco:</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation>Selezionare secondo arco</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>Primo arco:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Secondo arco:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Prendi:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>Prima curva:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Seconda curva:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Seleziona la seconda curva</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished">Generale</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Rotazione</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Angolo:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Suffisso:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation>Modifica angolo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferenze</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Configurazione</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo completo nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Seleziona il primo punto della linea</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Seleziona il secondo punto della linea</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Modifica lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calcolo</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>Primo punto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Secondo punto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Terzo punto:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Coordinate sul foglio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Coordinate</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Punto base</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Primo punto</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Secondo punto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Seleziona l&apos;ultimo punto della curva</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Colore:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>Primo punto:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Angolo:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Secondo punto:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>spline non valida</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo intero nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation>La lunghezza non può essere inferiore a 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Lista di punti</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Seleziona punto del tracciato curvo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Colore:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Punto:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation>Primo controllo del punto</translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Angolo:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation>Secondo controllo del punto</translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Lunghezza:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formula magica</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostra calcolo intero nella finestra di dialogo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation>La lunghezza non può essere inferiore a 0</translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation>Non in uso</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Campo vuoto</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Il valore non può essere 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Errore parser: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Primo punto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Secondo punto</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation>Punto più alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation>Punto più basso</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation>Punto più a sinistra</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation>Punto più a destra</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Seleziona il secondo punto dell&apos;asse</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Seleziona primo punto</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Seleziona secondo punto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>Primo punto:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Secondo punto:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation>Seleziona il secondo punto base</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation>Seleziona il primo punto della pince</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation>Seleziona il secondo punto della pince</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation>Seleziona il terzo punto della pince</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Formula guasta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Undo</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Correggi formula</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancel</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Errore durante la formula di calcolo. Prova ad annullare l&apos;ultima operazione o a correggere la formula errata.</translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">Valore calcolato</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished">Sposta la misura sopra</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished">Sposta la misura sotto</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula magica</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Dettagli</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Valore calcolato:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished">Descrizione:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Linea</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Angolo</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Arco</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Raggio</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished">Campo vuoto.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Campo vuoto</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Strumento</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Modifica formula</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Misure</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished">Funzioni</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Inserisci variabile nella formula</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Nascondi misure vuote</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished">Nome intero</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Lunghezza linea</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Lunghezza curva</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Angolo linea</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished">Arco di raggio</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished">Angolo di curvatura</translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Nome unico del pezzo del modello</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished">Modifica</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished">Impossibile salvare il file</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">Errore nel file.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Taglia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Altezza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished">Tessuto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished">Imbottitura</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished">Imbottitura interna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished">La cartella di destinazione</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished">Seleziona il percorso alla cartella di destinazione</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished">Sfogliare...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished">Formato file:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished">Nome file:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished">Nome del file di base</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished">Destra:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished">Sinistra:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished">Fondo:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished">Formato carta</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished">Il nome del file di base non ha corrispondenza con espressioni regolari.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished">Seleziona cartella</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished">Si è cercato di utilizzare un formato di numero fuori gamma.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished">Selezionato formato non presente.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation>Download fallito: %1.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation>Informazioni</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished">Gruppi</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - Punto base</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Arco_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished">Modifica</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">Storia</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished">Trova:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Punto base</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Arco_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Descrizione</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished">Unità:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Larghezza:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Altezza:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished">Conferma cancellazione</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Vuoi veramente cancellare?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Invertire</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>l programma viene fornito COSì COM&apos;è, SENZA ALCUN TIPO DI GARANZIA. COMPRESA LA GARANZIA DI DESIGN, COMMERCIABILITÀ E IDONEITÀ PER UN PARTICOLARE SCOPO.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished">Prendi:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished">Punto centrale:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Punto tangente:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Raggio:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished">Selezionare il centro del cerchio</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished">Modifica raggio</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Il raggio non può essere negativo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished">Prendi:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation>Centro:</translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Raggio:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula magica</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished">Seleziona secondo centro del cerchio</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished">Modifica primo raggio del cerchio</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished">Modifica secondo raggio del cerchio</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Il raggio non può essere negativo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Modelli:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Larghezza:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Altezza:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Ruota il pezzo</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Ruotare</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>grado</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Tre gruppi: grandi, medi, piccoli</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Due gruppi: grandi, piccoli</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>Area discendente</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centimetri</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Pollici</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Pixel</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Ritaglio automatico della lunghezza inutilizzata</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Unisci pagine (se possibile)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation>Larghezza divario:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Salva lunghezza del foglio</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Formato carta</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Sinistra:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Destra:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Top:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Fondo:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Campi sbagliati.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6626,84 +5194,67 @@ Apply settings anyway?</source>
 ⇥Area discendente = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation>Opzioni di Layout</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation>Shift/Offset lunghezza:</translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation>Consenti ai fogli con un&apos;altezza maggiore di velocizzare la creazione.</translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Stampa:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation>Nessun</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished">Millimetri</translation>
     </message>
@@ -6711,32 +5262,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,2660 +5289,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Strumenti per creare punti.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Strumenti per creare linee.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Linea</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Strumenti per creare curve.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Strumenti per creare archi.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Arco</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Misure</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nuovo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Crea nuovo modello</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Apri</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Apri file con modello</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Salva</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Salva modello</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Salva &amp;Come...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Salva il modello non ancora salvato</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Dettagli</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Strumenti cursore</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Storia</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>About &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;About Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>U&amp;scita</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Preferenze</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Segnalazione bug</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Mostra aiuto online</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>About Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Salva come</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Impossibile salvare il file</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Apri il file</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Errore di analisi del file.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Errore impossibile convertire il valore.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Errore parametro vuoto.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Errore id sbagliato.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Errore di analisi del file (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Id cattivo.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>File salvato</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>senzatitolo.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>Il pattern è stato modifcato.
 Vuoi salvare i cambiamenti?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Undo</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Redo</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>Questo file è già aperto in un&apos;altra finestra.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Unità sbagliate.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>File caricato</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Seamly2D non si è spenta correttamente. Vuoi riaprirei file (%1) che avevi aperto?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Riapri i file.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Layout</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation>Stampa</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation>Stampa PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation>Dividi e salva un layout in pagine più piccole (per stampanti normali)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation>Anteprima di stampa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation>Anteprima di stampa del layout originale</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation>Esporta Come...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation>Modalità layout</translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation>Modifiche non salvate</translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation>Misure caricate</translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation>Non puoi esportare il pannello vuoto.</translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation>Il file delle misure contiene misura(e) note come invalide.</translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation>Il file delle misure ha un formato sconosciuto.</translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation>Le tipologie dei file di misurazione non hanno corrispondenze.</translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation>Impossibile sincronizzare le misure.</translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation>Impossibile aggiornare le misure.</translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation>Il file delle misure &apos;%1&apos; non si trova.</translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation>File delle misure in carica</translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation>Valore della misura non supportata &apos;%1&apos; per questo pattern.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation>Impossibile stabilire la taglia. Il file non è stato aperto.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation>Il metodo %1 non fa nulla in modalità GUI</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation>Valore dell&apos;altezza non supportata &apos;%1&apos; per questo pattern.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation>Impossibile stabilire l&apos;altezza. Il file non è stato aperto.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation>Si prega di fornire un di input.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation>Stampa un layout originale</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation>Anteprima di stampa PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation>Anteprima di stampa del layout piastrellato</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation>Misure scaricate</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation>Impossibile scaricare misure. Alcune di queste sono utilizzate nel cartamodello.</translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>Nuovo pattern</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation>Apri il pattern</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation>Crea/modifica misure</translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>Salva...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Non salvare</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>File bloccato</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Questo file è già aperto in un&apos;altra finestra. Ignora se vuoi continuare (non consigliato, può provocare un danneggiamento dei dati).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Il file bloccato non può essere creato, per mancanza di autorizzazione. Ignora se vuoi continuare (scelta non consigliata, può causare un danneggiamento dei dati).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Si è verificato un errore sconosciuto, come ad esempio il fallimento di una partizione completa durante la trascrizione di un file bloccato. Ignora se vuoi continuare (scelta non consigliata, può causare un danneggiamento dei dati).</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Il file bloccato non può essere creato, per mancanza di autorizzazione.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Si è verificato un errore sconosciuto, come ad esempio il fallimento di una partizione completa durante la trascrizione di un file bloccato.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation>Operazioni</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation>Chiudi pezzo</translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation>Zoom originale</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Altezza:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Taglia:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation>Il file delle misure &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; non è stato trovato. Vuoi aggiornare la posizione del file?</translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation type="unfinished">Misure individuali</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>File Modello</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished">Valore calcolato</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished">Modifica</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotazione</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">Progetto Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished">Esporta</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished">Immagini</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished">Punto:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">senza titolo</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>modello</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
@@ -9405,86 +7291,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Creare file &apos;%1&apos; respinto! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Errore critico!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation>Errore di stampa</translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation>Impossibile procedere perché non ci sono stampanti disponibili nel sistema.</translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation>Senza nome</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation>Il layout è datato.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation>Il layout non è stato aggiornato dall&apos;ultima modifica del pattern. Vuoi continuare?</translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Impossibile preparare i dati per la creazione del layout</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation>Impossibile aprire stampante %1</translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation>Per avere l&apos;anteprima dei documenti con più pagine tutti i fogli dovrebbero avere la stessa dimensione.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation>Per stampare documenti con pagine multiple tutti i fogli devono avere la stessa dimensione.</translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation>Le pagine verranno tagliate perchè non si adattano al formato della carta della stampante.</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9492,148 +7358,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished">File</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Nuovo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Stampa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Salva</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Salva come</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Esporta in CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished">Aiuto</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished">Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished">Ctrl+G</translation>
     </message>
@@ -9641,123 +7477,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished">Collassa tutto</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished">Espandi tutto</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished">Seleziona tutto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished">Deseleziona tutto</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Altezza diretta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Larghezza diretta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Rientro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Mano</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Piede</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Testa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Circonferenza e arco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Verticale</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Orizzontale</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Busto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Equilibrio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Braccio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Gamba</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Altezza cavallo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Uomo &amp; Confezione</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Storico &amp; Specialità</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Misure modellistica</translation>
@@ -9766,18 +7581,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9785,37 +7592,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Unità:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9823,12 +7623,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation>muovi la prima etichetta della pince</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation>muovi la seconda etichetta della pince</translation>
     </message>
@@ -9836,7 +7634,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9844,7 +7641,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation>muovi l&apos;etichetta del punto</translation>
     </message>
@@ -9852,7 +7648,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished">muovi l&apos;etichetta del punto</translation>
     </message>
@@ -9860,7 +7655,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation>muovi punto singolo</translation>
     </message>
@@ -9868,7 +7662,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation>muovi curva spline</translation>
     </message>
@@ -9876,7 +7669,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation>muovi percorso spline</translation>
     </message>
@@ -9884,52 +7676,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>File nuove misure</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Tipo di misura:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Unità:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Misura base:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Altezza base:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Individuale</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Centimetri</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Pollici</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished">Millimetri</translation>
     </message>
@@ -9937,87 +7719,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished">Lettera</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished">Legale</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished">Tabloid</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished">Rotolo 24po / 60.96cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished">Rotolo 30po / 76.20cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished">Rotolo 36po / 91.44cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished">Rotolo 42po / 106.68cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished">Rotolo 44po / 111.76cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizzato</translation>
     </message>
@@ -10025,887 +7790,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished">Lettera:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished">Posizione:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished">Tutti gli oggetti sul tracciato devono seguire il senso orario.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished">Pronto!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Larghezza:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Formula magica</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished">Angolo:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizzato</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished">Altezza:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Lunghezza:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished">Tipo:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Invertire</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Opzioni</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished">Modifica lunghezza</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished">Modifica angolo</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished">Hai bisogno di più punti!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Hai doppi punti!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation>Centro:</translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation>In alto a sinistra:</translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation>In fondo a destra:</translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished">Top:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation>Fondo:</translation>
     </message>
@@ -10913,218 +8425,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11132,27 +8592,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11160,77 +8615,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11238,139 +8678,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11378,62 +8773,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished">Seleziona punto per valore Y (orizzontale)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -11441,316 +8824,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished">Intervallo:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished">Lingua</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">Lingua di interfaccia:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished">Unità di default:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished">L&apos;unità di default è stata aggiornata e verrà utilizzata come impostazione predefinita nella creazione del prossimo modello.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimetri</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished">Pollici</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished">Annullare</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished">Separatore decimale:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished">Millimetri</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished">Suono:</translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished">Email:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished">Locale dell&apos;utente</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished">Benvenuti</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11758,582 +9075,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Punto</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Linea</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Arco</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished">Operazioni</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Dettagli</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished">Risultato grafico</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished">Taglia:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Larghezza:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished">Esporta</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Percorso</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished">Modifica</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished">Apri Cartella</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12341,272 +9490,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Margine di cucitura</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished">Tipo:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">Lunghezza:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Larghezza:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Path</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Larghezza</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Altezza</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished">Templates</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12614,7 +9693,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>basata su Qt %1 (%2, %3 bit)</translation>
     </message>
@@ -12622,155 +9700,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Crea nuovo pezzo di cartamodello per iniziare a lavorare.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>pollice</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Proprietà</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Valore</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation>Aggiungi nodo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation>Modifiche applicate.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished">Tessuto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished">Imbottitura</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished">Imbottitura interna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12778,15 +9825,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation>troppo pochi elementi per la funzione somma.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation>troppo pochi elementi per la funzione sottrazione.</translation>
@@ -12795,217 +9838,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Gettone inaspettato &quot;$TOK$&quot; ha trovato una posizone $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Errore interno</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Nome funzione-, variabile- o costante invalidi: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Operatore binario identificativo non valido: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Identificatore operatore infisso non valido: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Operatore di suffisso non valido identificativo:&quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Puntatore non valido per la funzione di richiamo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>L&apos;espressione è vuota.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Puntatore non valido per la variabile.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Operatore inaspettato &quot;$TOK$&quot; trovato nella posizione $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Inattesa fine dell&apos;espressione nella posizione $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Elemento separatore inaspettato in posizione $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Parentesi inaspettata &quot;$TOK$&quot; in posizione $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Funzione inaspettata &quot;$TOK$&quot; in posizione $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Valore inaspettato &quot;$TOK$&quot; trovato in posizione $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Variabile inaspettata &quot;$TOK$&quot; trovata in posizione $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Elementi della funzione utilizzati senza una funzione (posizione: $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Parentesi mancante</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Troppi parametri per la funzione &quot;$TOK$&quot; nella posizione espressione $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Troppo pochi parametri per funzione &quot;$TOK$&quot; nella posizione espressione $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Dividi per zero</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Errore di dominio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Conflitto di nome</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>Valore non valido per priorità degli operatori (deve essere maggiore o uguale a zero).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>operatore binario definito dall&apos;utente &quot;$TOK$&quot; in conflitto con un operatore integrato.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Elemento della stringa inaspettato trovato in posizione $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Stringa non terminata a partire dalla posizione $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>Funzione stringa chiamata con un tipo di argomento non stringa.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>Valore stringa utilizzato dove è previsto un argomento numerico.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Nessun sovraccarico adatto per l&apos;operatore &quot;$TOK$&quot; nella posizione $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>La funzione risultante è una stringa.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Errore parser.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>Il separatore decimale è identico all&apos;argomento separatore della funzione.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>L&apos;operatore &quot;$TOK$&quot; deve essere preceduto da una parentesi di chiusura.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>All&apos;operatore if-then-else manca la clausola else</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Due punti fuori posto alla posizione $POS$</translation>
@@ -13014,7 +10021,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13022,7 +10028,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished">Rinomina la parte di cartamodello</translation>
     </message>
@@ -13030,12 +10035,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13043,7 +10046,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished">salva l&apos;opzione del dettaglio</translation>
     </message>
@@ -13051,7 +10053,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13059,7 +10060,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation>salva opzione strumento</translation>
     </message>
@@ -13067,88 +10067,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Lingua</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">Lingua di interfaccia:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished">Sistema di modellistica</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished">Sistema:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">Autore:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished">Libro:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished">Toolbar</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished">Il testo appare sotto l&apos;icona. (raccomandato per i principianti).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished">Altezza e taglia di default</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Altezza:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished">Taglia:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished">Separatore decimale:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished">Locale dell&apos;utente</translation>
     </message>
@@ -13156,52 +10138,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Percorso</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished">Modifica</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished">Apri Cartella</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13209,102 +10181,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Benvenuti</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation>Benvenuti a SeamlyME</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation>Utenti di 3D Look</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation>Per utilizzare una scansione del corpo 3D Look, il file deve essere convertito nel formato SeamlyME. </translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation>Allegare il file 3DLook a un&apos;e-mail e inviarlo a convert@seamly.io.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Riceverete un&apos;e-mail con il file convertito, che potrete caricare in SeamlyME come di consueto.</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation>Scegliere le unità di misura, il separatore decimale e la lingua preferiti. (È possibile modificarli in seguito.)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation>Unità:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Imposta le unità di misura predefinite per un nuovo file di misura.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Separatore decimale:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation>Lingua di interfaccia:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation>Imposta la lingua utilizzata per SeamlyMe.</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation>Non mostrare di nuovo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Locale dell&apos;utente</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Centimetri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Millimetri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Pollici</translation>
     </message>
@@ -13312,92 +10263,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Benvenuti</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation>Benvenuti a Seamly2D</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation>Unità:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Imposta le unità di misura predefinite per un nuovo file di misura.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Separatore decimale:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation>Lingua di interfaccia:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation>Non mostrare di nuovo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Locale dell&apos;utente</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Centimetri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Millimetri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Pollici</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation>Imposta la lingua utilizzata per Seamly2D.</translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation>Scegliere le unità di misura, il separatore decimale, la lingua e il suono di selezione preferiti. (È possibile modificarli in seguito.)</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation>Suono:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation>Imposta il suono del clic di selezione del nodo.</translation>
     </message>
@@ -13405,12 +10337,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13418,1071 +10348,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished">File</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Nuovo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished">Apri</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Salva</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Salva come</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Stampa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished">Modifica</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished">Annullare</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Misure</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Punto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Linea</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished">Operazioni</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotazione</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished">Immagini</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Dettagli</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished">Layout</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">Storia</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished">Aiuto</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14490,12 +11203,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14503,42 +11214,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14546,7 +11249,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14554,7 +11256,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14562,819 +11263,626 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Seleziona nuovo per la creazione di un file delle misure.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation>Valore calcolato</translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Formula</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Valore di base</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>Nelle taglie</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>Nelle altezze</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Dettagli</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Formula:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation>Valore base:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation>Nelle misure:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation>Nelle altezze:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Descrizione:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation>Sposta la misura sopra</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Sposta la misura sotto</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Valore calcolato:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation>Nome intero:</translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>Informazione</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Tipo:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation>Tipo di misura</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Path:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Mostra in Explorer</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Misura base:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation>Valore base della misura</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Altezza base:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation>Valore base dell&apos;altezza</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Nome specificato:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Cognome:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation>Data di nascita:</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>Email:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>Note:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>File</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Finestra</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Misure</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation>Menu</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation>Gradazione</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation>Individuale aperto ...</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation>Salva come ...</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>About &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>Informazioni su nastro</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation>Aggiungi nota</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation>Aggiungere personalizzato</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation>Sola lettura</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>Database</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation>Mostra informazioni su tutte le misure conosciute</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Preferenze</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation>untitled %1</translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>Questo file è già aperto in un&apos;altra finestra.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Errore nel file.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Impossibile salvare il file</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Salva come</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation>&amp;New Window</translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation>Modifica misure</translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Campo vuoto.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Errore Parser: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Misure individuali</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>senza titolo</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation>Modifiche non salvate</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Le misure sono state modificate.
 Vuoi salvare le tue modifiche?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Campo vuoto</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Apri il file</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation>Importa dal cartamodello</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation>Unità pattern:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Trova:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation>Trova Precedente</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation>Trova Prossimo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation>Impossibile bloccare. Questo file è già aperto in un&apos;altra finestra.</translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation>Il file contiene misura(e) non valide.</translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation>Il file ha un formato sconosciuto.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Nome intero</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation>File &apos;%1&apos; non esiste!</translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation>è proibito cambiare il nome di misure note.</translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation>Impossibile trovare misure &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation>è proibito cambiare il nome completo della misura conosciuta.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation>Creazione guidata funzione</translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation>Sposta la misura in alto</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation>Sposta la misura in basso</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation>Cancella misura</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation>sconosciuto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>maschio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>femmina</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation>Genere:</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation>Sistema PM:</translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation>Crea da esistente ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation>Crea da file esistente</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation>Seleziona file</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation>Diagramma misure</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Misure sconosciuta&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Misura sconosciuta&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>About Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>Il file non è stato ancora salvato.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation>Nome della misura nella formula</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation>Nome della misura nella formula.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation>Nome leggibile della misura.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>Salva...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Non salvare</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>File bloccato</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Il file bloccato non può essere creato, per mancanza di autorizzazione.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Si è verificato un errore sconosciuto, come ad esempio il fallimento di una partizione completa durante la trascrizione di un file bloccato.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation>Esporta in CSV</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Mostra nella barra di ricerca</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation>Nome Cliente</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation>Cognome Cliente</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation>Indirizzo Email Cliente</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Altezza:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Taglia:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished">Stampa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation>Ctrl+Alt+O</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation>File Modello</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Questo file è già aperto in un&apos;altra finestra. Ignora se vuoi continuare (non consigliato, può provocare un danneggiamento dei dati).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Il file bloccato non può essere creato, per mancanza di autorizzazione. Ignora se vuoi continuare (scelta non consigliata, può causare un danneggiamento dei dati).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Si è verificato un errore sconosciuto, come ad esempio il fallimento di una partizione completa durante la trascrizione di un file bloccato. Ignora se vuoi continuare (scelta non consigliata, può causare un danneggiamento dei dati).</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15382,7 +11890,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15390,22 +11897,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15413,22 +11916,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15436,47 +11935,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">Primo punto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Secondo punto</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished">Punto più alto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished">Punto più basso</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished">Punto più a sinistra</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished">Punto più a destra</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Linea_</translation>
     </message>
@@ -15484,47 +11974,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Strumento di unione</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vuoi veramente unire i dettagli?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished">Conserva pezzi originali</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Seleziona un secondo punto</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Seleziona un unico punto</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished">Seleziona un punto sullo spigolo</translation>
     </message>
@@ -15532,7 +12013,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15540,17 +12020,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Non chiedere di nuovo</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Do not &amp;ask again</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>Do not &amp;show again</translation>
     </message>
@@ -15558,57 +12035,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Impossibile ottenere le informazioni sulla versione.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>Troppe etichette &lt;%1&gt; nel file.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Versione &quot;%1&quot; non valida.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Versione &quot;0.0.0&quot; non valida.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Versione invalida. Versione minima supportata è %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Versione invalida. Versione massima supportata è %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Errore id non unico.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>Impossibile cambiare versione.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation>Errore nella creazione di una copia di riserva: %1.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Inaspettata versione &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15616,7 +12082,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15624,22 +12089,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Esporta in CSV</translation>
     </message>
@@ -15647,13 +12108,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
@@ -15661,23 +12119,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>Impossibile trovare strumento sulla tavola.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>Nuovo gruppo</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15685,7 +12138,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15693,12 +12145,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -15706,283 +12156,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Conferma cancellazione</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Vuoi veramente cancellare?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15990,302 +12383,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation>Percorso del file di misura personalizzato (modalità di esportazione).</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation>Il file di misura</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation>Numero formato</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation>Numero template</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>Larghezza pagina</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation>Unità di misura</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Angolo</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation>Ritaglio automatico lunghezza inutilizzata (modalità esportazione).</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation>Unità layout (come per la carta eccetto px, modalità esportazione).</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation>L&apos;unità</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation>La larghezza del gap</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation>Tipo di raggruppamento</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation>Impossibile usare il formato pagina e misure/unità esplicite della pagina assieme.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation>Altezza, larghezza e unità della pagina devono essere utilizzate tutte e 3 in una volta.</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation>Valore di rotazione non valido. Deve essere uno dei valori predefiniti.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation>Modello di pagina selezionata sconosciuto.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation>Unità cartacee non supportate.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation>Unità di layout non supportate.</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation>Le opzioni di esportazione posso venire utilizzate solo con file di input singoli.</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation>L&apos; opzione test può essere usata solo con file di input singolo.</translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation>Nome del file base del file di layout esportati. Usalo per abilitare la modalità di esportazione di console.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation>Il nome del file base dei file di layout</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>La cartella di destinazione</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation>Il valore di misura</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation>Il valore di altezza</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Larghezza della pagina in unità di misura correnti come 12.0 (non possono venire utilizzate con &quot;%1&quot;, modalità di esportazione).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Altezza pagina in unità correnti come 12.0 (non possono venire utilizzate con &quot;%1&quot;, modalità di esportazione).</translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation>Valore di gradazione misura non valido.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation>Valore di gradazione altezza non valido.</translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Programma di modellistica.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>File modello.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation>Il margine sinistro deve essere usato con le unità della pagina.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation>Il margine destro deve essere usato con le unità della pagina.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation>Il margine in alto deve essere accompagnato dalle unità della pagina.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation>Il margine in basso deve essere usato con le unità della pagina.</translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation>Unità di misura di altezza/larghezza pagina (non possono venire utilizzate con &quot;%1&quot;, modalità di esportazione). Valori corretti: %2.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation>Ignora i margini di stampa (modalità di esportazione). Sono disabilitati i valori &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Imposta tutti i margini a 0.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Margine sinistro della pagina è nelle unità correnti 3.0 (modalità di esportazione). Se non impostato verrà utilizzato il valore di default della stampante. Oppure 0 se nessuna stampante viene trovata. Il valore verrà ignorato se viene utilizzato &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Margine destro della pagina è in unità correnti 3.0 (modalità di esportazione). Se non impostato verrà utilizzato il valore di default della stampante. Oppure 0 se nessuna stampante viene trovata. Se viene utilizzato &quot;%1&quot; il valore verrà ignorato.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16293,43 +12626,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished">Misure</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16337,55 +12661,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>Impossibile trovare l&apos;oggetto</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16393,12 +12704,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16406,50 +12715,40 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>Questo ID è già esistente.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16457,27 +12756,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16485,7 +12779,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16493,11 +12786,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
@@ -16505,7 +12793,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished">Formula:</translation>
     </message>
@@ -16513,7 +12800,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16521,7 +12807,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16529,12 +12814,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16542,12 +12825,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16555,335 +12836,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Errore di analisi del file.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Errore impossibile convertire il valore.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Errore parametro vuoto.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Errore id sbagliato.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Errore di analisi del file (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation>Errore nome non unico.</translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16891,17 +13083,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16909,12 +13098,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16922,14 +13109,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16937,17 +13120,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angolo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -16955,27 +13135,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16983,37 +13158,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17021,7 +13189,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -17029,12 +13196,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17042,32 +13207,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Arco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17075,18 +13234,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17094,18 +13249,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17113,7 +13264,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -17121,28 +13271,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17150,17 +13294,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angolo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -17168,12 +13309,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angolo</translation>
     </message>
@@ -17181,7 +13320,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -17189,27 +13327,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angolo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17217,17 +13350,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angolo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -17235,7 +13365,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17243,12 +13372,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">Primo punto della linea</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Secondo punto della linea</translation>
     </message>
@@ -17256,27 +13383,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Punto centrale</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Angolo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17284,714 +13406,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Punto base</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation>Pince precisa</translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished">Punto base:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Lunghezza:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished">Angolo:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">Primo punto:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Punto centrale:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Raggio:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished">Primo angolo:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished">Secondo angolo:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished">Terzo punto:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished">Primo punto base:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished">Secondo punto base:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished">Primo punto della pince:</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished">Arco:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished">Curva:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished">Primo punto della linea:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished">Secondo punto della linea:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished">Centro dell&apos;arco:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished">Primo arco:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished">Secondo arco:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished">Prendi:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished">Prima curva:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished">Seconda curva:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Punto tangente:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished">Punto dell&apos;asse:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished">Suffisso:</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished">Quarto punto:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotazione</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinate</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished">Secondo punto della pince:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished">Terzo punto della pince:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Linea</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">Primo punto</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Seconda linea</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation>Centro:</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Origin point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Arco_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Linea_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Punto centrale</translation>
     </message>
@@ -17999,12 +13805,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18012,17 +13816,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Angolo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -18030,12 +13831,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18043,12 +13842,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18056,12 +13853,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18069,17 +13864,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Lunghezza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Angolo</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -18087,1552 +13879,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation>Bunka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation>Bunka Fashion College</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation>Barnfield and Richard</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation>Jo Barnfield e Andrew Richards</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation>Amicizia/Donne</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation>Elizabeth Friendship</translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation>Creazione di abiti storici-Cartamodelli dal 16° al 19° secolo</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation>Morris, K.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation>Karen Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation>Cucire biancheria intima che veste bene</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation>Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation>Lucia Mors de Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation>Creazione di cartamodelli in pratica</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation>Kim &amp; Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation>Injoo Kim e Mykyung Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation>Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation>Norah Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation>Corsetti e crinoline</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation>Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation>Frances Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation>Sistema Internazionale di Thornton</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation>La grande guerra: stili e modelli del decennio 1910</translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation>Hillhouse &amp; Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation>Marion S. Hillhouse e Evelyn A. Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation>Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation>Esther Kaplan Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation>Come progettare bellissimi abiti: progettazione e creazione del modello</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation>Minister &amp; Son</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>Edward Minister &amp; Son, ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation>Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation>Gertrude Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation>Loh &amp; Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation>May Loh e Diehl Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation>Progettazione della moda senza modelli</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation>Morris, F. R.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation>F. R. Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation>Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation>Gertrude Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation>Il libro dei modelli della casa Gertrude</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation>Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation>K. Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation>The Master Designer (Chicago, IL)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation>Kopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation>Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation>Doris Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation>Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation>Sarah J. Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation>Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation>Karla J. Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation>Progettazione e cucitura del jeans</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Rivista Lady Boutique magazine (Jappone)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation>Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation>M. Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation>Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation>Dorothy Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation>Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation>Bina Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation>Sue S. Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation>Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation>Mabel D. Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation>Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation>E. L. G. Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation>Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation>Elizabeth M. Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation>McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation>Donald H. McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation>Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation>Shri K. R. Zarapkar e Shri Arvind K. Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation>Zarapkar System of Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation>Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation>Philip Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation>Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation>Jack Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation>Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation>R. I. Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation>MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation>Jason MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation>The Victorian Tailor: An Introduction to Period Tailoring</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation>Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation>Helen Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation>Frederick T. Croonberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation>Sugino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting Vols. I, II, III (Giappone)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation>Louis Devere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation>The Handbook of Practical Cutting on the Centre Point System</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation>Winifred Aldrich</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation>Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation>Gareth Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation>Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation>Teresa Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation>Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation>Dennic Chunman Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation>Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation>Lori A. Knowles</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation>Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation>P. Clement Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation>Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation>Jno. J. Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation>GOST 17917-86</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation>Eddy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation>Nessuno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation>Il team di Seamly2D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>in</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Linea_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Arco_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">RaggioArco_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19641,17 +15176,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19659,7 +15191,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19667,7 +15198,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19675,7 +15205,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19683,12 +15212,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19696,7 +15223,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19704,7 +15230,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19712,17 +15237,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19730,47 +15252,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>ATTENZIONE:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>CRITICO:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>FATALE:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation>Informazioni</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19778,47 +15291,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>ATTENZIONE:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>CRITICO:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>FATALE:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>Over Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Website: %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Kan uw standaard browser niet openen</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Gebouwd op %1 op %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation>CPU:</translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation>OS:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Kijk voor Opwaarderingen</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation>Downloaden installeerprogramma %p% volledig</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation>onbekend</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation>voeg tekenblok %1 toe</translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>Voeg groep toe</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation>Voeg patroondeel toe</translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>voeg object toe</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation>Ankerpunt</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation>Ankerpunt gereedschap</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation>Punt:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation>Patroondeel:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Fout bij uitpakken bestand. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Fout slechte ID. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Fout kan waarde niet omzetten. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Fout lege parameter. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Fout verkeerde ID. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Er gaat iets verkeerd!!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Fout bij uitpakken bestand: %1. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Uitgeworpen uitzondering: %1. Programma wordt beëindigd.</translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Fout bij uitpakken bestand. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Fout slechte ID. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Fout kan waarde niet omzetten. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Fout lege parameter. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Fout verkeerde ID. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Er gaat iets verkeerd!!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Fout bij uitpakken bestand: %1. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Uitgeworpen uitzondering: %1. Programma wordt beëindigd.</translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation>Seamly2D&apos;s maten editor.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation>Het maten bestand.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation>De basis hoogte</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation>De basis maat</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation>Stel patroon bestand eenheid in: cm, mm, inches.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation>De patrooneenheid</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation>Ongeldig basis maat argument. Moet bestaan uit: cm, mm, inches.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation>Kan niet beginnen met verwerken van inkomende connecties op naam &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation>Test modus ondersteunt niet het openen van verschillende bestanden.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation>Alsublieft, verstrek éen invoer bestand.</translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation>Open met de basis maat. Geldige waardes: %1cm.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation>Ongeldige basis hoogte argument. Moet bestaan uit %1cm.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation>Ongeldige basis maat argument. Moet bestaan uit %1cm.</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation>Open met de basis hoogte. Geldige waardes: %1cm.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation>Gebruik voor eenheid testing. Laat het programma lopen en open een bestand zonder het te vertonen in een raamwerk.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Schakel hoog-dpi-schaling uit. Gebruik deze optie als je problemen hebt met schaalverandering (als default is ingeschakeld). Als alternatief kun je %1 omgevingsvariabele gebruiken.</translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation>Rekenmachine</translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation>±</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation>Backspace</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation>Wissen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation>Alles Wissen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation>MC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation>MR</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation>MS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation>M+</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation>÷</translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation>×</translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation>Sqrt</translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation>x²</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation>1/x</translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation>=</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation>Rekenmachine</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation>####</translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation>Decimaaltabel</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>verwijder groep</translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>verwijder gereedschap</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation>verwijder tekenblok %1</translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>Verwijder gereedschap</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation>Over SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation>Versie programma SeamlyMe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation>Herziene uitgave gebouwd: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation>Dit programma is een deel van het Seamly2D project.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation>Downloaden installeerprogramma %p% volledig</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation>Kijk voor Opwaarderingen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation>Kan uw standaard browser niet openen</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation>Gebouwd op %1 op %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation>Web site : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation>onbekend</translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toont volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Selecteer tweede punt van lijn</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Verander lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>Eerste punt van de lijn</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Tweede punt van de lijn</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation>Punt - Op Lijn</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -781,138 +628,104 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toont volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Straal kan niet negatief zijn</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Gelijke zijden</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Verander straal</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Verander eerste hoek</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Verander tweede hoek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Straal:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>Eerste hoek:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Tweede hoek:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Middelste punt:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Selecteer het middelste punt van de boog</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation>Boog - Straal en Hoeken</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Berekening Eerste Hoek&lt;/span&gt;&lt;br/&gt;Hoeken worden opgegeven in graden. Een volledige cirkel is 360 graden. Positieve waarden voor een hoek betekenen een richting tegen de klok, terwijl negatieve hoeken met de klok meegaan. Nul graden is op de positie van 3 uur op een horloge.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Hoekberekening&lt;/b&gt;&lt;br&gt;Hoeken worden opgegeven in graden. Een volledige cirkel is 360 graden. Positieve waarden voor een hoek betekenen een richting tegen de klok, terwijl negatieve hoeken met de klok meegaan. Nul graden is op de positie van 3 uur op een horloge.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -920,127 +733,96 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toont volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Verander straal</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Verander de eerste hoek</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Verander de booglengte</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Straal kan niet negatief zijn</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>Lengte kan niet gelijk zijn aan 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Straal:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>Eerste hoek:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Gecentreerde punt:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation>Boog - Straal en Lengte</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Hoekberekening&lt;/b&gt;&lt;br&gt;Hoeken worden opgegeven in graden. Een volledige cirkel is 360 graden. Positieve waarden voor een hoek betekenen een richting tegen de klok, terwijl negatieve hoeken met de klok meegaan. Nul graden is op de positie van 3 uur op een horloge.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -1048,107 +830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toont volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Selecteer tweede punt van lijn</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Selecteer derde punt van lijn</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Verander lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Derde punt:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation>Punt - Op Bisectrice</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -1156,77 +917,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Derde punt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Vierde punt:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Selecteer het tweede punt van de kromme</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Selecteer het derde punt van de kromme</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Selecteer het vierde punt van de kromme</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>Ongeldige spline</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation>Kromme - Vast</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
@@ -1234,57 +980,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Punt:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>Puntenlijst</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation>Ongeldig splinepad</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation>Spline - Vast</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation>Pad:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
@@ -1292,99 +1027,80 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toont volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Selecteer as punt</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Verander de hoek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>As punt:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Kromme:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation>Snijpunt - Kromme en As</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Hoekberekening&lt;/b&gt;&lt;br&gt;Hoeken worden opgegeven in graden. Een volledige cirkel is 360 graden. Positieve waarden voor een hoek betekenen een richting tegen de klok, terwijl negatieve hoeken met de klok meegaan. Nul graden is op de positie van 3 uur op een horloge.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -1392,67 +1108,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toont volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Verander de lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Boog:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation>Punt - Op Boog</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -1460,67 +1163,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toont volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Verander de lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Kromme:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation>Punt - Op Kromme</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -1528,67 +1218,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toont volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Verander de lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Kromme:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation>Punt - Op Spline</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -1596,22 +1273,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation>Aanpassen van datum/tijd label</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation>Indeling:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation>Voeg een indeling in</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;leeg&gt;</translation>
     </message>
@@ -1619,170 +1292,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation>Straal1:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Laat hele berekening zien in berichtenbox&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation>Straal2:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation>Eerste hoek:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation>Tweede hoek:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation>Hoek van draaiing:</translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation>Middelpunt:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation>Kies middelpunt van boog</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Straal mag niet negatief zijn</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Gelijke hoeken</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation>Bewerk straal1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation>Bewerk straal2</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Bewerk eerste hoek</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Bewerk tweede hoek</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation>Bewerk de grootte van de hoek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation>Boog - Ellipsvormig</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Berekening Eerste Hoek&lt;/span&gt;&lt;br/&gt;Hoeken worden opgegeven in graden. Een volledige cirkel is 360 graden. Positieve waarden voor een hoek betekenen een richting tegen de klok, terwijl negatieve hoeken met de klok meegaan. Nul graden is op de positie van 3 uur op een horloge.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Berekening Tweede Hoek&lt;/span&gt;&lt;br/&gt;Hoeken worden opgegeven in graden. Een volledige cirkel is 360 graden. Positieve waarden voor een hoek betekenen een richting tegen de klok, terwijl negatieve hoeken met de klok meegaan. Nul graden is op de positie van 3 uur op een horloge.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Berekening Draaiingshoek&lt;/span&gt;&lt;br/&gt;Hoeken worden opgegeven in graden. Een volledige cirkel is 360 graden. Positieve waarden voor een hoek betekenen een richting tegen de klok, terwijl negatieve hoeken met de klok meegaan. Nul graden is op de positie van 3 uur op een horloge.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -1790,107 +1415,84 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toon volledige berekening in berichtenbox &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Verander de hoek</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Verander de lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Basis punt:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation>Punt - Lengte en Hoek</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Hoekberekening&lt;/b&gt;&lt;br&gt;Hoeken worden opgegeven in graden. Een volledige cirkel is 360 graden. Positieve waarden voor een hoek betekenen een richting tegen de klok, terwijl negatieve hoeken met de klok meegaan. Nul graden is op de positie van 3 uur op een horloge.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -1898,47 +1500,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Export opties</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>Met hoofdtitel</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation>Codec:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Scheidingsteken</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation>Tabtoets</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>Komma</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>Puntkomma</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Spatie</translation>
     </message>
@@ -1946,72 +1539,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Selecteer eerste punt van lijn</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Selecteer tweede punt van lijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Basis punt:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation>Punt - Snijpunt Lijn en Loodrechte</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -2019,356 +1598,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation>binnenpad gereedschap</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation>Pad</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation>Onbenoemd pad</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation>Maak een naam voor jouw pad</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation>Soort:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation>Patroondeel:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation>Bewij de rij naar bovenaan de lijst</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation>Beweeg de rij één rij naar boven</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation>Beweeg de rij één rij naar beneden</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation>Beweeg de rij naar onderaan de lijst</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation>Het pad is een kniplijn</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation>Knip in stof</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation>Klaar!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation>Naadtoeslag</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation>Breedte:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation>Kernpunten</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation>Kernpunt:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation>Vooraf:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation>Terug naar standaard breedte</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation>Nadat:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation>Pasmarkeringen</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation>Pasmarkering:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation>Soort</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation>Knipje</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation>T Pasmarkering</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation>U Pasmarkering</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation>Interne V Pasmarkering</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation>Externe V Pasmarkering</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation>Kasteel</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation>Subtype</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation>Rechttoe rechtaan</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation>Bisector</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation>Selecteer om het hoekpunt als pasmarkering aan te duiden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation>Kruispunt van lijnen</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation>Zet hoek pasmarkering terug naar standaard.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation>Aantal:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation>Zet breedte pasmarkering terug naar standaard.</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation>Deze optie heeft alleen effect als de optie om een tweede pasmarkering te laten zien op de zoomlijn aangevinkt is in de algemene opties. Deze optie staat het vervolgens toe om het tweede knipje voor dit specifieke knipje, uit te zetten.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation>Toon tweede pasmarkering op de naadlijn</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation>Zet lengte pasmarkering terug naar standaard.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation> Breedte:</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation>Selecteer hoofdpad-objecten met de klok mee,&lt;b&gt;Shift&lt;/b&gt; - draai richting kromme om, &lt;b&gt;Enter&lt;/b&gt; - einde creatie </translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation>Keer om</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation>Verwijder</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation>Huidige naadtoeslag</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation>Bewerk zoombreedte</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation>Bewerk zoombreedte vooraf</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation>Bewerk zoombreedte voorbij</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation>Binnenpad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation>Aangepaste naadtoeslag</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation>Je hebt meer punten nodig!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation>Het eerste punt van  &lt;b&gt;aangepaste naadtoeslag&lt;/b&gt; kan niet gelijk zijn aan het laatste punt!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation>Je hebt punten dubbel!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation>Elk punt in het pad van de &lt;b&gt; aangepaste naadtoeslag&lt;/b&gt; moet uniek zijn!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation>Lijst van objecten is leeg!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation>Selecteer een detail om in te voegen, aub!</translation>
     </message>
@@ -2376,28 +1873,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Kon geen data voorbereiden om opmaak te creëren</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Maak een opmaak</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation>Gerangschikte patroondelen: %1 van %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Beste positie zoeken voor de patroondelen. Een moment geduld a.u.b.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation>Eén of meer patroondelen zijn groter dan het papierformaat dat je hebt gekozen. Selecter een groter papierformaat aub.</translation>
     </message>
@@ -2405,58 +1896,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Selecteer tweede punt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation>Lijn - Tussen Punten</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation>Lijn_</translation>
     </message>
@@ -2464,64 +1943,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Eerste lijn</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Tweede lijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Selecteer tweede punt van eerste lijn</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Selecteer eerste punt van tweede lijn</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Selecteer tweede punt van tweede lijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation>Punt - Snijpunt Lijnen</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -2529,124 +1994,100 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toont volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Eerste punt van de lijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Selecteer tweede punt van lijn</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Selecteer as punt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>As punt</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Tweede punt van de lijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Verander de hoek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>As punt:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation>Snijpunt - Lijn en As</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Hoekberekening&lt;/b&gt;&lt;br&gt;Hoeken worden opgegeven in graden. Een volledige cirkel is 360 graden. Positieve waarden voor een hoek betekenen een richting tegen de klok, terwijl negatieve hoeken met de klok meegaan. Nul graden is op de positie van 3 uur op een horloge.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -2654,22 +2095,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Maten</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation>ME Database - Voeg bekende maat toe</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation>Vind:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation>Zoek</translation>
     </message>
@@ -2677,47 +2114,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation>Spiegel over As</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation>As punt:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation>Achtervoegsel:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation>As-type:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation>Selecteer rotatiepunt op as</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation>Kies een draaipunt op de as dat geen deel uitmaakt van de geselecteerde objecten</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation>Verticale as</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation>Horizontale as</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
@@ -2725,47 +2153,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation>Spiegel over Lijn</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation>Eerste punt van de lijn:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation>Tweede punt van de lijn:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation>Achtervoegsel:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation>Selecteer eerste punt van de spiegellijn</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation>Het eerste punt van de spiegellijn mag geen deel uitmaken van de gekozen objecten</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation>Selecteer tweede punt van de spiegellijn</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation>Het tweede punt van de spiegellijn mag geen deel uitmaken van de gekozen objecten</translation>
     </message>
@@ -2773,93 +2192,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation>Achtervoegsel:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation>Bewerk de hoek</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Bewerk de lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation>Verplaats</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation>Oorsprong Punt:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation>Draaiing:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Middelste punt</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation>Bewerk de draaiing</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
@@ -2867,42 +2264,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Eenheden:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Unieke naam patroondeel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Kies unieke naam voor het patroondeel.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>Nieuw patroon</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation>Millimeters</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation>Naam van het tekenblok:</translation>
     </message>
@@ -2910,107 +2299,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toont volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Selecteer tweede punt van lijn</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Verander de lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation>Punt - Op Loodrechte</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation>Draaiing:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -3018,210 +2386,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Patroon beschrijving</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Hoogtes en maten</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Alle hoogtes (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Alle maten (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Standaardhoogte en grootte</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Op maat</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Hoogte:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Maat:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Veiligheid</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Open alleen om te lezen</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation>Vraag het context menu op om te veranderen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>Geen afbeelding</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Verwijder afbeelding</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Verander afbeelding</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Sla afbeelding op in bestand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Toon afbeelding</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation>Afbeelding voor patroon</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Afbeeldingen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Sla bestand op</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>zonder titel</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Pad:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Toon in Explorer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;Leeg&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>Bestand was nog niet opgeslagen.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Toon in Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Patroon naam:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Patroon nummer:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Bedrijfs/ontwerpers naam:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Klant naam:</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation>Van meerdere maten metingen</translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Patroon</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation>Voor technische aantekeningen</translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation>Gegevens op label</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation>Labelsjabloon:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation>Bewerk patroonlabel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation>Bewerk sjabloon</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation>Datumindeling:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation>Tijdsindeling:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation>Sla labelgegevens op.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation>De gegevens op het label zijn veranderd. Wil je ze opslaan voordat het sjabloon wordt bewerkt?</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation>Patroon Voorkeuren</translation>
     </message>
@@ -3229,47 +2553,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Selecteer een boog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Raaklijn punt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Boog:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Kies:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Punt - Snijpunt Boog en Raaklijn</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -3277,87 +2592,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toon volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Selecteer middelste punt van boog</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Selecteer tweede punt van lijn</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Verander straal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Straal:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation>Midden van de boog:</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation>Punt - Snijpunt Boog en Lijn</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation>eerste lijnpunt:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation>tweede lijnpunt</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -3365,47 +2663,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation>Selecteer een tweede boog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>Eerste boog:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Tweede boog:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Kies:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation>Punt - Snijpunt Bogen</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -3413,52 +2702,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>Eerste kromme:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Tweede kromme:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Selecteer tweede kromme</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation>Punt - Snijpunt Krommes</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation>Verticale steek:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation>Horizontale steek:</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -3466,27 +2745,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Patroon</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation>Programma Voorkeuren</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation>Bestandpaden</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation>Grafisch</translation>
     </message>
@@ -3494,62 +2768,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Draaiing</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Achtervoegsel:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation>Verander de hoek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation>Draaipunt:</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation>Kies draaipunt</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation>Kies een draaipunt dat niet behoort tot de lijst van objecten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
@@ -3558,17 +2820,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation>Voorkeuren</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation>Bestandspaden</translation>
     </message>
@@ -3576,107 +2835,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toon volledige berekening in berichten box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Selecteer eerste punt van lijn</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Selecteer tweede punt van lijn</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Verander de lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Derde punt:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation>Punt - Lengte tot Lijn</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -3684,47 +2922,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Coordinaten op het blad</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Coordinaten</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation>Basis Punt</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation>X coordinaat:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation>Y coordinaat:</translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -3732,148 +2961,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Eerste punt</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Tweede punt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Selecteer laatste punt van de krommming</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>Ongeldige spline</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toon volledige berekening in berichten venster&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation>Verander eerste controle punt van hoek</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation>Verander tweede controle punt van hoek</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation>Verander eerste controle punt van lengte</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation>Verander tweede controle punt van lengte</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation>De lengte kan niet negatief zijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation>Kromme - Interactief</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
@@ -3881,163 +3068,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Lijst van punten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Selecteer punt van pad kromme</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Punt:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation>Eerste controlepunt</translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation>Tweede controlepunt</translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation>Ongeldig splinepad</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toon volledige berekening in berichten venster&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation>Verander eerste controle punt van hoek</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation>Verander tweede controle punt van hoek</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation>Verander eerste controle punt van lengte</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation>Verander tweede controle punt van lengte</translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation>De lengte kan niet negatief zijn</translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation>Niet gebruikt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation>Spline - Interactief</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation>Pad:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation>Resultaat waarde</translation>
     </message>
@@ -4045,108 +3187,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Leeg veld</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Waarde kan geen 0 zijn</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Fout bij uitpakken: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Eerste punt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Tweede punt</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation>Hoogste punt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation>Laagste punt</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation>Uiterst linkerpunt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation>Uiterst rechterpunt</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation>op lengte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation>op snijpunten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation>op eerste lijn symmetrie-as</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation>op tweede lijn symmetrie-as</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation>op eerste lijn rechte hoek</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation>op tweede lijn rechte hoek</translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Ongeldig resultaat. Waarde is oneindig of NaN. Controleer uw berekeningen.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation>Waarde kan niet kleiner dan 0 zijn</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation>Resultaat waarde</translation>
     </message>
@@ -4154,62 +3266,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Selecteer tweede punt van de as</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Selecteer eerste punt</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Selecteer tweede punt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation>Punt - Snijpunt As en Driehoek</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation>Eerste punt as:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation>Tweede punt as:</translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -4217,79 +3317,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation>Selecteer de tweede basis punt</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation>Selecteer de eerste figuurnaad punt</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation>Selecteer de tweede figuurnaad punt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation>Selecteer de derde figuurnaad punt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation>Eerste basis punt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation>Tweede basis punt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation>Eerste figuurnaad punt:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation>Tweede figuurnaad punt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation>Derde figuurnaad punt:</translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation>Echte Figuurnaden</translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation>Puntnaam 1:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation>Puntnaam 2:</translation>
     </message>
@@ -4297,27 +3380,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Incorrecte formule</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Ongedaan maken</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Verbeter formule</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Stop</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Fout tijdens het berekenen van de formule. Je kunt proberen om de laatste actie ongedaan te maken of de formule te herstellen.</translation>
     </message>
@@ -4325,214 +3403,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation>Variabelen</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation>Filter:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation>Filter de lijst met een sleutelwoord</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation>Gebruikersvariabelen</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation>De berekende waarde</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation>Verplaats maten omhoog</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Verplaats maten omlaag</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation>Voeg gebruikersvariabele toe</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation>Verwijder gebruikersvariabele</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation>Unieke naam voor variabele</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation>Berekende waarde:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation>Formule:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation>Beschrijving:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation>Herstel een patroon met alle veranderingen welke je gemaakt hebt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation>Herstel</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation>Lijnlengtes</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation>Lijn</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation>Lijnhoeken</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation>Lengtes krommes</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation>Kromme</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation>Hoeken krommes</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation>Lengte controlepunten</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation>Boogstralen</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation>Boog</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation>Straal</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation>Leeg veld.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation>Leeg veld</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Ongeldig resultaat. Waarde is oneindig of NaN. Controleer uw berekeningen.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Fout bij uitpakken: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation>Bewerk variabele</translation>
     </message>
@@ -4540,17 +3566,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation>Gereedschap</translation>
     </message>
@@ -4558,148 +3581,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation>Verander formule</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation>Maten</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation>Lijnlengtes</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation>Lijnhoeken</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation>Lengtes Krommes</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation>Hoeken Krommes</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation> Lengte Controlepunten</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation>Boogstraal</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation>Funkties</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation>Formule:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation>Voeg variabele in de formule</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation>Verberg ongeschreven maten</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation>Volledige naam</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation>Filter de lijst met een sleutelwoord</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation>Maat</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation>Gebruikersvariabele</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation>Lijnlengte</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation>Lengte van de kromme</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation>Lijnhoek</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation>Boogstraal</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation>Hoek van de kromme</translation>
     </message>
@@ -4707,37 +3700,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation>Voeg Groep Toe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation>Unieke naam patroondeel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
@@ -4745,296 +3731,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation>Bewerk labelsjabloon</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation>Verwijder huidig label en begin een nieuw</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation>Importeer uit labelsjabloon</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation>Exporteer label als sjabloon</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation>Bewerk</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation>Vet</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation>Schuin</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation>Links uitlijnen</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation>Gecentreerd in beschikbare ruimte</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation>Rechts uitlijnen</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation>Bijkomende fontgrootte. Gebruik om een lijn dikker te maken.</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation>Tekst:</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation>Regel tekst</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation>Voeg plaatshouder toe</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation>Invoegen...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation>Voorbeeldweergave</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;leeg&gt;</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation>Maak nieuw sjabloon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation>Door een nieuw sjabloon te maken overschrijft u het huidige. Doorgaan?</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation>Labelsjabloon</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation>Exporteer labelsjabloon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation>sjabloon</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation>Kon bestand niet opslaan</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation>Importeer sjabloon</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation>Sjabloon importeren zal het huidige overschrijven. Doorgaan?</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation>Bestandsfout.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation>Patroon naam</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation>Patroon nummer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation>Bedrijfs/ontwerpers naam</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation>Klant naam</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation>Patroon uitbreiding</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation>Naam patroonbestand</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation>Naam matenbestand</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation>Maat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation>Hoogte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation>Maten uitbreiding</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation>Patroondeel letter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation>Patroondeel commentaar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation>Patroondeel oriëntatie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation>Patroondeel draaiing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation>Patroondeel helling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation>Stofvouw positie op Patroondeel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation>Patroondeel naam</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation>Aantal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation>Materiaal: Stof</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation>Stof</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation>Materiaal: Voering</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation>Voering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation>Materiaal: Vlieseline</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation>Vlieseline</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation>Materiaal: Tussenvoering</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation>Tussenvoering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation>Woord: Knip</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation>Knip</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation>Woord: op stofvouw</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation>op stofvouw</translation>
     </message>
@@ -5042,12 +3968,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation>bestanden</translation>
     </message>
@@ -5055,163 +3979,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation>Exporteer Opmaak</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation>Binair formaat</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation>Tekst als paden</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation>Pad:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation>Doelmap</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation>Pad naar doelmap</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation>Kies pad naar doelman</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation>Verken...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation>Bestandsindeling:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation>Bestandsnaam:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation>Basis bestandsnaam</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation>Kwaliteit (0-100):</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation>Marges</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation>Rechts:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation>Links:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation>Top:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation>Onder:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation>Papierformaat</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation>Sjablonen: </translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation>Oriëntatie: </translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation>De basis bestandsnaam komt niet overeen met de normale computertaal.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation>Kies map</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation>Geprobeerd het buiten bereik indelings nummer te gebruiken.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation>Geen huidige indeling geselecteerd.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation>De bestemmingsmap bestaat niet of is niet leesbaar.</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation>%1 bestaat al.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation>%1 bestanden met basisnaam %2 bestaan al.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation>Wil je deze echt vervangen?</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation>Bevestig export</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5219,52 +4110,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation>Doorstroming van download is mislukt: %1.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation>Kan bestand %1 niet openen voor schrijven</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation>Download bestand mislukt: %1.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation>Download gestart, het installatieprogramma zal openen als de download volledig klaar is</translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation>Er zijn geen nieuwe versies beschikbaar.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation>Een nieuwe versie %1 is beschikbaar. Wil je het downloaden?</translation>
@@ -5273,369 +4154,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation>Groepenbeheer</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation>Groepen</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation>Naam Bestaat</translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation>%1 - Basis punt</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation>Boog_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation>Splinepad_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation>%1 - Snijpunt van Cirkels</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation>EllBoog_</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation>Groep kleur</translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation>Naam groep</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation>Bewerk</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation>Zichtbaar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation>De groep is zichtbaar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation>Vergrendeld</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation>De groep is vergrendeld</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation>Groep heeft objecten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation>Kleur</translation>
     </message>
@@ -5643,265 +4441,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation>Geschiedenis</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation>Vind:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation>Zoek tekst</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation>Id</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation>Basis Punt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation>Lijn_%1_%2</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation>Lijn van %1 naar %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation>Punt Op Lijn %1_%2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation>Punt Lengte tot Lijn</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation>Punt Op Loodrechte %1_%2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation>Punt Op Bisectrice %1_%2_%3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation>Snijpunt Lijnen %1_%2 en %3_%4</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation>Kromme Interactief</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation>Kromme Vast</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation>Boog_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation>Boog Straal &amp; Hoeken</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation>Boog Straal &amp; Lengte %1</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation>Splinepad_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation>Spline Interactief</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation>Spline Vast</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation>Snijpunt Boog met middelpunt %1 &amp; Lijn %2_%3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation>Snijpunt Lijn %1_%2 &amp; Loodrechte %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation>Snijpunt As %1_%2 &amp; Driehoekpunten %3 en %4</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation>Snijpunt XY van punten %1 en %2</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation>Punt Op Boog</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation>Punt Op Kromme</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation>Punt Op Spline</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation>%Snijpunt Lijn &amp; %1_%2 en As door punt %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation>Snijpunt Kromme &amp; As door punt %1</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation>Snijpunt Bogen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation>%1 - Snijpunt van Cirkels</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation>Snijpunt Krommes</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation>Snijpunt Cirkel &amp; Raaklijn</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation>Snijpunt Boog en Raaklijn</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation>Echte Figuurnaad %1_%2_%3</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation>EllBoog_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation>Boog Ellipsvormig met lengte %1</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation>Draaiing rond punt %1. Suffix %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation>Spiegeling over Lijn %1_%2. Suffix %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation>Spiegeling over As door %1 punt. Suffix %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation>Verplaats - draai rond punt %1. Suffix %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation>Beschrijving</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation>Punt Lengte en Hoek van punt %1</translation>
     </message>
@@ -5909,127 +4628,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished">Selectie</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished">Id</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Naam:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished">Geometrie</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished">Eenheid:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Breedte:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Hoogte:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished">Draaiing:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished">Kenmerken</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6037,110 +4727,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished">Eigenschappen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished">Bevestig verwijdering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Wil je dit echt verwijderen?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6150,102 +4815,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation>Patroondeel:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation>Kernpunten:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation>msg</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation>Keer om</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation>Pasmarkering</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation>Knipje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation>T Pasmarkering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation>U Pasmarkering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation>Interne V Pasmarkering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation>Externe V Pasmarkering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation>Kasteel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation>Verwijder</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation>Geen kernpunten gekozen. Druk Annuleren om verder te gaan</translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation> was automatisch omgekeerd.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation> moet mogelijk handmatig omgekeerd worden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation>Voeg kernpunten in</translation>
     </message>
@@ -6253,12 +4898,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Het programma wordt geleverd zoals het is, zonder enige vorm van garantie, inclusief de garantie op ontwerp, verkoopbaarheid en geschiktheid voor een bepaald doel.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6276,87 +4919,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation>Kies:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation>Middelpunt:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation>Raakpunt:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation>Straal:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation>Selecteer middelpunt cirkel</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation>Bewerk straal</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Straal kan niet negatief zijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Punt - Snijpunt Cirkel en Raaklijn</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -6364,12 +4990,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation>Snijpunt van cirkel en raaklijn</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Kan het snijpunt %1 van&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Cirkel en Raaklijn niet vinden&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Zal de oorsprong als plaatshouder gebruiken tot het patroon gecorrigeerd is.</translation>
     </message>
@@ -6377,110 +5001,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation>Kies:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation>Cirkel 1</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation>Middelpunt:</translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation>Straal:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toon volledige berekening in mededeling&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation>Cirkel 2</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation>Selecteer middelpunt tweede cirkel</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation>Verander straal eerste cirkel</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation>Verander straal tweede cirkel</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Straal kan niet negatief zijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation>Punt - Snijpunt Cirkels</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -6488,12 +5084,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Kan het snijpunt %1 van Cirkels niet vinden&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Zal de oorsprong als plaatshouder gebruiken tot het patroon gecorrigeerd is.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation>Snijpunt Cirkels</translation>
     </message>
@@ -6501,126 +5095,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Sjablonen:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Breedte:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Hoogte:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Draai patroondeel</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Draai om</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>graad</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Drie groepen: groot, middel en klein</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Twee groepen: groot, klein</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>Kleiner wordend gebied</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Pixels</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Automatisch inkorten van ongebruikte lengte</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Voeg pagina&apos;s samen( wanneer mogeljk)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation>Tussenruimte:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Sla de lengte van het blad op</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Papier Formaat</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Links:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Rechts:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Top:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Bodem:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Verkeerde velden.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6631,84 +5199,67 @@ Apply settings anyway?</source>
 	Kleiner wordende ruimte = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation>Opmaak opties</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation>Verschuivings/Offset lengte:</translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation>Regel voor het kiezen van het volgende patroondeel</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation>Verdeel in strepen</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation>Vermenigvuldiger</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation>Stel vermenigvuldiger in op de lengte van het grootste patroondeel in de opmaak.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation>Het mogelijk maken om van grote afmetingen van papier het creatieproces te versnellen.</translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Printer:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation>Geen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation>Tekst</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation>tekst zal omgezet worden naar paden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation>Exporteer tekst als paden</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation>Marges</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation>Neger marges</translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation>Opmaak adrukinstellingen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation>Millimeters</translation>
     </message>
@@ -6716,32 +5267,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation>Geen Pen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation>Volle lijn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation>Streep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation>Punt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation>Streep Punt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation>Streep Punt Punt</translation>
     </message>
@@ -6749,2660 +5294,2001 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Gereedschap om punten te maken.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Punt</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Gereedschap om lijnen te maken.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Lijn</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Gereedschap om krommes te maken.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Kromme</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Gereedschap voor het maken van bogen.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Boog</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;Bestand</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Maten</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nieuw</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Maak een nieuw patroon</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Open</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Open bestand met patroon</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Opslaan</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Opslaan patroon</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Opslaan &amp;als...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Sla nog niet opgeslagen patroon op</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Aanwijzer gereedschap</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Geschiedenis</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>Over &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;Over Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>E&amp;xit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Voorkeuren</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Rapporteer fout</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Toon online help</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>Over Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Opslaan als</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Kon bestand niet opslaan</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Open bestand</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Fout bij uitpakken bestand.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Fout. Kan waarde niet omzetten.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Fout. Lege parameter.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Fout. Verkeerde id.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Fout bij uitpakken bestand (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Slechte id.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>Bestand opgeslagen</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>zonder titel.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>Het patroon is aangepast.
 Wil je de veranderingen opslaan?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Ongedaan maken</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Opnieuw doen</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>Dit bestand is al geopend in een ander raamwerk.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Verkeerde eenheden.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>Bestand geladen</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Seamly2D  is niet correct gesloten. Wil je de geopende bestanden(%1) heropenen?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Heropen bestanden.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Opmaak</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation>Druk papierfomaatindeling PDF af</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation>Verdeel en sla een opmaak op in kleinere pagina&apos;s ( voor normale printers)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation>Druk voorbeeldweergave af</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation>Druk voorbeeldweergave van originele opmaak af</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation>Export als...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation>Opmaak modus</translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation>Niet opgeslagen veranderingen</translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation>Maten geladen</translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation>U kunt geen lege beelden exporteren.</translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation>Maten bestand bevat ongeldige bekende ma(a)t(en).</translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation>Maten bestand heeft een onbekende indeling.</translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation>Maten bestanden types komen niet overeen.</translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation>Kan maten niet synchroniseren.</translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation>Kan maten niet bijwerken.</translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation>Het maten bestand &apos;%1&apos; kon niet gevonden worden.</translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation>Laden maten bestand</translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation>Niet ondersteunde maat waarde &apos;%1&apos; voor dit patroon bestand.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation>Kon maat niet instellen. Bestand was niet geopend.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation>De methode %1 werkt niet in GUI modus</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation>Niet ondersteunde hoogte waarde &apos;%1&apos; voor dit patroon bestand.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation>Kon hoogte niet instellen. Bestand was niet geopend.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation>Alsublieft, verstrek éen invoer bestand.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation>Druk een originele opmaak af</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation>Bekijk vooraf papierformaatindeling PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation>Druk voorbeeldweergave papierformaatindeling opmaak af</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation>Maten niet geladen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation>kan maten niet ontladen. Sommigen worden gebruikt in het patroon.</translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>Nieuw patroon</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation>Open patroon</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation>Creër/verander maten</translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>Sla op...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Niet opslaan</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Vergrendelingsbestand</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Dit bestand is al geopend in een ander venster. Negeren als u wilt doorgaan (niet aanbevolen, kan leiden tot gegevensbeschadiging).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Het vergrendelingsbestand kon niet worden aangemaakt, wegens het ontbreken van machtigingen. Negeren als u wilt doorgaan  (niet aanbevolen, kan leiden tot gegevensbeschadiging).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Onbekende fout gebeurd, bijvoorbeeld een volledige partitie voorkomt het schrijven uit het vergrendelingsbestand. Negeren als u wilt doorgaan (niet aanbevolen, kan leiden tot gegevensbeschadiging).</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Het vergrendelingsbestand kon niet worden aangemaakt, wegens het ontbreken van machtigingen.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Onbekende fout gebeurd, bijvoorbeeld een volledige partitie voorkomt het schrijven uit het vergrendelingsbestand.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation>Bewerkingen</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation>Sluit patroon</translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation>Gereedschap aanwijzer</translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation>Originele zoom</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Hoogte:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Maat:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation>Het maten bestand&lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; kon niet gevonden worden. Wil je de bestanden locatie bijwerken?</translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation>Maten zijn gewijzigd. Wil je ze nu synchroniseren?</translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Graderen ondersteunt geen inches</translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation>Maten zijn gesynchroniseerd</translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation>Dit document kan niet gewijzigd worden.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Kan geen toestemming geven voor %1 om te wijzigen.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Het bestand is niet bewaard.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation>Het bestand is niet bewaard</translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation>alleen lezen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation>Laad individueel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation>Laad het individuele matenbestand</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation>Laad meermaten-systeem</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation>Laad het meermaten-systeem bestand</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation>Open SeamlyMe</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation>Wijzig Huidige</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation>Wijziging gerelateerd aan patroon-maten</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation>Synchroniseer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation>Synchroniseer maten gelinked aan het patroon na wijziging</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation>Verwijder Huidige</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation>Laad maten niet als ze niet gebruikt worden in een patroon-bestand</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation>Individuele maten</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation>Multimaten maten</translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Patroonbestanden</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation>Wiki</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation>Forum</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation>De berekende waarde</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation>Je kunt Layout mode nog niet gebruiken.</translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation>Applicatie ondersteunt niet het meerdere maten tabel met inches.</translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation>Kon de maat niet vaststellen. Heb een bestand nodig met meerdere maten metingen.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation>Kon de hoogte niet vaststellen. Heb een bestand nodig met meerdere maten metingen.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation>Voorbeeldweergave</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation>Beeld</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation>Namen Punten</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation>Bewerk</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation>&amp;Gereedschappen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation>&amp;Bewerkingen</translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation>Patroondeel</translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation>Hulpmiddelen</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation>Werkbalk Bestanden</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation>Werkbalk Mode</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation>Werkbalk Patroon</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation>Werkbalk Bewerken</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation>Eigenschappen Bewerken</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation>Opmaak Pagina&apos;s</translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation>Groepenbeheer</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation>Werkbalk Zoomen</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation>Werkbalk Gereedschappen</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation>Werkbalk Punten</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation>Werkbalk Lijnen</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation>Werkbalk Krommes</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation>Werkbalk Bogen</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation>Werkbalk Bewerkingen</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation>Werkbalk Patroondelen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation>Werkbalk Details</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation>Werkbalk Opmaak</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation>Werkbalk Puntnamen</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation>Gereedschapskist</translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation>Lijn tussen 2 Punten (Alt+L)</translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation>Gereedschap om bewerkingen uit te voeren op groepen objecten</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation>Draai geselecteerde objecten (R)</translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation>Exporteer Tekenblok (E,D)</translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation>Gereedschap om Patroondelen toe te voegen.</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation>Voeg Details toe</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation>Gereedschap om details toe te voegen aan patroondelen</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation>Verenig 2 Patroondelen (U)</translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation>Werkbalk Bekijk</translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation>Teken</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modus om met tekenblokken te werken. De tekenblokken zijn de basis om naar het volgende stadium over te gaan &amp;quot;Patroondeel Modus&amp;quot;. Voordat een Patroondeel kan worden bewerkt in  &amp;quot;Patroondeel Modus&amp;quot; moet u tenminste één patroondeel gemaakt hebben.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modus om patroondelen te bewerken. Voordat u de &amp;quot;Patroondeel Modus&amp;quot; kunt activeren moet u tenminste éénpatroondeel hebben gemaakt in de &amp;quot;Teken Modus&amp;quot;Patroondelen die hier worden afgewerkt vormen de basis voor een afdrukopmaak &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation>Nieuw Tekenblok</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation>Voeg nieuw Tekenblok toe (Ctrl+Shift+N)</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation>Hernoem Tekenblok</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation>Verander de naam van het tekenblok</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation>Variabelentabel</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modus voor het creëren van een opmaak voor patroondelen. Dezew modus is beschikbaar nadat tenminste één patroondeel is gemaakt in  &amp;quot;Patroondeel Modus&amp;quot;. De opmaak kan worden uitgevoerd naar het bestandsformaat van uw voorkeur en zo worden opgeslagen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation>Draaiing</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation>Spiegel over Lijn</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation>M,L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation>Spiegel over As</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation>M, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation>Verplaats</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation>Echte Figuurnaden</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation>T, D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation>Middelpunt</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation>P, S</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation>Snijpunt XY</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation>X, Y</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation>I, L</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation>Alt+C</translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation>A, X</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation>I, A</translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation>I, C</translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation>C, T</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation>A, T</translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation>A, L</translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation>Over Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation>Verlaat het Programma</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation>Programmavoorkeuren...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation>Patroonvoorkeuren...</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation>Inzoomen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation>In</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation>Inzoomen (Ctrl++)</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation>Uitzoomen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation>Uit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation>Uitzoomen (Ctrl+-)</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation>Toon Alles</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation>Pas Aan</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation>Zoom om alles te tonen (Ctrl+=)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation>Rapporteer fout...</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation>Sneltoetsen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation>Laatste Gereedschap</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation>Controlepunten Kromme</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation>Draai controlepunten en richting Kromme om (V, C)</translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation>Laad meerdere maten in</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation>Open het SeamlyMe Maten progeramma (Ctrl+M)</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation>Exporteer Variabelen naar CSV</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation>Geselecteerd</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation>Bewerk Labelsjabloon...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation>Vorige</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation>Zoom op vorige (Ctrl+Links)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation>Ctrl+Links</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation>Gebied</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation>Toon Panorama</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation>Z, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation>Zoom 1:1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation>Zoom naar 100 percent (Ctrl+0)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation>Ctrl+0</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation>Punt Gereeschap</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation>Lijn Gereedschappen</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation>Alt+L</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation>Kromme Gereedschappen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation>Boog Gereedschappen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation>Bewerkingen Gereedschappen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation>Opmaak Gereedschappen</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation>Patroondeel Gereedschappen</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation>Nieuw Patroondeel</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation>N, P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation>Nieuwe Afdrukopmaak</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation>N, L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation>Exporteer Opmaak</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation>E, L</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation>Ankerpunt</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation>A, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation>Binnenpad</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation>I, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation>Voeg Kernpunten In</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation>I, N</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation>Verenig 2 Patroondelen (U)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation>Exporteer Patroondelen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation>E, P</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation>Patroondeel Gereedschappen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation>Puntnaam tekst</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation>V, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation>Maak Tekst Groter</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation>Maak Tekst Groter (Ctrl+])</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation>Ctrl+]</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation>Maak Tekst Kleiner</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation>Maak Tekst Kleiner (Ctrl+[)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation>Ctrl+[</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation>Gebruik Gereedschapskleur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation>Gebruik Gereedschapskleur (T)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation>V, T</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation>Oorsprong Assenstelsel </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation>V, A</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation>Draadmodel Modus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation>Schakel Draadmodel Modus om (V, W)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation>V, W</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation>Recht-van-draad</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation>Draai Recht-van-draad om (V, G)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation>V, G</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation>Labels</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation>Schakel Labels om (V, L)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation>V, L</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation>Rekenmachine</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation>Ctrl+Shift+C</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation>Decimaaltabel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation>Ctrl+Shift+D</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation>Exporteer Tekenblok</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation>E, D</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation>Exporteer</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation>Naadtoeslag</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation>V, S</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation>Document Info...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation>Document Info</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation>Toon Document Info</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation>Matenbestand bevat niet alle benodigde maten.</translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation>&lt;b&gt;Gereedschap::Bewerkingen - Maak Groep:&lt;/b&gt; Kies een of meer objecten - Druk &lt;b&gt;%1&lt;/b&gt; voor meervoudige selectie, Druk &lt;b&gt;ENTER&lt;/b&gt; om de aanmaak van de groep af te sluiten </translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Gereedschap::Bewerkingen - Draaiing:&lt;/b&gt; Kies een of meer objecten - Druk &lt;b&gt;%1&lt;/b&gt; voor meervoudige selectie, Druk &lt;b&gt;ENTER&lt;/b&gt; om selectie te bevestigen</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Gereedschap::Bewerkingen - Spiegel over Lijn:&lt;/b&gt; Kies een of meer objecten. Druk &lt;b&gt;%1&lt;/b&gt; voor meervoudige selectxie, Druk &lt;b&gt;ENTER&lt;/b&gt; om selectie te bevestigen</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Gereedschap::Bewerkingen - Spiegel over As:&lt;/b&gt; Kies een of meerdere objecten - Druk &lt;b&gt;%1&lt;/b&gt; voor meervoudige selectxie, Druk &lt;b&gt;ENTER&lt;/b&gt; om selectie te bevestigen</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Gereedschap::Bewerkingen - Verplaats:&lt;/b&gt; Kies een of meerdere objecten - Druk &lt;b&gt;%1&lt;/b&gt; voor meervoudige selectxie, Druk &lt;b&gt;ENTER&lt;/b&gt; om selectie te bevestigen</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation>&lt;b&gt;Gereedschap::Bewerkingen - Echte Figuurnaden:&lt;/b&gt; Kies het eerste punt van de basislijn</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation>Tekenblok:</translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation>Draaiing</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation>Voeg Ankerpunt Toe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation>Maak Binnenpad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation>Voeg Kernpunten in Pad toe</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation>Verenigingsgereedschap</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation>Exporteer patroondelen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation>Patroondeel modus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation>U kunt de Patroondeel modus nog niet gebruiken. Maak eerst tenminste één patroondeel.</translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation>Patroondelen</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation>U kunt de Opmaak modus nog niet gebruiken. Maak eerst tenminste één patroondeel.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation>U kunt de Opmaak modus nog niet gebruiken. Maak eerst tenminste één patroondeel.</translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation>Tekenblok.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation>Naam Bestaat</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation>De opdracht kan niet worden uitgevoerd omdat de naam van het tekenblok al bestaat.</translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation>U hebt nog geen patroondelen om uit te voeren. Voeg tenminste één patroondeel toe aan de Opmaak.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation>Exporteer patroondelen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation>Kan patroondelen niet exporteren.</translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation>&lt;b&gt;Gereedschap::Patroondeel - Voeg een nieuw Patroondeel toe:&lt;/b&gt; Selecteer een pad van objecten met de klok mee.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation>&lt;b&gt;Gereedschap::Patroondeel - Voeg Ankerpunt toe:&lt;/b&gt; Selecteer een ankerpunt</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation>&lt;b&gt;Gereedschap::Patroondeel - Binnenpad:&lt;/b&gt; Selecteer padobjecten, gebruik &lt;b&gt;SHIFT&lt;/b&gt; om de richting van krommes om te draaien zodat ze met de klok meegaan</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Gereedschap::Patroondeel - Voeg kernpunten toe:&lt;/b&gt; Druk &lt;b&gt;%1&lt;/b&gt; voor meervoudige selectie. Druk &lt;b&gt;ENTER&lt;/b&gt; om de selectie te bevestigen</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation>&lt;b&gt;Gereedschap::Patroondeel - Vereniging:&lt;/b&gt; Selecteer een patroondeel</translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation>Tekenblok %1</translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation>Tekenblok %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation>Punt - Op Bisectrice (O, B)</translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation>Punt - Lengte tot Lijn (P, S)</translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation>Punt - Snijpunt As en Lijn (A, L)</translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation>Punt - Snijpunt As en Driehoek (X, T)</translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation>Punt - snijpunt XY (X, Y)</translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation>Punt - Snijpunt Lijn en Loodrechte (L, P)</translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation>Punt - Snijpunt Lijn en As (L, X)</translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation>Punt - Op Loodrechte (O, P)</translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation>Punt - Lengte en Hoek (L, A)</translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation>Punt - Op Lijn (O, L)</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation>Punt - Middelpunt op Lijn (Shift+O, Shift+L)</translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation>Punt - Snijpunt Lijnen (I, L)</translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation>Kromme - Interactief (Alt+C)</translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation>Spline - Interactief (Alt+S)</translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation>Kromme - Vast (A;lt+Shift+C)</translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation>Spline - Vast (Alt+Shift+S)</translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation>Punt - Op Spline (O, S)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation>Punt - Snijpunte Krommes (I, C)</translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation>Punt - Snijpunte Kromme en As (C, X)</translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation>Punt - Op Kromme (O, C)</translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation>Boog - Straal en Hoeken (Alt+A)</translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation>Punt - Op Boog (O, A)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation>Punt - Snijpunt Boog en As (A, X)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation>Punt - Snijpunt Bogen (I, A)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation>Punt - Snijpunt Cirkels (Shift+I, Shift+C)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation>Punt - Snijpunt Cirkel en Raaklijn (C, T)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation>Punt - Snijpunt As en Raaklijn (A, T)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation>Boog - Straal en Lengte (Alt+Shift+A)</translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation>Boog - Ellipsvormig (Alt+E)</translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation>Spiegel Objecten over LIjn (M, L)</translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation>Spiegel Objecten over As (M, A)</translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation>Verplaats Objecten (Alt+M)</translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation>Echte Figuurnaden (T, D)</translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation>Voeg nieuw Patroondeel toe (N, P)</translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation>Voeg Ankerpunt toe (A, P)</translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation>Voeg kernpunten in (I, N)</translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation>Voeg binnenpad toe (I, P)</translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation>Exporteer Patroondelen (E, P)</translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation>Nieuwe afdrukopmaak (N, L)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation>Exporteer Opmaak (E, L)</translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation>Alt+M</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation>Ellipsvormig</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation>Boog - Ellipsvormig</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation>Alt+E</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation>Middelpunt op Lijn</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation>Shift+O, Shift+L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation>Op Lijn</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation>O, L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation>Lengte en Hoek</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation>L, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation>Op Loodrechte</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation>O, P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation>Op Bisectrice</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation>O, B</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation>Lengte tot Lijn</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation>Snijpunt  As en Lijn</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation>Snijpunt As en Driehoek</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation>X, T</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation>Snijpunt Lijn en Loodrechte</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation>L, P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation>Snijpunt Lijn en As</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation>L, X</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation>Snijpunt Lijnen</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation>Kromme - Interactief</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation>Punt Op Kromme</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation>O, C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation>Kromme - Vast</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation>Alt+Shift+C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation>Spline - Interactief</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation>Punt Op Spline</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation>Punt Op Spline (O, S)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation>O, S</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation>Spline - Vast</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation>Alt+Shift+S</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation>Snijpunt Krommes</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation>Snijpunt Kromme en As</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation>C, X</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation>Straal en Hoeken</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation>Boog - Straal en Hoeken</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation>Punt Op Boog</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation>Punt Op Boog (O, A)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation>O, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation>Snijpunt  As en Lijn</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation>Snijpunt Boog en As (A, X)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation>Snijpunt Bogen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation>Snijpunt Bogen (I, A)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation>Snijpunt Cirkels</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation>Snijpunt Cirkels (Shift+I, Shift+C)</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation>Shift+I, Shift+C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation>Snijpunt Cirkel en Raaklijn</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation>Snijpunt Cirkel en Raaklijn (C, T)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation>Snijpunt Boog en Raaklijn</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation>Snijpunt Boog en Raaklijn (A, T)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation>Straal en Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation>Boog - Straal en Lengte</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation>Alt+Shift+A</translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation>Gebruik Laatstgebruikte Gereedschap (Ctrl+Shift+L)</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation>Zoom in op geselecteerd object (Ctrl+Rechts)</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation>Zoom in op geselecteerd Gebied (Ctrl+A)</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation>Toon werkgebied (Z, P)</translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation>Maak Nieuwe afdrukopmaak (N, L)</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation>Zoom in op punt (Ctrl+Alt+P)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation>Ctrl+Alt+P</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation>Voeg extra maten toe: %1</translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Middelpunt op Lijn&lt;/b&gt;: Kies eerste punt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Lengte en Hoek&lt;/b&gt;: Kies punt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Op Lijn&lt;/b&gt; Kies eerste punt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Op Loodrechte:&lt;/b&gt;Kies eerste punt van lijn</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Op Bisectrice&lt;/b&gt; Kies eerste punt van hoek</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Lengte tot Lijn:&lt;/b&gt; Kies punt</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt Boog en Lijn:&lt;/b&gt; Kies eerste punt van lijn</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt As en Driehoek:&lt;/b&gt; Kies eerste punt van as</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt XY:&lt;/b&gt; Kies punt voor X-waarde (verticaal)</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt Lijn en Loodrechte:&lt;/b&gt; Kies basispunt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt Lijn en As:&lt;/b&gt; Kies eerste punt van lijn</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation>&lt;b&gt;Gereedschap::Lijn:&lt;/b&gt; Kies eerste punt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt Lijnen&lt;/b&gt; Kies eerste punt van eerste lijn</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation>&lt;b&gt;Gereedschap::Kromme - Interactief:&lt;/b&gt; Kies startpunt van kromme</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation>&lt;b&gt;Gereedschap::Spline - Interactief:&lt;/b&gt; Kies startpunt van spline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation>&lt;b&gt;Gereedschap::Kromme - Vast:&lt;/b&gt; Kies eerste punt van kromme</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation>&lt;b&gt;Gereedschap::Spline - Vast&lt;/b&gt; Kies eerste punt van spline</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Op Kromme:&lt;/b&gt; Kies eerste punt van kromme</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Op Spline:&lt;/b&gt; Kies spline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt Krommes:&lt;/b&gt; Kies eerste kromme</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt Kromme en As:&lt;/b&gt; Kies kromme</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation>&lt;b&gt;Gereedschap::Boog - Straal en Hoeken:&lt;/b&gt; Kies middelpunt van boog</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Op Boog:&lt;/b&gt; Kies boog</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt Boog en As:&lt;/b&gt; Kies boog</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt Bogen:&lt;/b&gt; Kies eerste boog</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt Cirkels:&lt;/b&gt; Kies middelpunt eerste cirkel</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation>&lt;b&gt;Gereedschap::Punt - Snijpunt Cirkel en Raaklijn:&lt;/b&gt; Kies punt op raaklijn</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation>&lt;b&gt;Gereedschap:: Punt - Snijpunt Boog en Raaklijn:&lt;/b&gt; Kies punt op raaklijn</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation>&lt;b&gt;Gereedschap::Boog - Straal en Lengte:&lt;/b&gt; Kies middelpunt van de boog</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation>&lt;b&gt;Gereedschap::Boog - Ellipsvormig:&lt;/b&gt; Kies middelpunt van ellispvormige boog</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation>Afbeeldingen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation>Zoom in op Punt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation>Punt:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation>Snijpunt Boog en Lijn</translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation>Snijpunt Kromme &amp; As</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation>zonder titel</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation>Kon bestand niet exclusief openen. Dit bestand wordt al gebruikt in een ander venster. Verwacht botsingen als er twee copieën van het programma draaien.</translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation>Werkbalk Pen</translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation>Werkbalken</translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>patroon</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9410,86 +7296,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Bestand &apos;%1&apos; maken heeft gefaald! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Cruciale fout!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation>Afdruk fout</translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation>Kan niet verder gaan omdat er geen beschikbare printers in het systeem zijn.</translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation>naamloos</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation>De opmaak is verouderd.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation>De opmaak is niet meer bijgewerkt sinds de laatste veranderingen. Wilt u verder gaan?</translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Kon geen data voorbereiden om opmaak te creëren</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation>Kan printer niet openen %1</translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation>Voor de voorbeeldweergave van een multipagina document, moeten alle bladen dezelfde maat hebben.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation>Voor het afdrukken van multipagina&apos;s document, moeten alle bladen dezelfde maat hebben.</translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation>Pagina&apos;s zullen bijgesneden worden omdat deze niet het papierformaat van de printer hebben.</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation>Kan de printer marges niet bepalen</translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation>Kan geen pad maken</translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Patroon</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation>Eén of meer patroondelen zijn groter dan het gekozen papierformaat. Selecteer een groter papierformaat.</translation>
     </message>
@@ -9497,148 +7363,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation>Kopieer sneltoetsen naar het klembord</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation>Exporteer sneltoetsen als een PDF</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation>Zend sneltoetsen naar de printer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation>Bestand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation>Ctrl+Shift+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation>Opslaan als</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation>Exporteer naar CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
@@ -9646,123 +7482,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation>Vouw alles in</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation>Klap alles open</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation>Alles aanvinken</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation>Alles uitvinken</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation>Directe hoogte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation>Directe breedte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation>Inham</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation>Hand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation>Voet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation>Hoofd</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation>Omtrek en Boog</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation>Verticaal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation>Horizontaal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation>Buste</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation>Balans</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation>Arm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation>Been</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation>Kruislengte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation>Man &amp; Kleermakerij</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation>Historisch &amp; Specialiteit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation>Patroonteken maten</translation>
@@ -9771,18 +7586,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation>Kan maten &apos;%1&apos; niet vinden</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation>De maten naam is leeg!</translation>
     </message>
@@ -9790,37 +7597,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation>Vorm</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation> XPos:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation>xpos</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation>YPos:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation>ypos</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation>Eenheden:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation>eenheden</translation>
     </message>
@@ -9828,12 +7628,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation>verplaats de eerste figuurnaad label</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation>verplaats de tweede figuurnaad label</translation>
     </message>
@@ -9841,7 +7639,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9849,7 +7646,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation>verplaats punt label</translation>
     </message>
@@ -9857,7 +7653,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation>verplaats punt label</translation>
     </message>
@@ -9865,7 +7660,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation>verplaats enkel punt</translation>
     </message>
@@ -9873,7 +7667,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation>verplaats spline</translation>
     </message>
@@ -9881,7 +7674,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation>verplaats splinepad</translation>
     </message>
@@ -9889,52 +7681,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>Nieuw maten bestand</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Maten soort:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Eenheid:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Basis maat:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Basis hoogte:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Individueel</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation>Meerdere maten</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation>Millimeters</translation>
     </message>
@@ -9942,87 +7724,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation>A0</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation>A1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation>A2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation>A3</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation>A4</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation>Letter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation>Legaal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation>Tabloid</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation>ANSI C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation>ANSI D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation>ANSI E</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation>Papierrol 24in / 60,96cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation>Papierrol 30in / 76,20cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation>Papierrol 36in / 91,44cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation>Papierrol 42in / 106,68cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation>Papierrol 44in / 111,76cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation>Op maat</translation>
     </message>
@@ -10030,887 +7795,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation>Gereedschap Patroondeel</translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation>Eigenschappen </translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation>Paden </translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation>Naadtoeslag </translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation>Ankers </translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation>Recht van draad </translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation>Pasmarkeringen </translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation>Naam patroonlabel:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation>PatroonDeel</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation>Naam mag niet leeg zijn</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation>Letter:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation>Letter van patroondeel</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation>Aantal:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation>Positie:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation>op vouw</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation>Positie Stofvouw:</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation>Ongedefinieerd</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation>Op/Neer</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation>Links/Rechts</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation>Oriëntatie:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation>Links</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation>Rechts</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation>Draaiing:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation>Elke</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation>Helling:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation>CW X</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation>CCW X</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation>Aantekening:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation>Een veld om commentaar toe te voegen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation>Patroondeel mag niet gespiegeld worden in opmaak.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation>Hex Waarde</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation>Vulling:</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation>Hoofdpad</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation>Alle objecten op dit pad moeten elkaar &apos;met de klok mee&apos; volgen.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation>Verplaats regel naar bovenaan</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation>Verplaats regel één rij naar boven</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation>Verplaats regel één rij naar beneden</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation>Verplaats regel naar onderaan de lijst</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation>Klaar!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation>Binnenpad</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation>De naadtoeslag is deel van het hoofdpad</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation>Ingebouwd</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation>Verberg de hoofdpad wanneer naadtoeslag is ingeschakeld</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation>Breedte:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation>Formule wizard</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation>Berekening</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation>Kernpunten</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation>Kernpunt:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation>Vooraf:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation>Terug naar standaard breedte</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation>Gebruik Standaard</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation>Nadat:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation>Op maat</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation>Startpunt:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation>Eindpunt:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation>Hoort bij:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation>Patroondeel label</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation>Bewerk patroonlabel</translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation>Bewerk sjabloon</translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation>Toon label van patroondeel</translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation>Hoogte:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation>Ankerpunten</translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation>Patroonlabel</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation>Toon patroonlabel</translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation>Toon recht-van-draad</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation>Pijlen</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation>Soort:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation>Pasmarkering:</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation>Soort</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation>Knipje</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation>T Pasmarkering</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation>U Pasmarkering</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation>Interne V </translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation>Externe V</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation>Kasteel</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation>Subtype</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation>Rechttoe rechtaan</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation>Bisectrice</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation>Selecteer om het hoekpunt als pasmarkering aan te duiden</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation>Kruispunt van lijnen</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation> Breedte:</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation>Zet lengte pasmarkering terug naar standaard.</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation>Zet breedte pasmarkering terug naar standaard.</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation>Zet hoek pasmarkering terug naar standaard.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation>Aantal:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation>Selecteer het pad van objecten met de klok mee, Gebruik &lt;b&gt;SHIFT&lt;/b&gt; om de richting van krommes om te draaien, of &lt;b&gt;Ctrl&lt;/b&gt; om de richting te bewaren. Druk &lt;b&gt;ENTER&lt;/b&gt; om het maken van het patroondeel te beëindigen </translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation>Druk OK om een patroondeel te maken</translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation>Keer om</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation>Dubbel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation>Pasmarkering</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation>T Pasmarkering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation>U Pasmarkering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation>Interne V</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation>Externe V</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation>Uitgezonderd</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation>Verwijder</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation>Fout. Kan het pad van het patroondeel niet opslaan.</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation>Ongeldige uitkomst</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation>Lengte moet positief zijn</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation>Fout bij uitpakken: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation>Bewerk lengte</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation>Bewerk Hoek</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation>Bewerk hoogte</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation>Bewerk breedte</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation>Huidige naadtoeslag</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation>Verander breedte naadtoeslag</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation>Verander breedte naadtoeslag vóór het kernpunt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation>Verander breedte naadtoeslag voorbij het kernpunt</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation>Recht van draad</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation>Je hebt meer punten nodig!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation>Je moet de punten met de klok mee kiezen!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation>Eerste en laatste punt kunnen niet hetzelfde zijn!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation>Je hebt punten dubbel!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation>Elk punt in het pad moet uniek zijn!</translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation>Leeg</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation>hoofdpad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation>aangepaste naadtoeslag</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation>Beide</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation>Alleen voorkant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation>Alleen achterkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation>Toon pasmarkering op kniplijn.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation>Toon Pasmarkering op Kniplijn</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation>Toon pasmarkering op stiklijn.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation>Toon pasmarkering op Stiklijn</translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation>Toon Kniplijn</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation>Verberg Stiklijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation>Naadtoeslag</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation>Paden</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation>Labels</translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation>Flipperen:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation>Verbieden</translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation>Middelpunt:</translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation>Linksboven:</translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation>Rechtsonder:</translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation>Top:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation>Onder:</translation>
     </message>
@@ -10918,218 +8430,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation>Huidige naadtoeslag</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation>Verplaats patroondeellabel</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation>wijzig grootte van patroondeel label</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation>draai patroondeellabel</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation>verplaats patroon informatie label</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation>wijzig grootte patroon informatie label</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation>draai patroon informatie label</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation>verplaats recht-van-draad</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation>wijzig grootte recht-van-draad</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation>draai de recht-van-draad</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation>Vergrendel Patroondeel</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation>In Opmaak opnemen</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation>Flipping verbieden</translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation>Verhoog tot boven</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation>Verlaag tot beneden</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation>Verberg naadtoeslag</translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation>Toon Naadtoeslag</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation>Toon Recht-van-Draad</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation>Toon Patroonlabel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation>Toon label Patroondeel</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation>Hernoem...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation>Verwijder</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation>Flipping verbieden veranderd: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation>Toegelaten</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation>Uitgeschakeld</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation>Zichtbaarheid stiklijn veranderd: </translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation>Verberg</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation>Toon</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation>Toon Naadtoeslag</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation>Zichtbaarheid naadtoeslag veranderd: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation>Toon Recht-van-draad</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation>Zichtbaarheid Recht_van_draad veranderd: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation>Toon Patroonlabel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation>Zichtbaarheid Patroonlabel veranderd: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation>Toon Patroondeellabel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation>Zichtbaarheid label patroondeel veranderd: </translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation>Naam Patroondeel:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation>Hernoem Patroondeel</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation>hernoem patroondeel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation>Patroondeel hernoemd tot: </translation>
     </message>
@@ -11137,27 +8597,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation>Huidige lijnkleur</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation>Huidig lijnsoort</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation>Huidig Lijnbreedte</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation>Huidige pen terugzetten op standaardwaarden</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation>Huidige preset opslaan</translation>
     </message>
@@ -11165,77 +8620,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation>Stevig</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation>Dichtheid 1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation>Dichtheid 2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation>Dichtheid 3</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation>Dichtheid 4</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation>Dichtheid 5</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation>Dichtheid 6</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation>Dichtheid 7</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation>Horizontale lijn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation>Verticaal Lijn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation>Kruis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation>Diagonaal Achteruit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation>Diagonaal Voorwaarts</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation>Diagonaal Kruis</translation>
     </message>
@@ -11243,139 +8683,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation>Vorm</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation>Neem alle patroondelen op</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation>Sluit alle patroondelen uit</translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation>Keer opname van patroondelen om</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation>Vergrendel alle patroondelen</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation>Ontgrendel alle patroondelen</translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation>Keer vergrendeling van patroondelen om</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation>Flip opname van patroondeel in opmaak</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation>Vergrendeld</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation>Kleur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation>Patroondeel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11383,62 +8778,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation>Punt - snijpunt XY</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation>2e punt:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation>Selecteer punt voor Y waarde (horizontaal)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation>Unieke naam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Kies unieke naam.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
@@ -11446,316 +8829,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation>Interval:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>GUI taal:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation>Standaardwaarde eenheid:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>De standaardwaarde van de eenheid is opgewaardeerd en zal worden gebruikt  als de standaardbasis voor uw volgende patrooncreatie.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation>Bewerken</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation>Ongedaan maken</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation>Aantal stappen:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation> (0 - geen limiet)</translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation>Waarschuwingen over patroonbewerking</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation>Bevestig verwijderen item</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation>Bevestig herformatteren</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation>Standaard Suffix bij Bewerkingen</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation>Spiegel over as suffix:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation>Spiegel over LIjn suffix:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation>Verplaats suffix:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation>Draaiing suffix:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation>Bestandsbeheer</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation>Sta Automatisch Opslaan toe</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation> min</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation>Elke </translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation>Exportformaat</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation>Neem modus type op in bestandsnaam</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation>Sla laatst gebruikte op</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation>Standaard:</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation>Decimaal scheidingsteken:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation>_M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation>_MOV</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation>_R</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation>_ROT</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation>_MA</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation>_MBA</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation>_MB</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation>_MBL</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation>Millimeters</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation>Geluid bij selectie</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation>Geluid:</translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation>Info ontwerper</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation>Emailadres:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation>Lokalisatie gebruiker</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation>Startup</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation>Welkom</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation>Welkomstscherm niet weergeven</translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11763,582 +9080,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation>Voorkomen</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation>Werkbalken</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation>Tekstlabel verschijnt onder het icoon (aanbevolen voor beginners)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation>Toon werkbalk gereedschappen</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation>Gereedschapskist</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation>Punt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation>Lijn</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation>Kromme</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation>Boog</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation>Bewerkingen</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation>Patroondeel</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation>Opmaak</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation>Grafische afwerking</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation>Gebruik anti-aliasing</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation>Lettertypes</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation>Lettertype:</translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation>Lettergrootte:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation>6</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation>7</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation>8</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation>9</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation>10.5</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation>11</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation>12</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation>13</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation>14</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation>15</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation>16</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation>18</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation>20</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation>22</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation>24</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation>26</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation>28</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation>32</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation>36</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation>40</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation>44</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation>48</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation>54</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation>60</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation>66</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation>72</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation>80</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation>96</translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation>The quick brown fox jumps over the lazy dog</translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation>Namen Punten</translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation>GUI</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation>Kleuren</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation>Zoom Rubberband</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation>Positief:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation>Negatief:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation>Standaard:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation>Zweven</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation>Tekenen</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation>Oorsprong van de as</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation>Primaire:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation>Secundaire:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation>Tertiaire:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation>Navigeren</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation>Schuifbalken</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation>Toon Schuifbalken</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation>Breedte:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation> px</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation>Duur:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation>Duur van de animatie</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation> ms</translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation>Pas interval aan:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation>Tijd in milliseconden tussen iedere update van de animatie</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation>Snelheid:</translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation>Gebruik Ctrl toets</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation>Gedrag</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation>Beperkingen</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation>Hoek van de stap:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation> graad</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation>Zoom naar selectie met dubbelklik</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation>Verschuif naar actief terwijl Spatiebalk is ingedrukt</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation>Exporteer</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
         <translation>Kwaliteit:</translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation>Pad welke Seamly2D gebruikt</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation>Soort</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Pad</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation>Standaardwaarde</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation>Bewerk</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation>Open Map</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation>Mijn Individuele Maten</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>Mijn Multimaten Maten</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation>Mijn patronen</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation>Mijn opmaak</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation>Mijn Sjablonen</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation>Mijn Labelsjablonen</translation>
     </message>
@@ -12346,272 +9495,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation>Flipping verbieden</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation>Standaard is het kantelen voor alle nieuwe patroondelen uitgeschakeld</translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation>Verberg standaard  de hoofdpad als de naadtoeslag is ingeschakeld</translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation>Naad toeslag</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation>Standaard waarde:</translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation>Datum:</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation>Bewerk formaten</translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation>Tijd:</translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation>Patroondeel</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation>Pasmarkeringen</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation>Toon pasmarkering op zowel stiklijn als kniplijn.</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation>Soort:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation>Breedte:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation>Recht van draad</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation>Toon recht van draad</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation>x 3</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation>Paden</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation>Stiklijn</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation>Lijnbreedte</translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation>Kniplijn</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation>Uitsnijdingen</translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation>Labels</translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation>Labelgegevens (datum/tijd formaat)</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation>Knipje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation>T Pasmarkering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation>U Pasmarkering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation>Interne V Pasmarkering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation>Externe V Pasmarkering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation>Kasteel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation>Toon patroonlabels</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation>Toon labels van patroondelen</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation>Breedte</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation>Hoogte</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation>Sjablonen</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation>Patroonlabel:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation>Patroondeel label:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation>Labelsjabloon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation>Importeer sjabloon</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation>Toon Pasmarkering op kniplijn</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation>Toon pasmarkering op stiklijn</translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation>Interne delen</translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation>Toon Kniplijn</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation>Verberg Stiklijn</translation>
     </message>
@@ -12619,7 +9698,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>Gebaseerd op Qt %1 (%2, %3 bit)</translation>
     </message>
@@ -12627,155 +9705,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Maak een nieuw patroondeel om te gaan werken.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>inch</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Eigendom</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation>voeg kernpunt toe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation>Wijzigingen zijn toegepast.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Verkeerde naam label &apos; %1&apos;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation>Kan parameter toUlnt niet converteren</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation>Kan de parameter toBool niet converteren</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation>Kreeg een lege parameter</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation>Kan niet naar toDouble parameter converteren</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation>Kreeg de verkeerde parameter id. Alleen nodig id&gt;0.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation>Stof</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation>Voering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation>Vlieseline</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation>Tussenvoering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation>Knip</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation>op vouw</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation>Verenigd deel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation>verplaats patroondeel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation>Volle lijn</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation>Streep</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation>Punt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation>Streep Punt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation>Streep Punt Punt</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation>Geen Pen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
@@ -12783,15 +9830,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation>Te weinig argumenten voor de sum functie.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation>Te weinig argumenten voor de min functie.</translation>
@@ -12800,217 +9843,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Onverwacht teken &quot;$TOK$&quot; gevonden op positie $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Interne fout</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Ongeldige functie-, variabele- of constant naam:&quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Ongeldige binary operator identificator: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Ongeldige aanpassing operator identificator: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Ongeldige postfix operator identificator: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Ongeldige aanwijzer naar terughaalfunktie.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>Beschrijving is leeg.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Ongeldige aanwijzer voor variabele.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Onverwachte bediener &quot;$TOK$&quot; gevonden op positie $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Onverwacht eind van beschrijving voor positie $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Onverwacht argument scheidingsteken voor positie $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Onverwacht tussenzin &quot;$TOK$&quot;voor positie $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Onverwachte funktie &quot;$TOK$&quot; voor positie $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Onverwachte waarde &quot;$TOK$&quot; gevonden op positie $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Onverwachte variabele &quot;$TOK$&quot; gevonden op positie $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Funktie argumenten gebruikt zonder funktie( positie : $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Tussenzin missend</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Te veel parameters voor funktie &quot;$TOK$&quot; voor beschrijving positie $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Te weinig parameters voor funktie &quot;$TOK$&quot; voor beschrijving positie $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Gedeeld door nul</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Domein fout</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Naam conflict</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>Ongeldige waarde voor bediener prioriteiten( moet groter zijn of gelijk aan nul).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Door de gebruiker definieerde binary bediener &quot;$TOK$&quot; komt in conflict met een ingebouwde bediener.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Onverwachte karakterreeks teken gevonden op positie $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Onbeëindigd karakterreeks startend op positie $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>Karakterreeks funktie benoemd met een niet-karakterreeks type argument.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>Karakterreeks waarde gebruikt waar een nummeriek argument wordt verwacht.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Geen passende overbelasting voor bediener &quot;$TOK$&quot; voor positie $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>Funktie resultaat is een karakterreeks.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Uitpak fout.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>Decimale afscheidingsteken is identiek aan de funktie argument afscheidingsteken.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>De &quot;$TOK$&quot; bediener moet vervolgd worden met een gesloten accolade.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>Als-dan-anders bediener vermist een anders clausule</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Misplaatste dubbele punt op positie $POS$</translation>
@@ -13019,7 +10026,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13027,7 +10033,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation>hernoem patroondeel</translation>
     </message>
@@ -13035,12 +10040,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13048,7 +10051,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation>bewaar opties van detail</translation>
     </message>
@@ -13056,7 +10058,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation>bewaar pad-opties</translation>
     </message>
@@ -13064,7 +10065,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation>sla gereedschap optie op</translation>
     </message>
@@ -13072,88 +10072,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>GUI taal:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation>Patroon teken systeem</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation>Systeem:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation>Auteur:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation>Boek:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation>Bewerken maten</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation>Opnieuw instellen van waarschuwingen</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation>Werkbalk</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation>De tekst verschijnt onder het icoon. (Aanbevolen voor beginners).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation>Standaardhoogte en -grootte</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation>Hoogte:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation>Maat:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation>Startup</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation>Welkomstscherm niet weergeven</translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation>Decimaal scheidingsteken:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation>Lokalisatie gebruiker</translation>
     </message>
@@ -13161,52 +10143,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation>Soort</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Pad</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation>Bewerk</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation>Open Map</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation>Mijn Individuele Maten</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>Mijn Multimaten Maten</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation>Mijn Sjablonen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13214,102 +10186,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Welkom</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation>Welkom bij SeamlyME</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation>3D Look gebruikers</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation>Om een 3D Look bodyscan te gebruiken, moet het bestand worden geconverteerd naar het SeamlyME formaat. </translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation>Voeg uw 3DLook-bestand bij in een e-mail en stuur het naar convert@seamly.io.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Je ontvangt een e-mail met het geconverteerde bestand, dat je vervolgens zoals gewoonlijk in SeamlyME kunt laden.</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation>Kies de eenheden, het decimaalscheidingsteken en de taal van je voorkeur. (Je kunt deze later wijzigen.)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation>Eenheden:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Stelt de standaardeenheden in voor een nieuw meetbestand.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Decimaal scheidingsteken:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>GUI language:</source>
         <translation>GUI taal:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation>Stelt de taal in die wordt gebruikt voor SeamlyMe.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation>Niet meer weergeven</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Lokalisatie gebruiker</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Millimeters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
@@ -13317,92 +10268,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Welkom</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation>Welkom bij Seamly2D</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation>Eenheden:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Stelt de standaardeenheden in voor een nieuw meetbestand.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Decimaal scheidingsteken:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>GUI language:</source>
         <translation>GUI taal:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation>Niet meer weergeven</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Lokalisatie gebruiker</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Millimeters</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation>Stelt de taal in die wordt gebruikt voor Seamly2D.</translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation>Kies de eenheden, het decimaalscheidingsteken, de taal en het selectiegeluid van je voorkeur. (Je kunt deze later wijzigen.)</translation>
     </message>
     <message>
-        <location line="+159"/>
         <source>Sound:</source>
         <translation>Geluid:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation>Stelt het klikgeluid van de knooppuntselectie in.</translation>
     </message>
@@ -13410,12 +10342,10 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation>Verander kleur patroondeel</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation>Kleur Patroondeel veranderd: </translation>
     </message>
@@ -13423,1071 +10353,854 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation>Kopieer sneltoetsen naar het klembord</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation>Exporteer sneltoetsen als een PDF</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation>Zend sneltoetsen naar de printer</translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation>Seamly2D Sneltoetsen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation>Bestand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation>Ctrl+W</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation>Opslaan als</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation>Patroon Voorkeuren</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation>Ctrl+Shift+Comma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation>Document Informatie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation>Bewerk</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation>Ongedaan Maken</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation>Ctrl+Z</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation>Opnieuw doen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation>Ctrl+Y</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation>Beeld</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation>Teken Modus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation>Shift+D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation>Patroondeel Modus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation>Opmaak Modus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation>Shift+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation>Inzoomen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation>Ctrl++</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation>Uitzoomen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation>Ctrl+-</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation>Zoom 1:1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation>Ctrl+0</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation>Zoom in op Punt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation>Ctrl+Alt+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation>Toon Ales</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation>Ctrl+=</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation>Vorige</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation>Ctrl+Links</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation>Geselecteerd</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation>Ctrl+Rechts</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation>Gebied</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation>Toon Panorama</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation>Z, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation>V, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation>Maak Tekst Groter</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation>Ctrl+]</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation>Maak tekst Kleiner</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation>Ctrl+[</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation>Gebruik Gereedschapskleur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation>V, W</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation>Controlepunten Kromme</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation>V, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation>Oorsprong van de as</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation>V, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation>Naadtoeslag</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation>V, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation>Recht-van-draad</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation>V, G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation>Labels</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation>V, L</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation>Maten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation>Open SeamlyMe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation>Variabelentabel</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation>Gereedschap</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation>Nieuw Tekenblok</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation>Ctrl+Shift+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation>Hernoem Tekenblok</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation>F2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation>Punt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation>Lengte en Hoek</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation>L, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation>Op Lijn</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation>O, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation>Op Loodrechte</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation>O, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation>Op Bisectrice</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation>O, B</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation>Lengte tot Lijn</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation>P, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation>Snijpunt Boog en Lijn</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation>A, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation>Snijpunt As en Driehoek</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation>X, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation>Snijpunt XY</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation>X, Y</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation>Snijpunt Lijn en Loodrechte</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation>L, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation>Snijpunt - Lijn en As</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation>L, X</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation>Middelpunt op Lijn</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation>Shift+O, Shift+L</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation>Lijn</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation>Alt+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation>Punt - Snijpunt Lijnen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation>I, L</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation>Krommes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation>Kromme - Interactief</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation>Alt+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation>Spline - Interactief</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation>Kromme - Vast</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation>Alt+Shift+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation>Spline - Vast</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation>Alt+Shift+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation>Punt - Op Kromme</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation>O, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation>Punt - Op Spline	</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation>O, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation>Punt - Snijpunt Krommes</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation>I, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation>Punt - Snijpunt Kromme en As</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation>C, X</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation>Bogen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation>Boog - Straal en Hoeken</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation>Boog - Straal en Lengte</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation>Alt+Shift+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation>Punt - Op Boog</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation>O, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation>Punt - Snijpunt Boog en As</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation>A, X</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation>Punt - Snijpunt Bogen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation>I, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation>Punt - Snijpunt Cirkels</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation>Shift+I, Shift+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Punt - Snijpunt Cirkel en Raaklijn</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation>C, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Punt - Snijpunt Boog en Raaklijn</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation>A, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation>Ellipsvormige Boog</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation>Alt+E</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation>Bewerkingen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation>Draaiing</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation>Spiegel over Lijn</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation>M,L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation>Spiegel over As</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation>M, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation>Verplaats</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation>Alt+M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation>Echte Figuurnaden</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation>T, D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation>Exporteer Tekenblok</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation>E, D</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation>Afbeeldingen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation>Patroondeel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation>Nieuw Patroondeel</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation>N, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation>Ankerpunt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation>A, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation>Binnenpad</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation>I, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation>I, N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation>Ctrl+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation>In Opmaak opnemen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation>Flipping verbieden</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation>Ctrl+Home</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation>Ctrl+End</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation>Hernoem</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation>Del</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation>Verenig 2 Patroondelen (U)</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation>Exporteer Patroondelen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation>E, P</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation>Opmaak</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation>Nieuwe Opmaak</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation>N, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation>Exporteer Opmaak</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation>E, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation>Ctrl+Shift+L</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation>Geschiedenis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation>Ctrl+H</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation>Hulpmiddelen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation>Rekenmachine</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation>Ctrl+Shift+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation>Decimaaltabel</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation>Ctrl+Shift+D</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation>Shift+P</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation>Exporteer PDF</translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation>Voeg kernpunten in</translation>
     </message>
@@ -14495,12 +11208,10 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14508,42 +11219,34 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation>Document informatie</translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation>Kopieer info naar het klembord</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation>Exporteer info als PDF</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation>Zend info naar de printer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Bedrijf:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Klant:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Patroonnaam:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Patroon No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Versie:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Eenheden:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Maten:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Beschrijving: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Noten:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Figuur:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation>Info bestanden</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation>Exporteer PDF</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation>_info</translation>
     </message>
@@ -14551,7 +11254,6 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14559,7 +11261,6 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14567,813 +11268,621 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Selecteer Nieuw voor creëeren maten bestand.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation>Berekende waarde</translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Basis waarde</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>In maten</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>In hoogtes</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Formule:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation>Basis waarde:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation>In maten:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation>In hoogtes:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Beschrijving:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation>Verplaats maten omhoog</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Verplaats maten omlaag</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Bereken waarde:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation>Volledige naam:</translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Soort:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation>Maten soort</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Pad:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Toon in Explorer</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Basis maat:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation>Basis maat waarde</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Basis hoogte:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation>Basis hoogte waarde</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Voornaam:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Achternaam:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation>Geboortedatum:</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>Emailadres:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>Notities:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>Bestand</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Raamwerk</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Maten</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation>Menu</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation>Gradatie</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation>Open individueel ...</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation>Opslaan als ...</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>Over &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>Over het programma SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation>Voeg bekend toe</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation>Voeg op maat toe</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation>Alleen lezen</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>Archief</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation>Toon informatie over alle bekende maten</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Voorkeuren</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation>zonder titel %1</translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>Dit bestand is al geopend in een ander raamwerk.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Bestandsfout.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Kon bestand niet opslaan</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Opslaan als</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation>&amp;Nieuw Raamwerk</translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation>Verander maten</translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Leeg veld.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Fout bij uitpakken: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Individuele maten</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>zonder titel</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation>Niet opgeslagen veranderingen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Maten zijn veranderd.
 Wil je deze veranderingen opslaan?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Leeg veld</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Open bestand</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation>Invoeren van een patroon</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation>De patroon eenheid:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Vind:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation>Vind eerdere</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation>Vind volgende</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation>Afsluiten is mislukt. Dit bestand is al geopend in een ander raamwerk.</translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation>Bestand bevat ongeldige bekende ma(a)t(en).</translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation>Bestand heeft een onbekende indeling.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Volledige naam</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation>Bestand &apos;%1&apos; bestaat niet!</translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation>De naam van bekende maten is verboden om te veranderen.</translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation>Kan maten &apos;%1&apos; niet vinden.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation>De volledige naam van de bekende maten is verboden te veranderen.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation>Functie Wizard</translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation>Verplaats maten naar de top</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation>Verplaats maten naar onderen</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation>Verwijder maten</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation>onbekend</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>mannelijk</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>vrouwelijk</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation>Geslacht:</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation>PM systeem:</translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation>Creëer vanuit bestaande ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation>Creëer vanuit bestaand bestand</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation>Selecteer bestand</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation>Maten diagram</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Onbekende meting&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Onbekende meting&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>Over Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>Bestand was nog niet opgeslagen.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Zoek</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation>Maten naam in een formule</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation>Maten naam in een formule.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation>Maten menselijk-leesbare naam.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>Sla op...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Niet opslaan</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Vergrendelingsbestand</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Het vergrendelingsbestand kon niet worden aangemaakt, wegens het ontbreken van machtigingen.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Onbekende fout gebeurd, bijvoorbeeld een volledige partitie voorkomt het schrijven uit het vergrendelingsbestand.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation>Exporteer naar CSV</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Toon in Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation>Klant naam</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation>Klant&apos;s family naam</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation>Klant&apos;s emailadres</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Hoogte:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Maat:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation>Alle bestanden</translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation>Het maten-dokument heeft geen schrijftoestemming.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Kan geen toestemming geven voor %1 om te wijzigen.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Het bestand is niet bewaard.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation>Het bestand is niet bewaard</translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation>alleen lezen</translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation>Multimaten maten</translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Ongeldig resultaat. Waarde is oneindig of NaN. Controleer uw berekeningen.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation>Leeg</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation>Open meerdere maten...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation>Exporteren van meerdere maten metingen wordt niet ondersteund.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation>Ctrl+Shift+O</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation>Ctrl+,</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation>Sneltoetsen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation>Kon bestand niet exclusief openen. Dit bestand wordt al gebruikt in een ander venster. Verwacht botsingen als er twee copieën van het programma draaien.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation>Nummer</translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation>Open sjabloon ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation>Ctrl+Alt+O</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation>Patroonbestanden</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Dit bestand is al geopend in een ander venster. Negeren als u wilt doorgaan (niet aanbevolen, kan leiden tot gegevensbeschadiging).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Het vergrendelingsbestand kon niet worden aangemaakt, wegens het ontbreken van machtigingen. Negeren als u wilt doorgaan  (niet aanbevolen, kan leiden tot gegevensbeschadiging).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Onbekende fout gebeurd, bijvoorbeeld een volledige partitie voorkomt het schrijven uit het vergrendelingsbestand. Negeren als u wilt doorgaan (niet aanbevolen, kan leiden tot gegevensbeschadiging).</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation>Scan lichaam importeren als</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation>3D Measure Up</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation>3D Look</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation>Om een 3D Look bodyscan te gebruiken, moet het bestand worden geconverteerd naar het SeamlyME formaat.
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
@@ -15382,7 +11891,6 @@ Wil je deze veranderingen opslaan?</translation>
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15392,7 +11900,6 @@ load in SeamlyME as usual.
 </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation>3DLook-bestand converteren:</translation>
     </message>
@@ -15400,22 +11907,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation>Sluit in</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation>Sluit uit</translation>
     </message>
@@ -15423,22 +11926,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation>Vergrendeling Patroondeel</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation>Vergrendeling patroondeel veranderd: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation>Vergrendeld</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation>Ontgrendeld</translation>
     </message>
@@ -15446,47 +11945,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation>Eerste punt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation>Tweede punt</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation>Hoogste punt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation>Laagste punt</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation>Uiterst linkerpunt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation>Uiterst rechterpunt</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation>Verticale as</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation>Horizontale as</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation>Lijn_</translation>
     </message>
@@ -15494,47 +11984,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation>Gereedschap samenvoegen</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wil je echt details verenigen?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation>Behoud originele stukken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation>Kies het eerste punt</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation>Patroondeel moet tenminste twee punten en drie objecten hebben</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation>Selecteer een tweede punt</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation>Selecteer een uniek punt</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation>Selecteer een patroondeel</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation>Selecteer een punt op de rand van het patroondeel</translation>
     </message>
@@ -15542,7 +12023,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation>Verenig patroondelen</translation>
     </message>
@@ -15550,17 +12030,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Vraag niet opnieuw</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Niet opnieuw &amp;vragen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>Niet opnieuw &amp;tonen</translation>
     </message>
@@ -15568,57 +12045,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Kon geen versie informatie krijgen.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>Te veel etiketten &lt;%1&gt; in bestand.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Versie &quot;%1&quot; ongeldig.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Versie &quot;0.0.0&quot; ongeldig.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Ongeldige versie. Minimale ondersteunde versie is %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Ongeldige versie. Maximale ondersteunde versie is %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Fout geen unieke ID.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>Kon de versie niet veranderen.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation>Fout bij het maken van reserve bestand: %1.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Onverwachte versie &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation>Fout bij het openen van een tijdelijk bestand: %1.</translation>
     </message>
@@ -15626,7 +12092,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation>Kan deze spline niet knippen</translation>
     </message>
@@ -15634,22 +12099,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation>Exporteer naar CSV</translation>
     </message>
@@ -15657,13 +12118,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
@@ -15671,23 +12129,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>Kan gereedschap niet vinden in tabel.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation>Fout bij het maken of bijwerken van groep</translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>Nieuwe groep</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15695,7 +12148,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation>Patroondeel</translation>
     </message>
@@ -15703,12 +12155,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -15716,283 +12166,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Bevestig verwijdering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Wil je dit echt verwijderen?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation>Wijzig verkeerde formule</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation>Groen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation>Blauw</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation>Donkerrood</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation>Donkergroen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation>Donkerblauw</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation>Geel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation>Licht zalmkleurig</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation>Goudrood</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation>Oranje</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation>Dieprose</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation>Violet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation>Donkerviolet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation>Midden zeegroen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation>Citroengeel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation>Diep hemelsblauw</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation>Korenbloemblauw</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation>Zwart</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation>Goud</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation>Bladgroen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation>Gazongroen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation>Citroengroen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation>Groengeel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation>Zandkleurig</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation>Orangjerood</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation>Kastanje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation>Rose</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation>Felrose</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation>Blauw-violet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation>Midden violetrood</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation>Indigo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation>Paars</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation>Pruim</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation>Tu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation>Midden Turquoise</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation>Poederblauw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation>Licht hemelsblauw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation>Marine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation>Magenta</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation>Donker leigrijs</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation>Grijs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation>Gainsboro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation>Donker zeegroen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation>Lichtgrijs</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation>Licht staalblauw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation>Beige</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation>Distel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation>Zilver</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation>Rookwit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation>Wit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation>Donkergrijs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation>Kadettenblauw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation>Donker Khaki</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation>Zonnebruin</translation>
     </message>
@@ -16000,302 +12393,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation>Pad naar gebruikelijke maten bestand (export modus).</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation>Het maten bestand</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation>Indeling nummer</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation>Sjabloon nummer</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>De pagina breedte</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation>De maten eenheid</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation>Automatisch inkorten van ongebruikte lengte (export modus).</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation>Opmaak eenheden (als van een papier behalve px, export modus).</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation>De eenheid</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation>De tussenruimte</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation>Groeperen soort</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation>Kan papierformaat en expliciete paginagrootte/eenheden niet tegelijkertijd gebruiken.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation>Papier hoogte, breedte, eenheden moeten alle 3 tegelijkertijd gebruikt worden.</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation>Ongeldige rotatie waarde. Dat moet een van de vooraf gedefinieerde waarden zijn.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation>Onbekende pagina sjabloon geselecteerd.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation>Niet ondersteunde papier eenheden.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation>Niet ondersteunde opmaak eenheden.</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation>Exportopties kunnen worden gebruikt met slechts één invoerbestand.</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation>Test optie kan worden gebruikt met slechts één invoerbestand.</translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation>De basis bestandsnaam van geëxporteerde opmaak bestanden. Gebruik het om het export modus console in te schakelen.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation>De basis bestandsnaam van layout bestanden</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>De doelmap</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation>De grootte waarde</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation>De hoogte waarde</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Pagina breedte in huidige eenheden zoals 12.0 ( kan niet gebruikt worden met &quot;%1&quot;, export modus).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Pagina breedte in huidige eenheden zoals 12.0 ( kan niet gebruikt worden met &quot;%1&quot;, export modus).</translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation>Ongeldige gradatie grootte waarde.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation>Ongeldige gradatie hoogte waarde.</translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Patroon teken programma.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Patroon bestand.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation>Tussenruimte moet worden gebruikt in combinatie met verschuiving eenheden.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation>Linkermarge moet worden gebruikt in combinatie met pagina-eenheden.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation>Rechtermarge moet worden gebruikt in combinatie met pagina-eenheden.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation>Bovenmarge moet worden gebruikt in combinatie met pagina-eenheden.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation>Ondermarge moet worden gebruikt in combinatie met pagina-eenheden.</translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation>Het pad naar de uitvoer van de doelmap. Standaard de map waarin de toepassing is gestart.</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation>Hoogte/breedte pagina maten eenheden (kan niet worden gebruikt met &quot;%1&quot;, export-modus). Geldige waarden: %2.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation>Negeer afdrukmarges (export modus). Maak de waarde sleutels onbruikbaar: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Stel alle marges in op 0.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Linker pagina marge in huidige eenheden zoals 3.0 (export modus). Wanneer dat niet ingesteld is wordt de waarde gebruikt van de standaard printer. Of 0 als er geen printers gevonden zijn. Waarde wordt genegeerd als sleutel &quot;%1&quot; wordt gebruikt.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Rechter pagina marge in huidige eenheden zoals 3.0 ( export modus). Wanneer dat niet ingesteld is wordt de waarde gebruikt van de standaard printer. Of 0 als er geen printers gevonden zijn. Waarde wordt genegeerd als sleutel &quot;%1&quot; wordt gebruikt.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Bovenste pagina marge in huidige eenheden zoals 3.0 (export modus). Wanneer dat niet ingesteld is wordt de waarde gebruikt van de standaard printer. Of 0 als er geen printers gevonden zijn. Waarde wordt genegeerd als sleutel &quot;%1&quot; wordt gebruikt.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Onderste pagina marge in huidige eenheden zoals 3.0 (export modus). Wanneer dat niet ingesteld is wordt de waarde gebruikt van de standaard printer. Of 0 als er geen printers gevonden zijn. Waarde wordt genegeerd als sleutel &quot;%1&quot; wordt gebruikt.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation>Rotatie in graden (een van de vooraf gedefinieerde, export modus). Standaardwaarde is 180. 0 is niet roteren. Geldige waarden: %1. Elke waarde geeft weer hoeveel keer details zal worden gedraaid. Bijvoorbeeld 180 betekend twee keer (360/180 = 2) door 180 graden.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation>Verenig pagina&apos;s indien mogelijk (export modus). Maximale waarde beperkt door QImage welke slechts beelden met een maximum van 32768 x 32768 px  ondersteunt.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation>Sla lengte van het blad op wanneer ingesteld (export modus). De optie vertelt het programma een zo groot mogelijk breedte van blad te gebruiken. Kwaliteit van een opmaak kan slechter worden wanneer deze optie is gebruikt.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation>De opmaak tussenruimte  x2, gemeten in opmaak eenheden (export modus). Stel afstand in tussen details en een detail en een blad.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation>Stelt opmaak in het groeperen van zaken(export modus): %1.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation>Laat het programma in een test-modus lopen. Het programma in deze modus laad een enkel patroon bestand en sluit geruisloos zonder dat het hoofdvenster wordt weergegeven. De sleutel heeft prioriteit voor sleutel &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation>Verschuiving/Offset opmaaklengte gemeten in opmaak eenheden (export modus). De optie laat zien hoeveel punten langs de rand zal worden gebruikt bij het maken van een opmaak.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation>Verschuivings/Offset lengte</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation>Verschuiving/Offset lengte moet gebruikt worden in combinatie met verschuiving eenheden.</translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation>Nummer behorend bij de uitkomst indeling( standaardinstelling = 0, export modus):</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation>Nummer behorende bij de pagina sjabloon( standaardinstelling = 0, export modus):</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Schakel hoog-dpi-schaling uit. Gebruik deze optie als je problemen hebt met schaalverandering (als default is uitgeschakeld). Als alternatief kun je %1 omgevingsvariabele gebruiken.</translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation>Exporteer DXF in binary vorm.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation>Exporteer tekst als paden.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation>Exporteer alleen details. Exporteer details zoals wanneer ze gepositioneerd in de details modus. Elke opmaak gerelateerde opties zullen worden genegeerd.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation>Stel maat waarde van een patroon bestand vast, welke geopend zijn met meerdere maten metingen( exporteer modus). Geldige waardes: %1cm.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation>Stel hoogte waarde van een patroon bestand vast, welke geopend zijn met meerdere maten metingen (exporteer modus). Geldige waarde: %1cm.</translation>
     </message>
@@ -16303,43 +12636,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation>maten</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation>individueel</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation>meermaten</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation>sjablonen</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation>labelsjablonen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16347,55 +12671,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>Kan het object niet vinden</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation>Kan het object niet verplaatsen</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation>Kan het object niet vinden. Soort komt niet overeen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation>Hoeveelheid aan gratis id is verbruikt.</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation>Kan geen kromme maken van soort &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation>Kan het object niet vinden: </translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation>Kan het patroondeel niet vinden: </translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation>Kan het pad niet vinden: </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation>Kan het objecxt Id niet vinden: </translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation>Kan het object niet kiezen.</translation>
     </message>
@@ -16403,12 +12714,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation>Niet genoeg punten om een spline te maken.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation>Deze spline bestaat niet.</translation>
     </message>
@@ -16416,52 +12725,42 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>kan bestand niet openen %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Kan schema bestand niet openen %1:
 %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation>Validatie fout bestand %3 op lijn %1 kolom %2</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation>Fout bij uitpakken bestand %3 op lijn %1 kolom %2</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation>Krijg het kernpunt niet</translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>Deze ID is niet uniek.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation>Kan schema bestand niet laden &apos;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation>Het is mislukt om Conanical XML te schrijven.</translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;empty&gt;</translation>
     </message>
@@ -16469,27 +12768,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation>Toon Puntnaam</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16497,7 +12791,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation>Uitzondering: %1</translation>
     </message>
@@ -16505,11 +12798,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
@@ -16517,7 +12805,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation>Formule:</translation>
     </message>
@@ -16525,7 +12812,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation>Deel %1 heeft geen vorm.</translation>
     </message>
@@ -16533,7 +12819,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation>Toon Puntnaam</translation>
     </message>
@@ -16541,12 +12826,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>Waar</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>Niet waar</translation>
     </message>
@@ -16554,12 +12837,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Directory</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Open bestand</translation>
     </message>
@@ -16567,335 +12848,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Fout bij uitpakken bestand.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Fout kan waarde niet omzetten.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Fout lege parameter.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Fout verkeerde ID.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Fout bij uitpakken bestand (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Fout bij het maken of bijwerken van een enkele punt</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Fout bij het maken of bijwerken van eindpunt van een lijn</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Fout bij het maken of bijwerken van een punt langs een lijn</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Fout bij het maken of bijwerken van schouderpunt</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation>Fout bij het maken of bijwerken van een normaal punt</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Fout bij het maken of bijwerken van punt van bisector</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Fout bij het maken of bijwerken van punt van contact</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation>Fout bij het maken of bijwerken van vormgevend punt</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Fout bij het maken of bijwerken van hoogte</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Fout bij het maken of bijwerken van driehoek</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation>Fout bij het maken of bijwerken van geknipt splinepunt</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation>Fout bij het maken of bijwerken van geknipt splinepad punt</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation>Fout bij het maken of bijwerken van geknipte boog punt</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation>Fout bij het maken of bijwerken van het punt van kruising van lijnen en assen</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation>Fout bij het maken of bijwerken van het punt van kruising van kromme en as</translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Fout bij het maken of bijwerken van lijnen</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Fout bij het maken of bijwerken van een simpele kromme</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Fout bij het maken of bijwerken van een kromme pad</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation>Fout bij het maken of bijwerken van modelleren van simpele kromme</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation>Fout bij het maken of bijwerken van vormgeven van krommepad</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Fout bij het maken of bijwerken van een simpele boog</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation>Fout bij het maken of bijwerken van vormgeven van een boog</translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation>Fout bij het maken of bewerken van de kruising van bogen</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation>Fout bij het maken of bijwerken van een kruising van cirkels</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation>Fout bij het maken of bijwerken van punt van cirkel en raaklijn</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation>Fout bij het maken of bijwerken van het punt boog en raaklijn</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation>Fout bij het maken of bijwerken van coupenaden</translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Verkeerde label naam &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation>Onbekende punt type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation>Onbekende spline van soort &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation>Onbekende boog type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation>Onbekende gereedschap type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation>Fout geen unieke ID.</translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation>Fout bij het maken of bijwerken van kruispunt van krommes</translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation>Fout bij het maken of bijwerken van simpele interactieve spline</translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation>Fout bij het maken of bijwerken van interactieve splinepad</translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation>Fout bij het maken of bijwerken van derdegraads bezier kromme</translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation>Fout bij het maken of bijwerken van derdegraads bezier pad kromme</translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation>Fout bij het maken van of bijwerken van actie van draaiing</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation>Onbekende  bewerkingstype &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation>Fout bij het maken of bijwerken van de bewerking van een verplaatsing</translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation>Fout bij het maken of bijwerken van een kruispunt van een lijn</translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation>Fout bij het maken of bijwerken van een simpele ellipsvormige boog</translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation>Onbekende ellipsvormige boog type &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation>Fot bij het maken of bijwerken van vormgeven van een ellipsvormige boog</translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation>Onbenoemd pad</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation>Fout bij het maken of bijwerken van een pad deel</translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation>Fout bij het maken of bijwerken van een ankerpunt</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation>Fout bij het maken of bijwerken van snijpunt XY</translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation>Fout bij het maken of bijwerken van spiegelen over as</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation>Fout bij het maken of bijwerken van spiegelen over as</translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation>Patroondeel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation>wit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation>nobrush</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation>Fout bij het maken of bijwerken van een patroondeel</translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation>Fout bij het maken of bijwerken van verenigde patroondelen</translation>
     </message>
@@ -16903,17 +13095,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation>Raster ( %1 , %2 )</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation>Pagina %1 van %2</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation>Blad %1 van %2</translation>
     </message>
@@ -16921,12 +13110,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation>patronen</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation>layouts</translation>
     </message>
@@ -16934,14 +13121,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>Niet genoeg punten om een spline te maken.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>Deze spline bestaat niet.</translation>
     </message>
@@ -16949,17 +13132,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -16967,27 +13147,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation>Beginhoek</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation>     Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation>     Straal</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Eindhoek</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation>      Label</translation>
     </message>
@@ -16995,37 +13170,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation>Beginhoek</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation>     Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation>     Straal</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Eindhoek</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation>      Naam</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation>      Gereedschap</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation>Boog - Straal en Lengte</translation>
     </message>
@@ -17033,7 +13201,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -17041,12 +13208,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Kan geen snijpunt %1 maken van punt %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;naar curve %3 met een ashoek van %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Zal oorsprong gebruiken als plaatshouder tot patroon is gecorrigeerd.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation>Snijpunt van Kromme en As</translation>
     </message>
@@ -17054,32 +13219,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation>Boog</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>lengte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation>beginhoek</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation>eindhoek</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation>straal</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation>label</translation>
     </message>
@@ -17087,18 +13246,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation>Kromme</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>lengte</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation>label</translation>
     </message>
@@ -17106,18 +13261,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation>Kromme</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>lengte</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation>label</translation>
     </message>
@@ -17125,7 +13276,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -17133,28 +13283,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation>Beginhoek</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation>     Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation>    Straal</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Eindhoek</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation>      Label</translation>
     </message>
@@ -17162,17 +13306,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -17180,12 +13321,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Hoek</translation>
     </message>
@@ -17193,7 +13332,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -17201,27 +13339,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Kan het snijpunt %1 van&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Lijn en As niet vinden&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Zal de oorsprong als plaatshouder gebruiken tot het patroon gecorrigeerd is.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation>Snijpunt - Lijn en As</translation>
     </message>
@@ -17229,17 +13362,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -17247,7 +13377,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation>Oorsprongpunt</translation>
     </message>
@@ -17255,12 +13384,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation>Eerste lijnpunt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation>Tweede lijnpunt</translation>
     </message>
@@ -17268,27 +13395,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Middelste punt</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation>Draaipunt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation>Draaiingshoek</translation>
     </message>
@@ -17296,714 +13418,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Basis punt</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation>Coupenaden</translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation>Basis punt:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation>Middelste punt:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation>Straal:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation>Eerste hoek:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Tweede hoek:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation>Derde punt:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Punt 1 label:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation>Punt 2 label:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation>Eerste basis punt:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation>Tweede basis punt:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation>Eerste figuurnaad punt:</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation>Boog:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation>Kromme:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation>Eerste lijnpunt:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Tweede lijnpunt:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Midden van de boog:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation>Eerste boog:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation>Tweede boog:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation>Kies:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation>Eerste kromme:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation>Tweede kromme:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation>Raaklijn punt:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation>Cirkel straal:</translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation>Naam:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>C1: hoek:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation>C1: lengte:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>C2: hoek:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation>C2: lengte:</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation>As punt:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation>Achtervoegsel:</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation>Originele punt:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation>As punt:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation>Hoek van draaiing:</translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation>Vierde punt:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation>Punt - snijpunt XY</translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation>Draaiing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation>Draaipunt:</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation>Verplaats</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation>Spiegel over Lijn</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation>Spiegel over As</translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation>Coordinaten</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation>Punt - Lengte en Hoek</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation>Punt - Op Lijn</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation>Boog - Straal en Hoeken</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation>Boog - Straal en Lengte</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation>Punt - Op Bisectrice</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation>Tweede figuurnaad punt:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation>Derde figuurnaad punt:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation>Punt - Op Boog</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation>Punt - Op Kromme</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation>Punt - Op Spline</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation>Punt - Snijpunt Lijn en Loodrechte</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation>Lijn</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation>Punt - Snijpunt Lijnen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation>Eerste lijn</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation>Tweede lijn</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation>Punt - Op Loodrechte</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation>Draaiing:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation>Punt - Snijpunt Boog en Lijn</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation>eerste lijnpunt:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation>tweede lijnpunt:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation>Punt - Snijpunt Bogen</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation>Punt - Snijpunt Cirkels</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation>Eerste cirkel:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation>Middelpunt:</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation>Tweede cirkel:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation>Punt - Snijpunt Krommes</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation>Verticale steek:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation>Horizontale steek:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Punt - Snijpunt Cirkel en Raaklijn</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Punt - Snijpunt Boog en Raaklijn</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation>Punt - Lengte tot Lijn</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation>Kromme - Interactief</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation>Kromme - Vast</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation>Spline - Interactief</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation>Spline - Vast</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation>Punt - Snijpunt As en Driehoek</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation>Eerste punt as:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation>Tweede punt as:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation>Punt - Snijpunt Lijn en As</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation>Punt - Snijpunt Kromme en As</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation>Boog - Ellipsvormig</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation>Boog_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation>Splinepad_</translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation>Lijn_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Middelste punt</translation>
     </message>
@@ -18011,12 +13817,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Kan het snijpunt %1 van&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 en Raaklijn niet vinden&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Zal de oorsprong als plaatshouder gebruiken tot het patroon gecorrigeerd is.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation>Snijpunt Boog en Raaklijn</translation>
     </message>
@@ -18024,17 +13828,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -18042,12 +13843,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Kan het snijpunt %1 van Bogen niet vinden&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Zal de oorsprong als plaatshouder gebruiken tot het patroon gecorrigeerd is.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation>Snijpunt Bogen</translation>
     </message>
@@ -18055,12 +13854,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Kan het snijpunt %1 van Krommes niet vinden&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Zal de oorsprong als plaatshouder gebruiken tot het patroon gecorrigeerd is.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation>Punt Snijpunt Krommes</translation>
     </message>
@@ -18068,12 +13865,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation>  Oorsprongpunt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation>Draaiingshoek</translation>
     </message>
@@ -18081,17 +13876,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation>Lengte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Hoek</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -18099,1552 +13891,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation>Bunka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation>Bunka Fashion College</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation>Fundamentals of Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation>Barnfield and Richard</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation>Jo Barnfield and Andrew Richards</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation>Pattern Making Primer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation>Friendship/Women</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation>Elizabeth Friendship</translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation>Morris, K.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation>Karen Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation>Sewing Lingerie that Fits</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation>Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation>Lucia Mors de Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation>Patternmaking in Practic</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation>Kim &amp; Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation>Injoo Kim and Mykyung Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation>Apparel Making in Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation>Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation>Norah Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation>Corsets and Crinolines</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation>Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation>Frances Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation>Fashions of the Gilded Age</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation>Thornton&apos;s International System</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation>The Great War: Styles and Patterns of the 1910s</translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation>Hillhouse &amp; Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation>Marion S. Hillhouse and Evelyn A. Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation>Dress Design: Draping and Flat Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation>Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation>Esther Kaplan Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation>How to Design Beautiful Clothes: Designing and Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation>Minister &amp; Son</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>Edward Minister &amp; Son, ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation>The Complete Guide to Practical Cutting (1853)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation>Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation>Gertrude Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation>A Tailoring Manual</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation>Loh &amp; Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation>May Loh and Diehl Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternless Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation>Morris, F. R.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation>F. R. Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation>Ladies Garment Cutting and Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation>Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation>Gertrude Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation>Gertrude Mason&apos;s Patternmaking Book</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation>Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation>K. Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation>Master Designer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation>The Master Designer (Chicago, IL)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation>Master Designer&apos;s System of Designing, Cutting and Grading</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation>Kopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation>How to Draft Basic Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation>Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation>Doris Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation>Slacks Cut-to-Fit for Your Figure</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation>Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation>Sarah J. Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation>Sarah&apos;s Key to Pattern Drafting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation>Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation>Karla J. Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation>Design and Sew Jeans</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Lady Boutique magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation>Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation>M. Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation>Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation>Dorothy Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation>Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation>Bina Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation>Integrating Draping, Drafting and Drawing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation>Sue S. Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Dressmaking International magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation>Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation>Mabel D. Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation>Practical Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation>Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation>E. L. G. Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>Principles of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation>Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation>Elizabeth M. Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation>European Cut</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation>McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation>Donald H. McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation>How to Make Your Own Sewing Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation>Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation>Zarapkar System of Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation>Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation>Philip Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation>Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation>Jack Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation>Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation>R. I. Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation>MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation>Jason MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation>The Victorian Tailor: An Introduction to Period Tailoring</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation>Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation>Helen Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation>Supreme System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation>Frederick T. Croonberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation>Sugino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation>Dressmaking</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting Vols. I, II, III (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation>Centre Point System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation>Louis Devere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation>The Handbook of Practical Cutting on the Centre Point System</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation>Aldrich/Men</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation>Winifred Aldrich</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation>Aldrich/Women</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation>Metric Pattern Cutting for Women&apos;s Wear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation>Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation>Gareth Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Menswear</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation>Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation>Teresa Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation>Pattern-Drafting for Fashion: The Basics</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation>Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation>Dennic Chunman Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation>Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation>Dress Pattern Designing: The Basic Principles of Cut and Fit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation>Knowles/Men</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation>Lori A. Knowles</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation>The Practical Guide to Patternmaking for Fashion Designers: Menswear</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation>Friendship/Men</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation>Pattern Cutting for Men&apos;s Costume</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation>Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation>P. Clement Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation>Art in Dress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation>Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation>Jno. J. Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation>GOST 17917-86</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation>Ministry of consumer industry of the USSR</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation>Standard figure boys</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation>Eddy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation>Josephine F. Eddy and Elizabeth C. B. Wiley</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation>Pattern and Dress Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation>Knowles/Women</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation>American Garment Cutter</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation>Geen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation>Seamly2D team</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation>Seamly2D&apos;s internal standard</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>in</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Vvkpad</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Hoek1Vvkpad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Hoek2Vvkpad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation>Seg_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation>HuidigeLengte</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation>maat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation>hoogte</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>C1LengteVvkpad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>C2LengteVvkpad</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation>HuidigeNaadToegift</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation>datum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation>tijd</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation>PatroonNaam</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation>PatroonNummer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation>auteur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation>klant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation>pBestandsnaam</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation>mBestandsnaam</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation>pLetter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation>pOriëntatie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation>pDraaiing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation>pHelling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation>pNaam</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation>pAantal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation>mStof</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation>mVoering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation>mVlieseline</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation>mTussenvoering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation>wKnip</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>M_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Variable_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Lijn_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>HoekLijn_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Boog_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>EllBoog_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Spl_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Straalboog_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Radius1ElArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Radius2ElArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Hoek1boog_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Hoek2boog_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Angle1ElArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Angle2ElArc_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Hoek1Vvk_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Hoek2Vvk_</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>C1LengteVvk_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>C2LengteVvk_</translation>
@@ -19653,17 +15188,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation>&lt;b&gt;Krommepad&lt;/b&gt;: selecteer zeven of meer punten</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation>&lt;b&gt;Krommepad&lt;/b&gt;: selecteer meer punten om segment kompleet te maken</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Krommepad&lt;/b&gt;: selecteer zeven of meer punten, &lt;b&gt;Enter&lt;/b&gt; - voltooi creatie</translation>
     </message>
@@ -19671,7 +15203,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation>&lt;b&gt;Kruising tussen kromming en as&lt;/b&gt;: hoek = %1°; &lt;b&gt;Shift&lt;/b&gt; -steekhoek, &lt;b&gt;Enter&lt;/b&gt; - voltooi creatie </translation>
     </message>
@@ -19679,7 +15210,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Punt Lengte en Hoek&lt;/b&gt;: hoek = %1°, lengte = %2%3; Houd &lt;b&gt;SHIFT&lt;/b&gt; ingedrukt om hoeken te beperken, Druk &lt;b&gt;ENTER&lt;/b&gt; om te eindigen</translation>
     </message>
@@ -19687,7 +15217,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Snijpunt tussen lijn en as&lt;/b&gt;: hoek = %1°; &lt;b&gt;Shift&lt;/b&gt; - steekhoek, &lt;b&gt;Enter&lt;/b&gt; - voltooi creatie</translation>
     </message>
@@ -19695,12 +15224,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation>Lengte = %1%2, hoek = %3°, &lt;b&gt;Shift&lt;/b&gt; - steekhoek, &lt;b&gt;Muis klik&lt;/b&gt; -voltooi creatie</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation>Lengte = %1%2, hoek = %3°, draaiingshoek = %4 &lt;b&gt; SHIFT&lt;/b&gt; om hoeken te beperken, &lt;b&gt; CTRL&lt;/b&gt; verander draaipunt, &lt;b&gt; Muisklik&lt;/b&gt; - voltooi</translation>
     </message>
@@ -19708,7 +15235,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation>Hoek van draaiing = %1°, &lt;b&gt;Shift&lt;/b&gt; - steekhoek, &lt;b&gt;Muisklik&lt;/b&gt; - voltooi creatie</translation>
     </message>
@@ -19716,7 +15242,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation>Gebruik &lt;b&gt;Shift&lt;/b&gt; voor steekhoek</translation>
     </message>
@@ -19724,17 +15249,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Krommepad&lt;/b&gt;: selecteer drie of meer punten</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Krommings pad&lt;/b&gt;: selecteer drie of meer punten, &lt;b&gt;Enter&lt;/b&gt; - voltooi creatie</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation>Gebruik &lt;b&gt;Shift&lt;/b&gt; voor steekhoek</translation>
     </message>
@@ -19742,47 +15264,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>FOUTEN OPSPOREN:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>WAARSCHUWING:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>KRITISCH:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>FATAAL:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation>Cruciale fout</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation>Fatale fout</translation>
     </message>
@@ -19790,47 +15303,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>FOUTEN OPSPOREN:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>WAARSCHUWING:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>KRITISCH:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>FATAAL:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>INFO:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation>Cruciale fout</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation>Fatale fout</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>Sobre Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Web site: %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Não é possível abrir seu navegador padrão</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Construído de %1 a %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Checar atualizações</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>Adicionar grupo</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>Adicionar objeto</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished">Ponto:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished">Peça:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>Excluir grupo</translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>Ferramenta de exclusão</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>Ferramenta de exclusão</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">Sobre SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished">Versão SeamlyMe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Versão revista: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished">Este programa é parte do projero Seamly2D.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Checar atualizações</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Não é possível abrir seu navegador padrão</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Construído de %1 a %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Web site: %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Selecionar o segundo ponto da linha</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Editar comprimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>Primeiro ponto da linha</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Segundo ponto:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Segundo ponto da linha</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>O raio não pode ser negativo</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Ângulos iguais</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Editar raio</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Editar primeiro ângulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Editar segundo ângulo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Raio:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>Primeiro ângulo:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Segundo ângulo:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Ponto central:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Selecionar o ponto central do arco</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Cor:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Editar raio</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Editar o primeiro ângulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Editar comprimento do arco</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>O raio não pode ser negativo</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>O comprimento não pode ser igual a 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Raio:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>Primeiro ângulo:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Ponto central:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Cor:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Selecionar segundo ponto do ângulo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Selecione terceiro ponto do ângulo</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Editar comprimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Segundo ponto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Terceiro ponto:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Cor:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Segundo ponto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Terceiro ponto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Quarto ponto:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Selecionar segundo ponto da curva</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Selecionar terceiro ponto da curva</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Selecionar quarto ponto da curva</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>Spline inválido</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Ponto:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>Lista de pontos</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Cor:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation>Caminho spline inválido</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Caminho:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Selecione ponto do eixo</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Editar ângulo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Ângulo:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Ponto do eixo:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Editar comprimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Arco:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Editar comprimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Editar comprimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation>Raio1:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation type="unfinished">Cálculo</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation>Raio2:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation type="unfinished">Primeiro ângulo:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation type="unfinished">Segundo ângulo:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation>Ângulo de rotação:</translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation type="unfinished">Ponto central:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation>Selecionar o ponto central do arco</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">O raio não pode ser negativo</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Ângulos iguais</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation>Editar raio1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation>Editar raio2</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished">Editar primeiro ângulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished">Editar segundo ângulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation>Editar ângulo de rotação</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Editar ângulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Editar comprimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Ângulo:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Ponto base:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Opções de exportação</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>Com cabeçalho</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Separador</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation>Tabulação</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>Vírgula</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>Ponto-e-vírgula</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Espaço</translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Selecione o segundo pontoda linha</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Ponto base:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished">Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Segundo ponto:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished">Tipo:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished">Peça:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished">Pronto!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Margem de costura</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Largura:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished">Cálculo</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished">Nós</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished">Nó:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished">Antes:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished">Padrão</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished">Depois:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished">Ângulo:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished">Reto</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished">Bissetriz</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">Comprimento:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverso</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Editar tamanho da margem de costura</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished">Margem de costura personalizada</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished">São necessários mais pontos!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished">O primeiro ponto da &lt;b&gt;margem de costura personalizada&lt;/b&gt; não pode ser igual ao último ponto!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Existem pontos duplicados!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished">Cada ponto na &lt;b&gt;margem de costura personalizada&lt;/b&gt; deve ser único!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Não foi possível preparar dados para layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Criar Layout</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Selecioneo segundo ponto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Segundo ponto:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Linha_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Primeira linha</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Segunda linha</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Selecione o segundo ponto da segunda linha</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Selecione o primeiro ponto da segunda linha</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Selecione o segundo ponto da segunda linha</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Segundo ponto:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Primeiro ponto da linha</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Selecione o segundo pontoda linha</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Selecione ponto central</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Ponto central</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Segundo ponto da linha</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Editar ângulo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Ângulo:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Ponto central:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished">Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished">Segundo ponto:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Medidas</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished">Pesquisar:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished">Buscar</translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished">Sufixo:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished">Tipo de eixo:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Eixo vertical</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Eixo horizontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished">Sufixo:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation type="unfinished">Ângulo:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation type="unfinished">Comprimento:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation>Sufixo:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation type="unfinished">Editar ângulo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished">Editar comprimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation type="unfinished">Cálculo</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished">Ponto de origem:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotação:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Ponto central</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Unidades:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Centimetros</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Polegadas</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Nome único da peça de molde</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Escolha um nome único para peça de modelagem.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>Novo molde</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Selecione o segundo pontoda linha</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Editar comprimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Segundo ponto:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotação:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Descrição do molde</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Alturas e Tamanhos</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Todas as alturas (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Todos os tamanhos (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Altura e tamanho padrões</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Personalizado</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Tamanho:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Segurança</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Abrir somente para leitura</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>Sem imagem</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Remover imagem</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Trocar imagem</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Salvar imagem para arquivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Mostrar imagem</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Imagens</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Salvar Arquivo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>sem título</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Caminho:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Mostrar no Explorador</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;Empty&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>O arquivo ainda não foi salvo.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Mostrar no Localizador</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Nome do molde:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Número do molde:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Nome da Empresa/Modelista:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Nome do cliente:</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Molde</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Selecione um arco</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Ponto tangente:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Arco:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Selecione o ponto central da curva</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Selecione o segundo pontoda linha</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Editar raio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Raio:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation>Selecionar segundo arco</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>Primeiro arco:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Segundo arco:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>Primeira curva:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Segunda curva:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Selecionar segunda curva</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Molde</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished">Geral</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Rotação</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Ângulo:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Sufixo:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation type="unfinished">Editar ângulo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferências</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Configuração</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Selecione o segundo pontoda linha</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Editar comprimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Cálculo</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Segundo ponto:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Terceiro ponto:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Ponto base</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Primeiro ponto</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Segundo ponto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Cor:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Ângulo:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Segundo ponto:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>Spline inválido</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished">Cálculo</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Lista de pontos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Cor:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Ponto:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Ângulo:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation>Caminho spline inválido</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Comprimento:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished">Cálculo</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Caminho:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Campo vazio</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Primeiro ponto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Segundo ponto</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Resultado inválido. Valor é infinito ou não é um número. Por favor, verifique seus cálculos.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Selecioneo segundo ponto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Segundo ponto:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filtrar lista por palavra-chave</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">O valor calculado</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Fórmula</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Detalhes</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Valor calculado:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished">Fórmula:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished">Cálculo</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished">Descrição:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Linha</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Ângulo</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Arco</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished">Campo vazio.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Campo vazio</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Resultado inválido. Valor é infinito ou não é um número. Por favor, verifique seus cálculos.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Ferramenta</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Editar fórmula</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Medidas</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished">Funções</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished">Fórmula:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished">Cálculo</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Insira variável na fórmula</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Ocultar medidas sem valores</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished">Nome completo</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Filtrar lista por palavra-chave</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Comprimento da linha</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Comprimento da curva</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Ângulo da Linha</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished">Raio do arco</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished">Ângulo da curva</translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Nome único da peça de molde</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">Erro de arquivo.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Tamanho:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Altura:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished">Tecido</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished">Forro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished">Entretela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Caminho:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished">Diretório de destino</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished">Selecionar caminho para diretório de destino</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished">Navegar...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished">Formato do arquivo:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished">Nome do arquivo:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished">Direita:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished">Esquerda:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished">Topo:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished">Base:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished">Formato do papel</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished">Selecionar diretório</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished">Tentativa de uso de número fora da faixa permitida.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - ponto base</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Arco_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">Histórico</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished">Pesquisar:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Ponto base</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Arco_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Descrição</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished">Unidade:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Largura:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Altura:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotação:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished">Peça:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverso</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished">nenhum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished">Ponto central:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Ponto tangente:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Raio:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished">Cálculo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished">Selecione o centro do círculo</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished">Editar raio</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">O raio não pode ser negativo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Raio:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mostrar cálculo completo na caixa de mensagem&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished">Cálculo</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished">Selecionar centro do segundo círculo</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished">Editar raio do primeiro círculo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished">Editar raio do segundo círculo</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">O raio não pode ser negativo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Largura:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Rotacionar peça</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Rotacionar por</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>grau</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Três grupos: grande médio, pequeno</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Dois grupos: grande, pequeno</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centimetros</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Polegadas</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Píxels</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Cortar automaticamente comprimento não usado</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Unir páginas (se for possível)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Salvar comprimento da folha</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Formato do papel</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Esquerda:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Direita:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Topo:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Base:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Campos incorretos.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6623,84 +5191,67 @@ Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation>Regra para escolha da próxima peça</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation>Multiplicador</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Impressora:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation type="unfinished">nenhum</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6708,32 +5259,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6741,2659 +5286,2000 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Linha</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Arco</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Medidas</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Detalhes</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Histórico</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Preferências</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Abrir arquivo</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>Arquivo Salvo</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>Arquivo carregado</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>Novo molde</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Tamanho:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation>Medidas individuais</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation>O valor calculado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished">Fórmula</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotação</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Mover</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">Sobre Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished">Exportar</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished">Imagens</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished">Ponto:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">sem título</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>molde</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished">Padrão</translation>
     </message>
@@ -9401,86 +7287,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Não foi possível preparar dados para layout</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Molde</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9488,148 +7354,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Salvar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9637,123 +7473,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished">Esconder todos</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished">Exibir todos</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished">Verificar todos</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished">Desmarcar todos</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Mão</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Pé</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Cabeça</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Circunferência e arco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Vertical</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Horizontal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Busto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Braço</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Perna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Masculino &amp; Alfaiataria</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Medidas de modelagem</translation>
@@ -9762,18 +7577,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9781,37 +7588,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished">Forma</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Unidades:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9819,12 +7619,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9832,7 +7630,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9840,7 +7637,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9848,7 +7644,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9856,7 +7651,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9864,7 +7658,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9872,7 +7665,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9880,52 +7672,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>Novo arquivo de medidas</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Tipo de medida:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Unidade:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Tamanho base:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Altura base:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Individual</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Centimetros</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Polegadas</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9933,87 +7715,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished">Carta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished">Ofício</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished">Rolo de 24&quot;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished">Rolo de 30&quot;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished">Rolo de 36&quot;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished">Rolo de 42&quot;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished">Rolo de 44&quot;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizado</translation>
     </message>
@@ -10021,887 +7786,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished">Nome não pode ficar vazio</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished">Classificar:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished">Colocação:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotação:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">nenhum</translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished">Proibir peça de ser espelhada no layout.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished">Todos os objetos no traçado devem seguir o sentido horário.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished">Pronto!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished">Padrão</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Largura:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Auxiliar de fórmula</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished">Cálculo</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished">Nós</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished">Nó:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished">Antes:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished">Depois:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished">Ângulo:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizado</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished">Altura:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Comprimento:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished">Tipo:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished">Reto</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished">Bissetriz</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverso</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Opções</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished">Resultado infinito ou indefinido</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished">Comprimento deve ser positivo</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished">Editar comprimento</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished">Editar ângulo</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Editar tamanho da margem de costura</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished">Fio</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished">São necessários mais pontos!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Existem pontos duplicados!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished">Ambos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished">Apenas frente</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished">Apenas costas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Paths</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished">Topo:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished">Base:</translation>
     </message>
@@ -10909,218 +8421,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11128,27 +8588,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11156,77 +8611,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11234,139 +8674,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished">Forma</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11374,62 +8769,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished">Selecionar ponto para valor Y (horizontal)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
@@ -11437,316 +8820,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished">Intervalo:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished">Idioma</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>Linguagem GUI:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation>Unidade padrão:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished">A unidade padrão foi atuaizada e será usada como padrão para o próximo molde criado.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation>Centímetros</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished">Polegadas</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished">nenhum</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11754,582 +9071,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Linha</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Arco</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Detalhes</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished">Tamanho:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Largura:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished">Exportar</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12337,272 +9486,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Margem de costura</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished">Tipo:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">Comprimento:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Largura:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Paths</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Largura</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Altura:</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12610,7 +9689,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12618,155 +9696,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished">Tecido</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished">Forro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished">Entretela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12774,15 +9821,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
@@ -12791,217 +9834,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Conflito de nomes</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
@@ -13010,7 +10017,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13018,7 +10024,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13026,12 +10031,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13039,7 +10042,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13047,7 +10049,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13055,7 +10056,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13063,88 +10063,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Idioma</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">Linguagem GUI:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished">Sistema de modelagem</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">Autor:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished">Livro:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished">Barra de ferramentas</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished">A legenda aparece sob o ícone. (recomendado para iniciantes).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished">Altura e tamanho padrões</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Altura:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished">Tamanho:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13152,52 +10134,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished">Padrão</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13205,102 +10177,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished">Unidades:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished">Linguagem GUI:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Polegadas</translation>
     </message>
@@ -13308,92 +10259,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished">Unidades:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished">Linguagem GUI:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Polegadas</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13401,12 +10333,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13414,1071 +10344,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Salvar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Medidas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Linha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotação</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Mover</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished">Imagens</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished">Renomear</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Detalhes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">Histórico</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14486,12 +11199,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14499,42 +11210,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14542,7 +11245,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14550,7 +11252,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14558,818 +11259,625 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Fórmula</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Detalhes</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Fórmula:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Descrição:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Valor calculado:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Tipo:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Caminho:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Mostrar no Explorador</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Tamanho base:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Altura base:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Medidas</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>Sobre SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Preferências</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Erro de arquivo.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Campo vazio.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Medidas individuais</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>sem título</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Campo vazio</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Abrir arquivo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Pesquisar:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Nome completo</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>O arquivo ainda não foi salvo.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Mostrar no Localizador</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Tamanho:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Resultado inválido. Valor é infinito ou não é um número. Por favor, verifique seus cálculos.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15377,7 +11885,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15385,22 +11892,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15408,22 +11911,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15431,47 +11930,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">Primeiro ponto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Segundo ponto</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Eixo vertical</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Eixo horizontal</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Linha_</translation>
     </message>
@@ -15479,47 +11969,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15527,7 +12008,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15535,17 +12015,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15553,57 +12030,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Versão inesperada&quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15611,7 +12077,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15619,22 +12084,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15642,13 +12103,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
@@ -15656,23 +12114,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>Novo grupo</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15680,7 +12133,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15688,12 +12140,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -15701,283 +12151,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15985,302 +12378,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>A largura da página</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Ângulo</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>A pasta de destino</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16288,43 +12621,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16332,55 +12656,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16388,12 +12699,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16401,50 +12710,40 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16452,27 +12751,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Excluir</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16480,7 +12774,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16488,11 +12781,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
@@ -16500,7 +12788,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished">Fórmula:</translation>
     </message>
@@ -16508,7 +12795,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16516,7 +12802,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16524,12 +12809,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>Verdadeiro</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>Falso</translation>
     </message>
@@ -16537,12 +12820,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Abrir arquivo</translation>
     </message>
@@ -16550,335 +12831,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16886,17 +13078,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16904,12 +13093,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16917,14 +13104,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16932,17 +13115,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Ângulo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -16950,27 +13130,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16978,37 +13153,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17016,7 +13184,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -17024,12 +13191,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17037,32 +13202,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Arco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17070,18 +13229,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17089,18 +13244,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17108,7 +13259,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -17116,28 +13266,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17145,17 +13289,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Ângulo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -17163,12 +13304,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Ângulo</translation>
     </message>
@@ -17176,7 +13315,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -17184,27 +13322,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Ângulo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17212,17 +13345,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Ângulo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -17230,7 +13360,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17238,12 +13367,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17251,27 +13378,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Ponto central</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Ângulo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17279,714 +13401,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation>Ponto base:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Comprimento:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished">Ângulo:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">Segundo ponto:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Ponto central:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Raio:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished">Primeiro ângulo:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished">Segundo ângulo:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished">Terceiro ponto:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished">Arco:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished">Curva:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation>Primeiro arco:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation>Segundo arco:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation>Primeira curva:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation>Segunda curva:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation>Ponto tangente:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation>Ponto do eixo:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation>Sufixo:</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation>Ponto de origem:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation>Tipo de eixo:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation>Ângulo de rotação:</translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation>Quarto ponto:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotação</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished">Mover</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Linha</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">Primeira linha</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Segunda linha</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished">Rotação:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Arco_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Linha_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Ponto central</translation>
     </message>
@@ -17994,12 +13800,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18007,17 +13811,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Ângulo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -18025,12 +13826,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18038,12 +13837,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18051,12 +13848,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18064,17 +13859,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Comprimento</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Ângulo</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
@@ -18082,1552 +13874,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation>Como Fazer Sua Própria Modelagem</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation>nenhum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>mm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation>Segmento_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Linha_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">LinhaDeAngulo_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Arco_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19636,17 +15171,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19654,7 +15186,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19662,7 +15193,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19670,7 +15200,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19678,12 +15207,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19691,7 +15218,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19699,7 +15225,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19707,17 +15232,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Traçado de Curva&lt;/b&gt;: selecione três ou mais pontos</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19725,47 +15247,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>DEBUG:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>AVISO:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>CRÍTICO:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>INFORMAÇÃO:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19773,47 +15286,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>DEBUG:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>AVISO:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>CRÍTICO:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>FATAL:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>INFORMAÇÃO:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>Despre Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Site Web: %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Nu pot deschide browser-ul implicit</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Construit pe %1 la %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>adaugă obiect</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation> instrument ștergere</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation type="unfinished"> instrument ștergere</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">Despre Bandă</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished">Varianta cu Bandă</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Revizie Versiune: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished">Acest program face parte din proiectul Seamly2D.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Nu pot deschide browser-ul implicit</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Construit pe %1 la %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Site Web: %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Selectați al doilea punct al liniei</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Editează lungimea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Lungime:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>Primul Punct:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>Primul punct al liniei</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Al doilea punct:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Al doilea punct al liniei</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Raza nu poate fii negativă</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Unghiuri egale</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Editare raza</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Editează primul unghi</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Editează al doilea unghi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Rază:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>Primul unghi:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Al doilea unghi:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Punct central:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Selectează punctul de centru pentru curbură</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Culoare:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Editare raza</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Editează primul unghi</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Editează lungimea arcului</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Raza nu poate fii negativă</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>Lungimea nu poate fii egală cu 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Rază:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>Primul unghi:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Lungime:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Punct central:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Culoare:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Alege al doilea punct de unghi</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Alege al treilea punct de unghi</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Editează lungimea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lungime:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>Primul Punct:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Al doilea punct:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Al treilea punct:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation type="unfinished">Primul Punct:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Al doilea punct:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation type="unfinished">Al treilea punct:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation type="unfinished">Lista punctelor</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Rută:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Alege punctul de axă</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Editare unghi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Unghi:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Punct de axă:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Curbă:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Editare lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lungime:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Arc:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Editare lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lungime:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Curbă:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Editare lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Lungime:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Curbă:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation type="unfinished">Primul unghi:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation type="unfinished">Al doilea unghi:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation type="unfinished">Punct central:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished">Selectează punctul de centru pentru curbură</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished">Eroare</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Raza nu poate fii negativă</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished">Unghiuri egale</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished">Editează primul unghi</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished">Editează al doilea unghi</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Editează unghiul</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Editează lungimea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Lungime:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Unghi:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Alege primul punct al liniei</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Selectați al doilea punct al liniei</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished">Primul Punct:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Al doilea punct:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished">Gata!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Adaos cusatură</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Lățime:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished">Unghi:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">Lungime:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Înapoi</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Șterge</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished">Ai nevoie de mai multe puncte!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Ai puncte duble!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Nu s-au putut pregăti datele pentru crearea unei schițe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Alege al doilea punct</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>Primul Punct:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Al doilea punct:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Prima linie</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>A doua linie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Alege al doilea punct al primei linii</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Alege primul punct al liniei a doua</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Alege al doilea punct al liniei a doua</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>Primul Punct:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Al doilea punct:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Primul punct al liniei</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Selectați al doilea punct al liniei</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Alege punctul de axă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Punct de axă</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Al doilea punct al liniei</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Editează unghiul</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Unghi:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Punct de axă:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished">Primul Punct:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished">Al doilea punct:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Măsurători</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished">Punct de axă:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation type="unfinished">Unghi:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation type="unfinished">Lungime:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Punct central</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Unități:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Centimetrii</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Inci</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Selectați al doilea punct al liniei</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Editează lungimea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Lungime:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>Primul Punct:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Al doilea punct:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Descriere tipar</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Înălțimi și Dimensiuni</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Toate înălțimile (cm)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Toate dimensiunile (cm)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Înălțime:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Rută:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Arc:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Selectează punctul de centru pentru curbură</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Selectați al doilea punct al liniei</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Editare raza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Rază:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation type="unfinished">Unghi:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Preferințe</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Configurație</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Alege primul punct al liniei</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Selectați al doilea punct al liniei</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Editează lungimea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Lungime:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Calcul</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>Primul Punct:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Al doilea punct:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Al treilea punct:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Coordinate pe foaie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Coordinate</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Punct de bază</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Primul Punct</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Al doilea punct</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Alege ultimul punct de curbă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Culoare:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation type="unfinished">Primul Punct:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation type="unfinished">Unghi:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation type="unfinished">Al doilea punct:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation type="unfinished">Lungime:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Eroare</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Lista punctelor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Alege punctul de traiectorie al curbei</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Culoare:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation type="unfinished">Unghi:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation type="unfinished">Lungime:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation type="unfinished">Eroare</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Rută:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Câmp gol</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Valoarea nu poate fi 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Eroare Parser: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Primul Punct</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Al doilea punct</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Alege al doilea punct al axei</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Alege primul punct</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Alege al doilea punct</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>Primul Punct:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Al doilea punct:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Formula stricată</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Anulare</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Repară formula</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp; Anulare</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">Valoarea calculată</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Asistent Formulă</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Detalii</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Linie</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Unghi</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Curbură</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Curbura</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Rază</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Eroare</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Câmp gol</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Eroare Parser: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Instrument</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Editează formula</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Măsurători</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Introdu variabilă în formulă</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Ascunde măsurători goale</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Linie lungime</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Curbă lungime</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Linie Unghi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished">Fișierul nu a putut fii salvat</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">Eroare de fișier.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Dimensiune</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Înălțime</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Rută:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation type="unfinished">Eroare</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Șterge</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 Punct de bază</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">Decurs</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Punct de bază</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Descriere</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Lățime:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished">Înălțime:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Șterge</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Înapoi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Șterge</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Programul este prevăzut CA ATARE CU NICI O GARANȚIE DE ORICE FEL, INCLUSIV GARANȚIA DE DESIGN, COMERCIALIZARE ȘI POTRIVIRE PENTRU UN ANUMIT SCOP.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished">Punct central:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Rază:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished">Editare raza</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Eroare</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Raza nu poate fii negativă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Rază:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Arată calcul complet în message box &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Eroare</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Raza nu poate fii negativă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Șabloane:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Lățime:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Înălțime:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Rotește Piesa</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Rotită de</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>Grad</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Trei grupuri: mare, mijlociu, mic</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Două grupuri: mare, mic</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>Zonă descendentă</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centimetrii</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Inci</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Pixeli</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6623,84 +5191,67 @@ Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6708,32 +5259,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6741,2659 +5286,2000 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Instrumente pentru crearea de puncte.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Punct</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Instrumente pentru crearea de linii.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Instrumente pentru crearea curbe.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Curbură</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Instrumente pentru crearea de arce.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Curbura</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp; Fișier</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp; Ajutor</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Măsurători</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Nou</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp; Nou</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Crează un tipar nou</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Deschide</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Deschide</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Deschide fișier cu tipar</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Salvează</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Salvează</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Salvează tipar</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Salvează &amp;Ca și.....</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Salvează tiparul care încă nu este salvat</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Detalii</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Instrumente indicator</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Decurs</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>Despre&amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp; Despre Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>E&amp;xit</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Preferințe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Raportează o eroare</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Arată ajutorul online</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>Despre Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Salvează ca și</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Fișierul nu a putut fii salvat</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Deschide fișier</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Anulare</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Unități de măsură greșite.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation type="unfinished">Înălțime:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation type="unfinished">Măsuri individuale</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Fișiere tipar</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished">Valoarea calculată</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished">Formula</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">Despre Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Șterge</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>model</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9401,86 +7287,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Nu s-au putut pregăti datele pentru crearea unei schițe</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9488,148 +7354,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Nou</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Salvează</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Salvează ca și</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9637,123 +7473,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
@@ -9762,18 +7577,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9781,37 +7588,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Unități:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9819,12 +7619,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9832,7 +7630,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9840,7 +7637,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9848,7 +7644,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9856,7 +7651,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9864,7 +7658,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9872,7 +7665,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9880,52 +7672,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Individual</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Centimetrii</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Inci</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9933,87 +7715,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10021,887 +7786,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished">Toate obiectele de pe rută trebuie să urmeze în sensul acelor de ceasornic.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished">Gata!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Lățime:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Valoare</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished">Asistent Formulă</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished">Calcul</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished">Unghi:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished">Înălțime:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Lungime:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Înapoi</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Șterge</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Opțiuni</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Eroare</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Eroare Parser: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished">Ai nevoie de mai multe puncte!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Ai puncte duble!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Căi</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10909,218 +8421,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Șterge</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11128,27 +8588,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11156,77 +8611,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11234,139 +8674,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11374,62 +8769,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11437,316 +8820,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished">Interval:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished">Limba</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">Limbaj GUI:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished">Unitate standard:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished">Unitatea standard a fost actualizată și va fi utilizată ca standard pentru modelele viitoare pe care le creați.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimetrii</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished">Inci</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11754,582 +9071,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Punct</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Linie</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Curbură</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Curbura</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Detalii</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Lățime:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12337,272 +9486,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Adaos cusatură</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">Lungime:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Lățime:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Căi</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Lățime</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Înălțime</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12610,7 +9689,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12618,155 +9696,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12774,15 +9821,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
@@ -12791,217 +9834,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
@@ -13010,7 +10017,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13018,7 +10024,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13026,12 +10031,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13039,7 +10042,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13047,7 +10049,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13055,7 +10056,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13063,88 +10063,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Limba</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">Limbaj GUI:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished">Sistem construire Tipare</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished">Sistem:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">Autor:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished">Carte:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished">Bară de instrumente</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Înălțime:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13152,52 +10134,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13205,102 +10177,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished">Unități:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished">Limbaj GUI:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimetrii</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Inci</translation>
     </message>
@@ -13308,92 +10259,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished">Unități:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished">Limbaj GUI:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Centimetrii</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Inci</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13401,12 +10333,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13414,1071 +10344,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Nou</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished">Deschide</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Salvează</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Salvează ca și</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Măsurători</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Punct</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Linie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Șterge</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Detalii</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">Decurs</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14486,12 +11199,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14499,42 +11210,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14542,7 +11245,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14550,7 +11252,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14558,818 +11259,625 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Formula</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Valoarea de bază</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>În dimensiuni</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>În înălțimi</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Detalii</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Rută:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Prenume:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Nume de familie:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Fereastră</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Măsurători</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Salvează</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>Despre&amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>Despre Bandă</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Nou</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Preferințe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Eroare de fișier.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Fișierul nu a putut fii salvat</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Salvează ca și</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Eroare Parser: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Măsuri individuale</translation>
     </message>
     <message>
-        <location line="+217"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Câmp gol</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Valoare</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Deschide fișier</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>masculin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>feminin</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>Despre Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation type="unfinished">Înălțime:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-368"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+802"/>
         <source>Pattern files</source>
         <translation>Fișiere tipar</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15377,7 +11885,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15385,22 +11892,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15408,22 +11911,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15431,47 +11930,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">Primul Punct</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Al doilea punct</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15479,47 +11969,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Instrument Uniune</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Alege un al doilea punct</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Alege un punct unic</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished">Alege un punct pe margine</translation>
     </message>
@@ -15527,7 +12008,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15535,17 +12015,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15553,57 +12030,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15611,7 +12077,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15619,22 +12084,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15642,13 +12103,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
@@ -15656,23 +12114,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15680,7 +12133,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15688,12 +12140,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
@@ -15701,283 +12151,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15985,302 +12378,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Unghi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16288,43 +12621,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16332,55 +12656,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16388,12 +12699,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16401,50 +12710,40 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16452,27 +12751,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Șterge</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16480,7 +12774,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16488,11 +12781,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
@@ -16500,7 +12788,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16508,7 +12795,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16516,7 +12802,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16524,12 +12809,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16537,12 +12820,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16550,335 +12831,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16886,17 +13078,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16904,12 +13093,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16917,14 +13104,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16932,17 +13115,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Unghi</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
@@ -16950,27 +13130,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16978,37 +13153,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17016,7 +13184,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
@@ -17024,12 +13191,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17037,32 +13202,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Curbura</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17070,18 +13229,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Curbură</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17089,18 +13244,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Curbură</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17108,7 +13259,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
@@ -17116,28 +13266,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17145,17 +13289,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Unghi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
@@ -17163,12 +13304,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Unghi</translation>
     </message>
@@ -17176,7 +13315,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
@@ -17184,27 +13322,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Unghi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17212,17 +13345,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Unghi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
@@ -17230,7 +13360,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17238,12 +13367,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">Primul punct de linie</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Al doilea Punct de linie</translation>
     </message>
@@ -17251,27 +13378,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Punct central</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Unghi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17279,714 +13401,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Punct de bază</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Lungime:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished">Unghi:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">Primul Punct:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">Al doilea punct:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Punct central:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Rază:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished">Primul unghi:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished">Al doilea unghi:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished">Al treilea punct:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished">Arc:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished">Curbă:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished">Punct de axă:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinate</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Linie</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">Prima linie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">A doua linie</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Origin point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Punct central</translation>
     </message>
@@ -17994,12 +13800,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18007,17 +13811,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Unghi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
@@ -18025,12 +13826,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18038,12 +13837,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18051,12 +13848,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18064,17 +13859,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Lungime</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Unghi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">Nume</translation>
     </message>
@@ -18082,1552 +13874,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>cm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation type="unfinished">sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation type="unfinished">cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation type="unfinished">tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation type="unfinished">asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation type="unfinished">acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation type="unfinished">atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation type="unfinished">sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation type="unfinished">cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation type="unfinished">tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation type="unfinished">asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation type="unfinished">acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation type="unfinished">atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation type="unfinished">log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation type="unfinished">log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation type="unfinished">log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation type="unfinished">ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation type="unfinished">exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation type="unfinished">sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation type="unfinished">sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation type="unfinished">rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation type="unfinished">abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19636,17 +15171,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19654,7 +15186,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19662,7 +15193,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19670,7 +15200,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19678,12 +15207,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19691,7 +15218,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19699,7 +15225,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19707,17 +15232,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19725,47 +15247,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19773,47 +15286,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>О проекте Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Веб сайт : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Невозможно открыть браузер по умолчанию</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation>Автоматические</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Собрано %1 в %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation>Seamly 2D</translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation>CPU:</translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation>OS:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation>Страна:</translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Проверить наличие обновлений</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation>Загрузка установщика %p% завершена</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation>неизвестный</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation>добавить блок чертежа %1</translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>добавить группу</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation>Добавить объект в группу</translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation>Добавить деталь</translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>добавить объект</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation>добавить в группу</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation>Наименование:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation>Шпилька</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation>Инструмент Шпилька</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation>Точка:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation>Деталь:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Ошибка парсинга файла. Программа будет закрыта.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Ошибка, неправильный id. Программа будет закрыта.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Ошибка, невозможно преобразовать значение. Программа будет закрыта.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Ошибка, пустой параметр. Программа будет закрыта.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Ошибка, неправильный id. Программа будет закрыта.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Что-то не так!!!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Ошибка парсинга: %1. Работа программы будет завершена.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Программное исключение: %1. Работа программы будет завершена.</translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Ошибка в разборе файла. Работа программы будет завершена.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Ошибка идентификатора. Работа программы будет завершена.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Ошибка преобразования значения. Работа программы будет завершена.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Ошибка пустого параметра. Работа программы будет завершена.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Ошибка неправильного идентификатора. Работа программы будет завершена.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Что-то не так!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Ошибка разбора: %1. Работа программы будет завершена.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Программное исключение: %1. Работа программы будет завершена.</translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation>Редактор мерок Seamly2D.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation>Файл мерок.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation>Базовая высота</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation>Базовый размер</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation>Задать единицы измерения выкройки: см, мм или дюймы.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation>Единицы измерения выкройки</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation>Ошибка: неверный параметр базового размера, должен быть см, мм или дюймы.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation>Невозможно начать найти входящие соединения с именем &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation>Режим проверки не поддерживает открытия нескольких файлов.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation>Укажите один входной файл.</translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation>Открыть с базовым размером. Возможные значения: %1 см.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation>Неверный параметр базовой высоты. Должен быть %1 см.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation>Неверный параметр базового размера. Должен быть %1 см.</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation>Открыть с базовой высотой. Возможные значения: %1 см.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation>Используйте для юнит тестирования. Запускает программу и открывает файл без показа окна.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Отключить масштабирование с высоким разрешением. Вызовите эту опцию, если есть проблема с масштабированием (по умолчанию масштабирование включено). Или вы можете использовать %1 переменную среды.</translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation>Калькулятор</translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation>.</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation>±</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation>Удалить последнюю</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation>Удалить всё</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation>MC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation>MR</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation>MS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation>M+</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation>÷</translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation>×</translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation>Sqrt</translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation>x²</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation>1/x</translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation>=</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation>Калькулятор</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation>####</translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation>Десятичная диаграмма</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -587,7 +470,6 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;15/16 = .9375&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -603,7 +485,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>удалить группу</translation>
     </message>
@@ -611,7 +492,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>инструмент удаления</translation>
     </message>
@@ -619,7 +499,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation>добавить блок рисования %1</translation>
     </message>
@@ -627,7 +506,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>удалить инструмент</translation>
     </message>
@@ -635,52 +513,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation>О SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation>Версия  SeamlyMe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation>Ревизия: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation>Эта программа является частью проекта Seamly2D.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation>Загрузка установщика %p% завершена</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation>Проверить наличие обновлений</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation>Невозможно открыть браузер по умолчанию</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation>Собрано %1 в %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation>Веб сайт : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation>неизвестный</translation>
     </message>
@@ -688,107 +556,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Показать полный расчет в отдельном окне&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Выберите вторую точку линии</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Редактировать длину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>Первая точка линии</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Вторая точка линии</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation>Точка - на линии</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -796,138 +643,104 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Радиус не может быть отрицательным</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Углы равны</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Редактировать радиус</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Редактировать первый угол</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Редактировать второй угол</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Радиус:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>Первый угол:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Второй угол:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Центральная точка:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Выберите точку центра дуги</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation>Дуга - радиус и углы</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Углы указаны в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится в положении «3 часа».&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Расчет угла&lt;/b&gt;&lt;br&gt;Углы указываются в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится в положении «3 часа».&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -935,127 +748,96 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Показать полный расчёт в отдельном окне&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Изменить радиус</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Изменить первый угол</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Изменить длину дуги</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Радиус не может быть отрицательным</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>Длина не может быть нулевой</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Радиус:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>Первый угол:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Центральная точка:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation>Дуга - Радиус и Длина</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Расчет угла&lt;/b&gt;&lt;br&gt;Углы указываются в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится в положении «3 часа».&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -1063,107 +845,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Выберите вторую точку угла</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Выберите третью точку угла</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Редактировать длину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Третья точка:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation>Точка – на биссектрисе</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -1171,77 +932,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>Начальная точка:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Третья точка:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Четвертая точка:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Выберите вторую точку кривой</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Выберите третью точку кривой</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Выберите четвертую точку кривой</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>Неправильная кривая</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation>Кривая - фиксированная</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
@@ -1249,57 +995,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Точка:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>Список точек</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation>Неправильное задание кривой</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation>Сплайн- Фиксированный</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation>Контур:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
@@ -1307,99 +1042,80 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Выберите точку оси</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Редактрировать угол</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Точка оси:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Кривая:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation>Пересечение — кривой и оси</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Расчет угла&lt;/b&gt;&lt;br&gt;Углы указываются в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится на отметке «3 часа».&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt; /table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation></translation>
     </message>
@@ -1407,67 +1123,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Редактировать длину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Дуга:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation>Точка - на дуге</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -1475,67 +1178,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Редактировать длину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Кривая:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation>Точка - на кривой</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -1543,67 +1233,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Редактировать длину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Кривая:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation>Точка - на сплайне</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -1611,22 +1288,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation>Редактор даты и времени метки</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation>Формат:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation>Вставить формат</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;пусто&gt;</translation>
     </message>
@@ -1634,170 +1307,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation>Радиус1:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Показать полный расчет во всплывающем окне&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation>Радиус2:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation>Первый угол:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation>Второй угол:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation>Угол поворота:</translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation>Центральная точка:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation>Выберите центральную точку дуги</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Радиус не может быть отрицательным</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Углы равны</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation>Изменить радиус1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation>Изменить радиус2</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Изменить первый угол</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Изменить второй угол</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation>Изменить угол поворота</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation>Дуга – Эллиптическая</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Углы указаны в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится в положении «3 часа».&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Углы указаны в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится в положении «3 часа».&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Углы указаны в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится в положении «3 часа».&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -1805,90 +1430,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Редактрировать угол</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Редактировать длину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Базовая точка:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation>Точка — длина и угол</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translatorcomment>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
@@ -1897,17 +1502,14 @@ p, li { white-space: pre-wrap; }
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -1915,47 +1517,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Экспорт настроек</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>С заголовком</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation>Кодек:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Разделитель</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation>Вкладка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>Запятая</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>Точка с запятой</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Пробел</translation>
     </message>
@@ -1963,72 +1556,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Выберите первую точку линии</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Выберите вторую точку линии</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Базовая точка:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation>Точка — пересечения линии и перпендикуляра</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -2036,356 +1615,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation>Инструмент Внутренний Контур</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation>Контур</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation>Безымянный контур</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation>Задайте имя для вашего контура</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation>Деталь:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation>Переместить строку в начало списка</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation>Переместить строку на одну строку вверх</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation>Переместить строку на одну строку вниз</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation>Переместить строку в конец списка</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation>Контур представляет собой обрезанный контур</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation>Вырезать на ткани</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation>Стаус:</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation>Готово!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation>Прибавка на швы</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Показать полный расчет в отдельном окне&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation>Узлы</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation>Узел:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation>До:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation>Вернуться к значению ширины по умолчанию</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation>После:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation>Надсечки</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation>Надсечка:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation>Щель</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation>Т надсечка</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation>U надсечка</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation>V Внутренний</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation>V Внешний</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation>Замок</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation>Алмаз</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation>Прямой</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation>Биссектриса</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation>Выберите, чтобы обозначить угловую точку как надсечку</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation>Пересечение</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation>Восстановить угол надсечки по умолчанию.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation>Число:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation>Восстановить ширину надсечки по умолчанию.</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation>Этот вариант действует только в том случае, если в глобальных настройках включен вторая надсечка на линии шва. Этот вариант помогает отключить вторую метку только для этой метки.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation>Показать вторую надсечку на линии шва</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation>Восстановить длину надсечки по умолчанию.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation> Ширина:</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation>Выберите объекты основного контура. Используйте клавишу&lt;b&gt;SHIFT&lt;/b&gt;, чтобы изменить направление кривой. Нажмите клавишу&lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание контура </translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation>Изменить направление</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation>Текущая прибавка на швы</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation>Редактировать ширину прибавки на швы</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation>Редактировать ширину прибавки на швы до точки</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation>Редактировать ширину прибавки на швы после точки</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation>Внутренний контур</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation>Пользовательская прибавка на швы</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation>Вам нужно выбрать больше точек!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation>Первая точка &lt;b&gt;пользовательской прибавки на швы&lt;/b&gt; не может быть той же что и последняя точка!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation>Повторяются две точки подряд!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation>Каждая точка в &lt;b&gt;пользовательской прибавке на швы&lt;/b&gt; должна быть уникальной!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation>Список деталей пустой!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation>Пожалуйста, выберите деталь для вставки!</translation>
     </message>
@@ -2393,28 +1890,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Не удалось подготовить данные для создания раскладки</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Создать раскладку</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation>Размещено заготовок: %1 из %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Поиск лучшей позиции для детали. Пожалуйста, подождите.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation>Размер одного или нескольких фрагментов выкройки превышает выбранный вами формат бумаги. Пожалуйста, выберите больший формат бумаги.</translation>
     </message>
@@ -2422,58 +1913,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Выберите вторую точку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation>Линия – между точками</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation>Линия_</translation>
     </message>
@@ -2481,64 +1960,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Первая линия</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Вторая линия</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Выберите вторую точку первой линии</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Выберите первую точку второй линии</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Выберите вторую точку второй линии</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation>Точка — на пересечении линий</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -2546,124 +2011,100 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Первая точка линии</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Выберите вторую точку линии</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Выберите точку оси</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Точка оси</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Вторая точка линии</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Редактрировать угол</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Точка оси:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation>Пересечение — Линии и Оси</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Расчет угла&lt;/b&gt;&lt;br&gt;Углы указываются в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится в положении «3 часа».&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -2671,22 +2112,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Мерки</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation>База данных ME — Добавить известные измерения</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation>Найти:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
@@ -2694,47 +2131,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation>Отражение по Оси</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation>Точка оси:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation>Суффикс:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation>Тип оси:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation>Выберите точку вращения оси</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation>Выберите точку вращения оси, которая не входит в список объектов</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation>Вертикальная ось</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation>Горизонтальная ось</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
@@ -2742,47 +2170,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation>Отражение по Линии</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation>Первая точка линии:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation>Вторая точка линии:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation>Суффикс:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation>Выберите первую точку линии отражения</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation>Выберите первую точку линии отражения, которая не находиться в списке объектов</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation>Выберите вторую точку линии отражения</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation>Выберите вторую точку линии отражения, которая не находиться в списке объектов</translation>
     </message>
@@ -2790,94 +2209,72 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation>Суффикс:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation>Изменить угол</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Изменить длину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation>Переместить</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation>Начальная точка:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation>Вращение:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Центральная точка</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation>Изменить вращение</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Расчет угла&lt;/b&gt;&lt;br&gt;Углы указываются в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится в положении «3 часа».&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Углы указаны в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится в положении «3 часа».&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
@@ -2885,42 +2282,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Единицы измерения:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Сантиметры</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Дюймы</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Уникальное название выкройки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Выберите уникальное название выкройки.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>Новая выкройка</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation>Миллиметры</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation>Название блока рисования:</translation>
     </message>
@@ -2928,107 +2317,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Выберите вторую точку линии</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Редактировать длину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation>Точка – на Перпендикуляре</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation>Вращение:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Углы указаны в градусах, т.е. полный круг равен 360 градусам. Положительные значения угла означают направление против часовой стрелки, а отрицательное значение — направление по часовой стрелке. Ноль градусов находится в положении «3 часа».&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -3036,210 +2404,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Описание выкройки</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Росты и размеры</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Все росты (см)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Все размеры (см)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Размер и рост по умолчанию</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Пользовательские</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Защита</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Открыть только для чтения</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation>Для редактирования вызовите контекстное меню</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>Нет изображения</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Удалить изображение</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Заменить изображение</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Сохранить изображение в файл</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Показать изображение</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation>Изображение для выкройки</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Изображения</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Сохранить файл</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>без названия</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Путь:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Показать в Explorer</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;Пусто&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>Файл не был записан.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Показать в Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Название выкройки:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Номер выкройки:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Название компании / имя дизайнера:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Имя клиента:</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation>Для мультиразмерных мерок</translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Выкройка</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation>Для технических примечаний</translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation>Данные метки</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation>Шаблон метки:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation>Редактировать метку выкройки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation>Редактировать шаблон</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation>Формат даты:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation>Формат времени:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation>Сохраните данные метки.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation>Данные метки были изменены. Хотите сохранить их прежде чем редактировать шаблона метки?</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation>Настройки выкройки</translation>
     </message>
@@ -3247,47 +2571,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Выберите дугу</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Точка касательной:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Дуга:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Взять:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Точка — пересечения дуги и касательной</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -3295,87 +2610,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Выберите точку центра дуги</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Выберите вторую точку линии</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Редактировать радиус</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Радиус:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation>Центр дуги:</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation>Точка — Пересечения Дуги и Линии</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation>1-я точка линии:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation>2-ая точка линии</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -3383,47 +2681,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation>Выберите вторую дугу</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>Первая дуга:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Вторая дуга:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Взять:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation>Точка - Пересечения дуг</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -3431,52 +2720,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>Первая кривая:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Вторая кривая:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Выбрать вторую кривую</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation>Точка — Пересечения Кривых</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation>Взять Вертикаль:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation>Взять Горизонталь:</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -3484,27 +2763,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Выкройка</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation>Настройки программы</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation>Общее</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation>Пути файлов</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation>Графика</translation>
     </message>
@@ -3512,62 +2786,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Поворот</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Суффикс:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation>Изменить угол</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation>Точка вращения:</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation>Выберите точку вращения</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation>Выберите точку вращения, которая не входит в список объектов</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
@@ -3577,17 +2839,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation>Предпочтения</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation>Пути файла</translation>
     </message>
@@ -3595,107 +2854,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Выберите первую точку линии</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Выберите вторую точку линии</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Редактировать длину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Третья точка:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation>Точка - в доль линии</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -3703,47 +2941,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Координаты на листе</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Координаты</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation>Базовая точка</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation>Координата X:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation>Координата Y:</translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -3751,148 +2980,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Первая точка</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Вторая точка</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Выберите последнюю точку кривой</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>Начальная точка:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>Неправильная кривая</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation>Изменить угол первой контрольной точки</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation>Изменить угол второй контрольной точки</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation>Изменить длину первой контрольной точки</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation>Изменить длину второй контрольной точки</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation>Длина не может быть отрицательной</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation>Кривая — Интерактивная</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
@@ -3900,163 +3087,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Список точек</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Выберите точку сложной кривой</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Точка:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation>Первая контрольная точка</translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation>Вторая контрольная точка</translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation>Неправильный контур кривой</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation>Изменить угол первой контрольной точки</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation>Изменить угол второй контрольной точки</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation>Изменить длину первой контрольной точки</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation>Изменить длину второй контрольной точки</translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation>Длина не может быть отрицательной</translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation>Не используется</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation>Интерактивный сплайн</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation>Путь:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation>Значение результата</translation>
     </message>
@@ -4064,108 +3206,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Пустое поле</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Значение не может быть 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Ошибка синтаксического анализа: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Первая точка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Вторая точка</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation>Самая высокая точка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation>Самая низкая точка</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation>Самая левая точка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation>Самая правая точка</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation>по длине</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation>по точкам пересечения</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation>по симметрии первого ребра</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation>по симметрии второго ребра</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation>по прямому углу первого ребра</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation>по прямому углу второго ребра</translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Недопустимый результат. Значение бесконечности или нечисловое. Пожалуйста, проверьте расчеты.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation>Значение не может быть меньше 0</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation>Значение результата</translation>
     </message>
@@ -4173,62 +3285,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Выберите вторую точку оси</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Выберите первую точку</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Выберите вторую точку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation>Точка — Пересечения Оси и Треугольника</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation>1-я точка оси:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation>2-ая точка оси:</translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -4236,79 +3336,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation>Выберите вторую базовую точку</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation>Выберите первую точку вытачки</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation>Выберите вторую точку вытачки</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation>Выберите третью точку вытачки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation>Первая точка основы:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation>Вторая точка основы:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation>Первая точка вытачки:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation>Первая точка вытачки:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation>Третья точка вытачки:</translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation>Правильная вытачка</translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation>Название точки 1:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation>Название точки 2:</translation>
     </message>
@@ -4316,27 +3399,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Неисправная формула</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Отменить</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Исправить формулу</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Отмена</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Ошибка при расчете формулы. Вы можете попробовать отменить последнюю операцию или исправить неисправную формулу.</translation>
     </message>
@@ -4344,214 +3422,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation>Переменные</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation>Фильтр:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation>Фильтр списка по ключевому слову</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation>Пользовательские переменные</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation>Рассчитанное значение</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation>Формула</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation>Переместить мерку выше</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Переместить мерку ниже</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation>Добавить пользовательскую переменную</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation>Удалить пользовательскую переменную</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Детали</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation>Выберите уникальное название</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation>Рассчитанное значение:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation>Формула:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation>Описание:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation>Обновите выкройку со всеми внесенными вами изменениями</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation>Длины линий</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation>Линия</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation>Углы линий</translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation>Длина кривой</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation>Кривая</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation>Углы кривой</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation>Длина между контрольными точками</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation>Радиусы Дуги</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation>Дуга</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation>Радиус</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation>Пустое поле.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation>Пустое поле</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Недопустимый результат. Значение бесконечность или нечисленное. Пожалуйста, проверьте расчеты.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Ошибка синтаксического анализа: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation>Редактировать переменную</translation>
     </message>
@@ -4559,17 +3585,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation>Инструмент</translation>
     </message>
@@ -4577,148 +3600,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation>Редактировать формулу</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation>Мерки</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation>Пользовательские переменные</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation>Длины линий</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation>Углы линий</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation>Длина кривой</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation>Углы кривой</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation> Длина между контрольными точками</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation>Радиус Дуги</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation>Функции</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation>Формула:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation>Удалить формулу</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation>Вернуться к исходной формуле</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation>Вставить переменную в формулу</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation>Скрыть переменные измерения, которые не имеют значения</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation>Спрятать пустые мерки</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation>Полное Название</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation>Фильтр списка переменных по ключевому слову</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation>Фильтр списка по ключевому слову</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation>Мерки</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation>Пользовательские переменные</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation>Длины линий</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation>Длина кривой</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation>Углы линий</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation>Радиус дуги</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation>Угол кривой</translation>
     </message>
@@ -4726,37 +3719,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation>Добавить группу</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation>Уникальное имя выкройки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation>Уникальное название группы</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
@@ -4764,298 +3750,238 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation>Редактировать шаблон этикетки</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation>Стереть действующую метку и начать новую</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation>Импортировать из шаблона метки</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation>Экспортировать метку как шаблон</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translatorcomment>Формат букв</translatorcomment>
         <translation>Жирный</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translatorcomment>Формат букв</translatorcomment>
         <translation>Наклонный штрих</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation>Выравнить по левому краю</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation>Расположить горизонтально по центру в свободной части</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation>Выравнить по правому краю</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation>Дополнительный размер шрифта. Используйте, чтобы увеличить линию.</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation>Текст:</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation>Строка текста</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation>Указать заполнители</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation>Заполнить...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation>Предварительный просмотр</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;пусто&gt;</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation>Создать новый шаблон</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation>Создание нового шаблона заменит текущий. Хотите Продолжить?</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation>Шаблон метки</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation>Экспортировать шаблон метки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation>шаблон</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation>Не удалось сохранить файл</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation>Импортировать шаблон</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation>Импортирование нового шаблона заменит текущий. Хотите Продолжить?</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation>Ошибка файла.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation>Время</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation>Название выкройки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation>Номер выкройки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation>Название компании / имя дизайнера</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation>Имя клиента</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation>Расширение выкройки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation>Название файла выкройки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation>Название файла мерок</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation>Рост</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation>Расширение мерок</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation>Буква детали</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation>Примечания к детали</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation>Ориентация детали</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation>Вращение детали</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation>Наклон детали</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation>Позиция детали на сгибе ткани</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation>Название детали</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation>Количество</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation>Материал: Ткань</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation>Ткань</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation>Материал: Подкладка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation>Подкладка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation>Материал: Флезелин</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation>Материал: Флезелин</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation>Материал: Дублерин</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation>Дублерин</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation>Слово: Разрезать</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation>Разрезать</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation>Слово: на сгиб</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation>на сгиб</translation>
     </message>
@@ -5063,12 +3989,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation>(плоские) файлы</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation>файлы</translation>
     </message>
@@ -5076,163 +4000,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation>Экспорт макета</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation>Двоичная форма</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation>Текст как пути</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation>Путь:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation>Папка назначения</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation>Путь к папке назначения</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation>Выберите путь к папке назначения</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation>Обзор...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation>Формат файла:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation>Название файла:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation>Базовое Название файла</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation>Качество (0-100):</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation>Поля</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation>Правое:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation>Левое:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation>Верхнее:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation>Нижнее:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation>Формат листа</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation>Шаблоны: </translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation>Ориентация: </translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation>Базовое имя файла не соответствует регулярному выражению.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation>Выберите папку</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation>Попытка использования номера формата вне диапазона.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation>Выбран несуществующий формат.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation>Директория назначения не существует или недоступен для чтения.</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation>%1 уже существует.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation>Файлы %1 с базовым именем %2 уже существуют.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation>Вы хотите заменить их?</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation>Подтвердить экспорт</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation>Экспортировать файлы:</translation>
     </message>
@@ -5240,23 +4131,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation>Ошибка скачивания: %1.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
@@ -5265,29 +4151,24 @@ for writing</source>
 для записи</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation>Не удалось загрузить файл: %1.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation>Загрузка началась, установщик откроется после завершения загрузки</translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation>Новых обновлений нет.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation>Появилось новое обновление %1.
@@ -5297,369 +4178,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation>Управление группой</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation>Показать все группы</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation>Скрыть все группы</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation>Заблокировать все группы</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation>Разблокировать все группы</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation>Добавить новую группу в список</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation>Удалить действующую группу из списка</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation>Редактировать свойства группы</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation>Группы</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation>Список групп</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation>Список объектов группы</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation>Объекты</translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation>Двойной щелчок приближает объект.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation>Название уже существует</translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation>Действие невозможно выполнить, поскольку название группы уже существует.</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation>Редактировать группу</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation>Показать, какие группы в списке видны</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation>Показать, какие группы в списке заблокированы</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation>Показать, какие группы содержат объекты</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation>Неизвестный объект</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation>%1 - Базовая точка</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation>%1 - Точка на Расстоянии и под Углом</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation>Линия %1_%2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation>%1 - Точка - на Линии</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation>%1 - Точка - в доль линии</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation>%1 - Точка на Перпендикуляре</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation>%1 - Точка на Биссектрисе</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation>%1 - Точка на пересечении линий</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation>%1 - Кривая Интерактивная</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation>Спл_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation>%1 - Кривая Фиксированная</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation>%1 - Дуга радиус и углы</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation>Дуга_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation>%1 - Дуга Радиус и Длина</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation>%1 - Интерактивный сплайн</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation>СплКонтур_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation>%1 - Сплайн Фиксированный</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation>%1 - Точка Пересечения Дуги и Линии</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation>%1 - Точка пересечения линии и перпендикуляра</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation>%1 - Точка Пересечения Оси и Треугольника</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation>%1 - Точка на пересечении осей XY</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation>%1 - Точка на Дуге</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation>%1 - Точка на Кривой</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation>%1 - Точка на Сплайне</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation>%1 - Точка Пересечения Линии и Оси</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation>%1 - Точка Пересечения Кривой и Оси</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation>%1 - Точка Пересечения дуг</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation>%1 - Точка Пересечения Окружностей</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation>%1 - Точка Пересечения Кривых</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation>%1 - Точка Пересечения Окружности и Касательной</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation>%1 - Точка Пересечения Дуги и Касательной</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation>%1 - Правильная вытачка %2_%3_%4</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation>%1 - Эллиптическая Дуга</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation>Дуга_</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation>%1 - Вращение</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation>%1 - Переместить</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation>%1 - Отражение по Линии</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation>%1 - Отражение по Оси</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation>Переместить Группу Объектов</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation>Удалить Группу Объектов</translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation>Цвет группы</translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation>Название группы</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation>Видно</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation>Группа видна</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation>Заблокировано</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation>Группа заблокирована</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation>В группе есть объекты</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
@@ -5667,265 +4465,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation>История</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation>Найти:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation>Поиск текста</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation>Идентификатор</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation>Базовая точка</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation>Линия_%1_%2</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation>Линия от %1 до %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation>Точка на Линии %1_%2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation>Точка в доль линии</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation>Точка на Перпендикуляре %1_%2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation>Точка на Биссектрисе %1_%2_%3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation>Точка Пересечения Линий %1_%2 и %3_%4</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation>Спл_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation>Интерактивная Кривая</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation>Фиксированная Кривая</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation>Дуга_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation>Дуга Радиус и Углы</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation>Дуга Радиус и Длина %1</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation>СплКонтур_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation>Интерактивный сплайн</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation>Фиксированный Сплайн</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation>Точка Пересечения Дуги с центром в %1 и Линии %2_%3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation>Точка пересечения Линии %1_%2 и Перпендикуляра %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation>Точка Пересечения Оси %1_%2 и Треугольника в точках %3 и %4</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation>Точка Пересечения Осей XY в точках %1 и %2</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation>Точка на дуге</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation>Точка на кривой</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation>Точка на сплайне</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation>%Точка пересечения Линии %1_%2 и Оси через точку %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation>Точка Пересечения Кривой и Оси через точку %1</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation>Точка Пересечения Дуг</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation>%1 - Точка Пересечения Окружностей</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation>Точка Пересечения Кривых</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation>Точка Пересечения Окружности и Касательной</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation>Точка Пересечения Дуги и Касательной</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation>Правильная вытачка %1_%2_%3</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation>Дуга_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation>Эллиптическая Дуга длиной %1</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation>Вращение вокруг точки %1. Суффикс %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation>Отражение по Линии %1_%2. Суффикс %3</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation>Отражение по оси через точку %1. Суффикс %2</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation>Перемещение - повернуть вокруг точки %1. Суффикс %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation>Точка на Расстоянии и под Углом из точки %1</translation>
     </message>
@@ -5933,127 +4652,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished">Выбрать</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished">Идентификатор</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished">Геометрия</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished">Единицы:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Ширина:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished">Вращение:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished">Свойства</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6061,110 +4751,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished">Свойства</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished">Подтвердите удаление</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Вы точно хотите удалить?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6174,102 +4839,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation>Деталь:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation>Узлы:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation>Стаус:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation>msg</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation>Изменить направление</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation>Надсечка</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation>Никакая</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation>Щель</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation>Т-Надсечка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation>U-Надсечка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation>V Внутренний</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation>V Внешний</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation>Замок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation>Алмаз</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation>Узлы не выбраны. Нажмите «Отмена», чтобы продолжить</translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation> был автоматически отменен.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation> возможно, потребуется перевернуть вручную.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation>Вставить узлы</translation>
     </message>
@@ -6277,12 +4922,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Программа предоставляется КАК ЕСТЬ без ГАРАНТИЙ ЛЮБОГО РОДА, ВКЛЮЧАЯ ГАРАНТИИ ДИЗАЙНА, КОММЕРЧЕСКОЙ ЦЕННОСТИ И ПРИГОДНОСТИ ДЛЯ КОНКРЕТНЫХ ЦЕЛЕЙ.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6300,87 +4943,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation>Взять:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation>Центральная точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation>Точка касательной:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation>Радиус:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Показать полный расчет в отдельном окне&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation>Выберите центр окружности</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation>Редактировать радиус</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Радиус не может быть отрицательным</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Точка - Пересечения Окружности и Касательной</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -6388,12 +5014,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation>Пересечение Окружности и Касательной</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Невозможно найти точку пересечения %1&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Окружности и касательной&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Используйте исходную точку в качестве заполнителя до тех пор, пока выкройка не будет исправлена.</translation>
     </message>
@@ -6401,110 +5025,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation>Взять:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation>Окружность 1</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation>Центр:</translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation>Радиус:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показать полный расчет в окне сообщения&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation>Окружность 2</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation>Выберите центр второй окружности</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation>Изменить радиус окружности</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation>Изменить радиус второй окружности</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Радиус не может быть отрицательным</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation>Точка - Пересечения Окружностей</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -6512,12 +5108,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Невозможно найти точку пересечения %1окружностей&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Используйте исходную точку в качестве заполнителя, пока выкройка не будет исправлена.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation>Точка Пересечения Окружностей</translation>
     </message>
@@ -6525,126 +5119,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Шаблоны:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Повернуть заготовки</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Повернуть на</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>градусы</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Три группы: большие, средние, малые</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Две группы: большие, малые</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>По убыванию площади</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Сантиметры</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Дюймы</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Пиксели</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Автоматически обрезать неиспользуемую длину</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Объединить страницы (если возможно)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation>Ширина зазора:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Сохранить размер листа</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Формат листа</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Левое:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Правое:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Верхнее:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Нижнее:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Неправильные поля.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6655,85 +5223,68 @@ Apply settings anyway?</source>
 	По уменьшению площади = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation>Параметры раскладки</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation>Длина сдвига/смещения:</translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation>Правило выбора очередной заготовки</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation>Разделить на полосы</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation>Множитель</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation>Укажите множитель для длины самой большой заготовки детали в раскладке.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation>Активация может ускорить время формирования листов, имеющих большую высоту.</translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Принтер:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translatorcomment>Принтер:</translatorcomment>
         <translation>Никакой</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation>Текст</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation>Текст будет преобразован в пути</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation>Экспортировать текст как пути</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation>Поля</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation>Игнорировать поля</translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation>Параметры печати макета</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation>Миллиметры</translation>
     </message>
@@ -6741,32 +5292,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation>Без карандаша</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation>Сплошная линия</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation>Пунктирная линия</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation>Точки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation>Пунктир Точка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation>Пунктир Точка Точка</translation>
     </message>
@@ -6774,2659 +5319,2000 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Инструменты для создания точек.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Инструменты создания линий.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Линия</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Инструменты создания кривых.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Кривая</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Инструменты создания дуг.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Дуга</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Помощь</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Мерки</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Новый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Новый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Создать новую выкройку</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Открыть</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Открыть файл с выкройкой</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Сохранить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Сохранить выкройку</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Сохранить &amp;как...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Сохранить еще не сохраненную выкройку</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Детали</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Инструмент указатель</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>История</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>Про &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;Про Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>&amp;Выход</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Сообщить об ошибке</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Показать справку</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>Про Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Не удалось сохранить файл</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Ошибка парсинга файла.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Ошибка, невозможно преобразовать значение.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Ошибка, пустой параметр.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Ошибка, неправильный id.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Ошибка парсинга файла (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Неправильный идентификатор.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>Файл сохранен</translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>Выкройка была изменена. Хотите сохранить изменения?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Отменить</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Вернуть</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>Этот файл уже открыт в другом окне.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Неправильные единицы измерения.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>Файл загружен</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Seamly2D была закрыта неправильно . Хотите восстановить файлы (%1) которые были открыты раньше?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Повторно открыть файлы.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Макет</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation>Печать плиткой в PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation>Разделить и распечатать макет на страницы меньшего размера.(для обычных принтеров)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation>Предварительный просмотр</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation>Предварительный просмотр исходного макета</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation>Экспортировать как...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation>Режим макета</translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation>Несохранённые изменения</translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation>Мерки загружены</translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation>Невозможно экспортировать пустую сцену.</translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation>Файл мерок содержит неправильные мерки.</translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation>Неизвестный формат файла мерок.</translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation>Типы файлов мерок не соответствуют.</translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation>Невозможно синхронизировать мерки.</translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation>Невозможно обновить мерки.</translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation>Файл мерок «%1» не может быть найден.</translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation>Загрузка файла мерок</translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation>Значение размера &apos;%1&apos; не поддерживается для этого файла выкройки.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation>Невозможно установить размер. Файл не открылся.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation>Метод %1 не делает ничего в графическом режиме</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation>Значение высоты &apos;%1&apos; не поддерживается для этого файла выкройки.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation>Невозможно установить высоту. Файл не открылся.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation>Необходимо указать один входной файл.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation>Распечатать оригинальный макет</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation>Просмотр печати плиткой в PDF</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation>Предварительный просмотр плиткой</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation>Мерки сброшены</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation>Невозможно сбросить мерки. Некоторые из них используются в выкройке.</translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>Новая выкройка</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation>Открыть выкройку</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation>Создать/Изменить мерки</translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>Сохранить...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Не сохранять</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Блокировка файла</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Этот файл уже открыт в другом окне. Игнорируйте, если хотите продолжить (не рекомендуется, может привести к повреждению данных).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Файл блокировки не может быть создан из-за отсутствия разрешений. Игнорируйте, если хотите продолжить (не рекомендуется, может привести к повреждению данных).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Произошла неизвестная ошибка, например, полностью заполненный раздел предотвращает запись файла блокировки. Игнорируйте, если  хотите продолжить (не рекомендуется, может привести к повреждению данных).</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Не удалось создать файл блокировки из-за отсутствия разрешений.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Произошла неизвестная ошибка, например, полностью заполненный раздел предотвращает запись файла блокировки.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation>Операции</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation>Закрыть выкройку</translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation>Инструмент указатель</translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation>Начальный масштаб</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation>Файл меток &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; не найден. Хотите обновить данные о местоположении файла?</translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation>Мрки были изменены. Хотите обновить мерки сейчас?</translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Градация не поддерживает дюймы</translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation>Мерки обновлены</translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation>Документ не имеет прав на запись.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Невозможно установить разрешения для %1 для записи.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Не удалось сохранить файл.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation>Не удалось сохранить файл</translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation>только для чтения</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation>Загрузить индивидуальные</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation>Загрузить файл с индивидуальными мерками</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation>Загрузить Мультиразмерные</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation>Загрузить файл с мультиразмерными мерками</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation>Открыть SeamlyMe</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation>Редактировать текущие</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation>Редактировать подключенные к выкройке мерки</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation>Синхронизировать</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation>Синхронизовать подключенные к выкройке мерки после изменения</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation>Сбросить текущие</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation>Сбросить мерки, если они не используются в файле выкройки</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation>Индивидуальные мерки</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation>Мультиразмерные мерки</translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Файлы выкроек</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation>Wikipedia</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation>Форум</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation>Рассчитанное значение</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation>Формула</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation>Сейчас невозможно использовать режим макета.</translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation>Программа не поддерживает мультиразмерные таблицы в дюймах.</translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation>Не удалось установить размер. Нужен файл с мультиразмерными измерениями.</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation>Не удалось установить высоту. Нужен файл с мультиразмерными измерениями.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation>Предварительный просмотр</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation>Вид</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation>Названия точек</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation>&amp;Инструменты</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation>&amp;Операции</translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation>Деталь</translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation>Утилиты</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation>Панель инструментов «Файл»</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation>Панель инструментов «Режим»</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation>Панель инструментов «Выкройка»</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation>Панель инструментов «Редактирование »</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation>Редактор свойств</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation>Страницы макета</translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation>Управление группой</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation>Панель инструментов «Зум »</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation>Панель инструментов «Коробка Инструментов »</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation>Панель инструментов «Точки»</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation>Панель инструментов «Линии»</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation>Панель инструментов «Кривые»</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation>Панель инструментов «Дуги»</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation>Панель инструментов «Операции»</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation>Панель инструментов «Деталь»</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation>Панель инструментов «Подробности»</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation>Панель инструментов «Макет»</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation>Панель инструментов «Название точки»</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation>Коробка инструментов</translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation>Линия между двумя точками (Alt+L)</translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation>Инструменты для выполнения операций с объектами</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation>Поворот выбранных объектов (R)</translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation>Экспорт блоков чертежа (E, D)</translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation>Инструменты для добавления деталей выкройки.</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation>Добавить подробности</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation>Инструменты для добавления подробности к деталям выкройки</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation>Объединение 2 деталей (U)</translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation>Вид панели инструментов</translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation>Чертёж</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Режим работы с блоками чертежа. Эти блоки   чертежа являются основой для перехода к следующему этапу «Режим Деталь ». Прежде чем вы сможете включить «Режим Деталь » вам нужно создать хотя бы однин чертеж выкройки.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Режим работы с деталями выкройки. Прежде чем вы сможете включить «Режим Деталь » вам необходимо создать хотя бы однин чертеж выкройки в режиме «Чертёж ». Детали выкройки, созданные на этом этапе, будут использованы для создания макета.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation>Новый блок чертежа</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation>Добавить Новый блок чертежа (Ctrl+Shift+N)</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation>Переименовать блок чертежа</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation>Поменять название блока чертежа</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation>Таблица переменных</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Режим создания макета деталей выкройки. Этот режим доступен, если хотя бы одна деталь выкройки была создана в «Режиме Деталь». Макет можно экспортировать в предпочитаемый вами формат файла и сохранить.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation>Вращение</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation>Отражение по Линии</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation>M, L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation>Отражение по Оси</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation>M, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation>Переместить</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation>Правильная вытачка</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation>T, D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation>Точка по середине</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation>P, S</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation>Пересечение осей XY</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation>X, Y</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation>I, L</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation>Alt+C</translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation>A, X</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation>I, A</translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation>I, C</translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation>C, T</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation>A, T</translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation>A, L</translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation>О проекте Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation>Выйти из программы</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation>Настройки программы...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation>Настройки выкройки...</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation>Приблизить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation>Приблизить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation>Приблизить (Ctrl++)</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation>Уменьшить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation>Уменьшить</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation>Уменьшить (Ctrl+-)</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation>Масштабировать всё</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation>Масштабировать</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation>Масштабировать для всех(Ctrl+=)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation>Сообщить об ошибке...</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation>Ярлыки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation>Последний инструмент</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation>Контрольные точки кривой</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation>Переключить контрольные точки и направление кривой (V, C)</translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation>Загрузить мультиразмер</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation>Откройте программу мерок SeamlyMe (Ctrl+M)</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation>Экспорт переменных в CSV</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation>Выбрано</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation>Редактор шаблона меток...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation>Предыдущий</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation>Зум к предыдущему (Ctrl+Left)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation>Ctrl+Left</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation>Область</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation>Панорама</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation>Z, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation>Зум 1:1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation>1:1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation>Зум до 100 процентов (Ctrl+0)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation>Ctrl+0</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation>Инструменты Точки</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation>Инструменты Линии</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation>Alt+L</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation>Инструменты Кривой</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation>Инструменты Дуги</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation>Инструменты Операций</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation>Инструменты Макета</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation>Инструменты Детали</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation>Новая Деталь выкройки</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation>N, P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation>Новый макет печати</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation>N, L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation>Экспортировать Макет</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation>E, L</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation>Шпильки</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation>A, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation>Внутренний контур</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation>I, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation>Вставить узлы</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation>I, N</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation>Соеденить детали</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation>Экспортировать детали</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation>E, P</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation>Инструменты Подробности</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation>Текст названия точки</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation>V, P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation>Увеличить размер текста</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation>Увеличить размер текста (Ctrl+])</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation>Ctrl+]</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation>Уменьшить размер текста</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation>Уменьшить размер текста (Ctrl+[)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation>Ctrl+[</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation>Использовать инструмента цвета</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation>Использовать инструмента цвета (T)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation>V, T</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation>Начало оси </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation>Переключить начало оси (V, A)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation>V, A</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation>Каркасный режим</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation>Переключить каркасный режим (V, W)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation>V, W</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation>Направление долевой нити</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation>Переключить линии долевой нити (V, A)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation>V, G</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation>Метки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation>Переключить Метки(V, L)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation>V, L</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation>Калькулятор</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation>Ctrl+Shift+C</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation>Десятичная диаграмма</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation>Ctrl+Shift+D</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation>Экспорировать  блоки чертежа</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation>E, D</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation>Прибавки на швы</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation>V, S</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation>Информация о документе...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation>Информация о документе</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation>Отображение информации о документе</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation>Файл мерок не содержит всех необходимых измерений.</translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation>&lt;b&gt;Инструмент::Операции – Создать группу:&lt;/b&gt; выберите один или несколько объектов – удержите клавишу &lt;b&gt;%1&lt;/b&gt; при выборе нескольких объектов. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание группы </translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Инструмент::Операции – Вращение:&lt;/b&gt; выберите один или несколько объектов – удержите клавишу&lt;b&gt;%1&lt;/b&gt; при выборе  нескольких объектов . Нажмите &lt;b&gt;ENTER&lt;/b&gt; для подтверждения выбора</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Инструмент::Операции  – Зеркальное отображение по линии:&lt;/b&gt; Выберите один или несколько объектов – удержите клавишу &lt;b&gt;%1&lt;/b&gt;  при выборе нескольких объектов . Нажмите &lt;b&gt;ENTER&lt;/b&gt; для подтверждения выбора</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Инструмент::Операции  – Зеркальное отображение по осям:&lt;/b&gt; Выберите один или несколько объектов – удержите клавишу  &lt;b&gt;%1&lt;/b&gt; при выборе нескольких объектов . Нажмите &lt;b&gt;ENTER&lt;/b&gt; для подтверждения выбора</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Инструмент::Операции  – Переместить:&lt;/b&gt; Выберите один или несколько объектов – удержите клавишу  &lt;b&gt;%1&lt;/b&gt; при выборе нескольких объектов . Нажмите &lt;b&gt;ENTER&lt;/b&gt; для подтверждения выбора</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation>&lt;b&gt;Инструмент::Операции  – Правильная вытачка:&lt;/b&gt; выберите первую точку линии основы</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation>Блок Чертежа:</translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation>Вращение</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation>Добавить шпильку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation>Создать Внутренний контур</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation>Вставить узлы в контур</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation>Инструмент Соединения</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation>Экспортировать Деталь выкройки</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation>Режим Деталь</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation>Вы пока не можете использовать режим &quot;Деталь&quot;. Пожалуйста, создайте хотя бы одну выкройку.</translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation>Детали Выкройки</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation>Вы пока не можете использовать режим Макета. Пожалуйста, создайте хотя бы одну выкройку.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation>Вы пока не можете использовать режим Макета. Пожалуйста, добавьте в макет хотя бы одну выкройку.</translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation>Блок Чертежа.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation>Название уже существует</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation>Действие не может быть выполнено, поскольку имя чертежа уже существует.</translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation>У вас нет деталей для экспорта. Пожалуйста, добавьте хотя бы одну деталь в макет.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation>Экспортировать детали</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation>Невозможно экспортировать детали.</translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation>&lt;b&gt;Инструмент::Операции – Добавить новую деталь выкройки:&lt;/b&gt; выберите основной контур из объектов по часовой стрелке.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation>&lt;b&gt;Инструмент::Операции – Добавить точку-шпильку:&lt;/b&gt; Выберите точку привязки (шпильку)</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation>&lt;b&gt;Инструмент::Деталь – Внутренний контур:&lt;/b&gt; выберите объекты контура и используйте клавишу&lt;b&gt;SHIFT&lt;/b&gt;, чтобы изменить направление кривой</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation>&lt;b&gt;Инструмент::Деталь – Вставить узлы:&lt;/b&gt; выберите один или несколько объектов – удержите клавишу &lt;b&gt;%1&lt;/b&gt; при выборе нескольких объектов. Нажмите &lt;b&gt;ENTER&lt;/b&gt; для подтверждения выбора</translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation>&lt;b&gt;Инструмент:: Объединение Деталей:&lt;/b&gt; Выберите деталь выкройки</translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation>Блок Чертежа %1</translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation>Блок Чертежа %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation>Точка - на Биссектрисе (O, B)</translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation>Точка - в доль линии (P, S)</translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation>Точка — Пересечения Дуги и Линии (A, L)</translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation>Точка — Пересечения Оси и Треугольника (X, T)</translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation>Точка на пересечении осей XY (X, Y)</translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation>Точка - Пересечения Линии и Перпендикуляра (L, P)</translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation>Точка - Пересечения Линии и Оси (L, X)</translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation>Точка - на Перпендикуляре (O, P)</translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation>Точка - на Расстоянии и под Углом (L, A)</translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation>Точка - на Линии  (O, L)</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation>Точка - по середине Линии (Shift+O, Shift+L)</translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation>Точка - на Пересечении линий (I, L)</translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation>Кривая - Интерактивная (Alt+C)</translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation>Интерактивный сплайн (Alt+S)</translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation>Кривая - Фиксированная (Alt+Shift+C)</translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation>Сплайн - Фиксированный (Alt+Shift+S)</translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation>Точка - на сплайне (O, S)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation>Точка Пересечения Кривых (I, C)</translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation>Точка Пересечения Кривой и Оси (C, X)</translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation>Точка на Кривой (O, C)</translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation>Дуга - радиус и углы (Alt+A)</translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation>Точка на Дуге (O, A)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation>Точка — Пересечения Дуги и Оси (A, X)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation>Точка Пересечения дуг (I, A)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation>Точка Пересечения Окружностей (Shift+I, Shift+C)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation>Точка - Пересечения Окружности и Касательной (C, T)</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation>Точка — пересечения дуги и касательной (A, T)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation>Дуга - Радиус и Длина (Alt+Shift+A)</translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation>Эллиптическая Дуга (Alt+E)</translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation>Отражение по Линии (M, L)</translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation>Отражение по Оси (M, A)</translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation>Переместить  Объекты (M, A)</translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation>Правильная вытачка (T, D)</translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation>Добавить новую Деталь выкройки(N, P)</translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation>Добавить шпильку (A, P)</translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation>Вставить узлы (I, N)</translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation>Добавить Внутренний контур (I, P)</translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation>Экспортировать детали (E, P)</translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation>Новый макет печати (N, L)</translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation>Экспортировать Макет (E, L)</translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation>Alt+M</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation>Эллиптическая</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation>Дуга – Эллиптическая</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation>Alt+E</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation>Точка на середине линии</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation>Shift+O, Shift+L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation>На Линии</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation>O, L</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation>Длина и Угол</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation>L, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation>на Перпендикуляре</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation>O, P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation>на биссектрисе</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation>O, B</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation>Длина линии</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation>Пересечение Дуги и Линии</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation>Пересечение Оси и Треугольника</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation>X, T</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation>Пересечение Линии и Перпендикуляра</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation>L, P</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation>Пересечение Линии и Оси</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation>L, X</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation>Пересечение Линий</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation>Кривая — Интерактивная</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation>Точка на кривой</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation>O, C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation>Кривая - фиксированная</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation>Alt+Shift+C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation>Интерактивный - сплайн</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation>Точка на сплайне</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation>Точка на сплайне (O, S)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation>O, S</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation>Сплайн- Фиксированный</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation>Alt+Shift+S</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation>Пересечение Кривых</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation>Пересечение кривой и оси</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation>C, X</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation>Радиус и Углы</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation>Дуга - радиус и углы</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation>Точка на дуге</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation>Точка на Дуге (O, A)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation>O, A</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation>Пересечение Дуги и Оси</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation>Пересечение Дуги и Оси (A, X)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation>Пересечение Дуг</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation>Пересечение Дуг (I, A)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation>Пересечениа Окружностей</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation>Пересечение Окружностей (Shift+I, Shift+C)</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation>Shift+I, Shift+C</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation>Пересечение Окружности и Касательной</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation>Пересечение Окружности и Касательной (C, T)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation>Пересечение Дуги и Касательной</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation>Пересечение Дуги и Касательной (A, T)</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation>Радиус и Углы</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation>Дуга - Радиус и Длина</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation>Alt+Shift+A</translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation>Активировать последний использованный инструмент (Ctrl+Shift+L)</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation>Приблизить выбранное (Ctrl+Вправо)</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation>Приблизить выделенную область (Ctrl+A)</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation>Рабочая область панорамирования (Z, P)</translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation>Создать новый макет печати (N, L)</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation>Приблизить к точке (Ctrl + Alt + P)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation>Ctrl+Alt+P</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation>Укажите дополнительные мерки: %1</translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation>&lt;b&gt;Инструмент::Точка — на середине линии&lt;/b&gt;: выберите первую точку</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation>&lt;b&gt;Инструмент::Точка – на расстоянии и под углом&lt;/b&gt;: Выберите точку</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation>&lt;b&gt;Инструмент::Точка – На линии:&lt;/b&gt; Выберите первую точку</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Инструмент::Точка – На перпендикуляре:&lt;/b&gt; Выберите первую точку линии</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation>&lt;b&gt;Инструмент::Точка  - на биссектрисе:&lt;/b&gt; Выберите первую точку линии угла</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation>&lt;b&gt;Инструмент::Точка - Длина до линии:&lt;/b&gt; Выберите точку</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения дуги и линии:&lt;/b&gt; Выберите первую точку линии</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation>&lt;b&gt;Инструмент::Точка  – Пересечения оси и треугольника:&lt;/b&gt; Выберите первую точку оси</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation>&lt;b&gt;Инструмент::Точка  - пересечения XY&lt;/b&gt; Выберите точку для значения X (вертикаль)</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения линии и перпендикуляра:&lt;/b&gt; Выберите точку основы</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения линии и оси:&lt;/b&gt; Выберите первую точку линии</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation>&lt;b&gt;Инструмент::Линия:&lt;/b&gt;:Выберите первую точку</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения линий:&lt;/b&gt; Выберите первую точку первой линии</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation>&lt;b&gt;Инструмент:: – Интерактивная Кривая:&lt;/b&gt; Выберите начальную точку кривой</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation>&lt;b&gt;Инструмент:: — Интерактивный Сплайн:&lt;/b&gt; Выберите начальную точку сплайна</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation>&lt;b&gt;Инструмент::— Фиксированная кривая:&lt;/b&gt; Выберите первую точку кривой</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation>&lt;b&gt;Инструмент:: — Фиксированный Сплайн:&lt;/b&gt;Выберите первую точку  сплайна</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation>&lt;b&gt;Инструмент::Точка – На кривой:&lt;/b&gt; Выберите первую точку кривой</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation>&lt;b&gt;Инструмент::Точка – На сплайне:&lt;/b&gt; Выберите сплайн</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения кривых:&lt;/b&gt; Выберите первую кривую</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения кривой и оси:&lt;/b&gt; Выберите кривую</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation>&lt;b&gt;Инструмент::Дуга – Радиус и углы:&lt;/b&gt; Выберите точку центра дуги</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation>&lt;b&gt;Инструмент::Точка – На дуге:&lt;/b&gt; Выбрать дугу</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения дуги и оси:&lt;/b&gt; Выбрать дугу</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения дуг:&lt;/b&gt; Сначала выберите дугу</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения окружностей:&lt;/b&gt; Выберите центр первой окружности</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения окружности и касательной:&lt;/b&gt; Выберите точку на касательной</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation>&lt;b&gt;Инструмент::Точка – Пересечения дуги и касательной:&lt;/b&gt; Выберите точку на касательной</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation>&lt;b&gt;Инструмент::Дуга – Радиус и длина:&lt;/b&gt; Выберите точку центра дуги</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation>&lt;b&gt;Инструмент::Дуга — Эллиптическая:&lt;/b&gt; Выберите точку центра эллиптической дуги</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation>Изображения</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation>Зум до точки</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation>Точка:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation>Пересечение Дуги и Линии</translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation>Пересечение кривой и оси</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation>Добавить объект в группу (G)</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation>Добавить объект в группу</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation>Добавить Группу Объектов</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation>Группа заблокирована. Разблокируйте, чтобы добавлять объекты</translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation>Не удалось сохранить файл.</translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation>Выкройка доступна только для чтения.</translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation>Не удалось заблокировать. Файл с таким именем открыт в другом окне.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation>без названия</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation>Не удалось заблокировать. Этот файл уже открыт в другом окне. Возможна коллизия при запуске двух копий программы.</translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation>Панель инструментов «Перо»</translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation>Коробка инструментов</translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation>Исключение из файла.</translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation>Исключение экспорта.</translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>выкройка</translation>
     </message>
     <message>
-        <location line="+3397"/>
         <source>untitled.sm2d</source>
         <translation>безымянный.sm2d</translation>
     </message>
     <message>
-        <location line="-4942"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
@@ -9434,86 +7320,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Ошибка при создании файла «%1»! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Критическая ошибка!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation>Ошибка печати</translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation>Невозможно продолжить, в системе нет доступных принтеров.</translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation>безымянный</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation>Макет устарел.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation>Макет не был обновлен после последнего изменения выкройки. Хотите продолжить?</translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Невозможно подготовить данные для создания макета</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation>Невозможно открыть принтер %1</translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation>При предварительном просмотре многостраничного документа все страницы должны быть одного размера.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation>При печати многостраничного документа все страницы должны быть одного размера.</translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation>Страницы будут обрезаны, т.к. они не соответствуют формату бумаги принтера.</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation>Невозможно установить поля принтера</translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation>Невозможно создать контур</translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Выкройка</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation>Размер одного или нескольких деталей выкройки превышает выбранный вами формат бумаги. Пожалуйста, выберите больший формат бумаги.</translation>
     </message>
@@ -9521,148 +7387,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation>Скопировать ярлыки в буфер обмена</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation>Экспортировать ярлыки в формате PDF</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation>Отправить ярлыки на принтер</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation>Экспортировать PDF</translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation>Файл</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation>Новый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation>Открыть индивидуальные мерки</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation>Открыть Мультиразмерные мерки</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation>Ctrl+Shift+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation>Экспорт в CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation>Выйти</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation>Помощь</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation>Горячие клавиши</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation>Ярлыки SeamlyMe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation>Найти предыдущий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation>Найти следующий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
@@ -9670,125 +7506,104 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation>Свернуть все</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation>Развернуть все</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation>Выбрать все</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation>Снять выбор со всех</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translatorcomment>Раздел мерок</translatorcomment>
         <translation>Точный рост</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translatorcomment>Раздел мерок</translatorcomment>
         <translation>Точная ширина</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation>Отступ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation>Кисть</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation>Ступня</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation>Голова</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation>Окружность и дуга</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation>Вертикально</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation>Горизонтально</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation>Грудь</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation>Баланс</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation>Рука</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation>Нога</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation>Промежность и подъем</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation>Пошив на мужчин</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation>Исторические и особенные</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation>Мерки выкройки</translation>
@@ -9797,18 +7612,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation>Невозможно найти мерку «%1»</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation>Пустое название мерки!</translation>
     </message>
@@ -9816,37 +7623,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation> Позиция X:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation>позиция x</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation>Позиция Y:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation>позиция y</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation>Единицы измерения:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation>единицы</translation>
     </message>
@@ -9854,12 +7654,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation>переместить первую метку вытачки</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation>переместить вторую метку вытачки</translation>
     </message>
@@ -9867,7 +7665,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation>Переместить Группу элементов</translation>
     </message>
@@ -9875,7 +7672,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation>переместить точку метки</translation>
     </message>
@@ -9883,7 +7679,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation>переместить точку метки</translation>
     </message>
@@ -9891,7 +7686,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation>переместить одиночную точку</translation>
     </message>
@@ -9899,7 +7693,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation>переместить сплайн</translation>
     </message>
@@ -9907,7 +7700,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation>переместить сложный сплайн</translation>
     </message>
@@ -9915,52 +7707,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>Новый файл мерки</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Тип мерки:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Единицы:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Базовый размер:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Базовая высота:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Индивидуальная</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Multisize</source>
         <translation>Мультиразмерные</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Centimeters</source>
         <translation>Сантиметры</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Миллиметры</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inches</source>
         <translation>Дюймы</translation>
     </message>
@@ -9968,87 +7750,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation>A0</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation>A1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation>A2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation>A3</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation>A4</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation>Буква/символ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation>Легальный</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation>Таблоид</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation>ANSI C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation>ANSI D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation>ANSI E</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation>Рулон 24 дюйма</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation>Рулон 30 дюймов</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation>Рулон 36 дюймов</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation>Рулон 42 дюйма</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation>Рулон 44 дюйма</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation>Пользовательские</translation>
     </message>
@@ -10056,887 +7821,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation>Инструмент Деталь Выкройки</translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation>Свойства </translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation>Контуры </translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation>Прибавка на швы </translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation>Метки </translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation>Шпильки </translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation>Долевая нить </translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation>Надсечки </translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation>Название детали:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation>Детали Выкройки</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation>Имя не может быть пустым</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation>Буква:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation>Буквенное обозначение детали выкройки</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation>Количество:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation>Размещение:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation>на сгибе</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation>Положение на сгибе:</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation>Неопределенный</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation>Вверх/Вниз</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation>Левое/Правое</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation>Ориентация:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation>Левое</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation>Правый</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation>Вращение:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation>Ничего</translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation>1-сторонний</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation>2-сторонний</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation>4-сторонний</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation>Любой</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation>Наклон:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation>CW X</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation>CCW X</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation>Примечания:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation>Текстовое поле для добавления заметок</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation>Запретить отражение детали в макете раскладки.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation>шестнадцатеричное значение</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation>Заполнить:</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation>Главный контур</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation>Все объекты должны следовать в направлении по часовой стрелке.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation>Переместить строку в начало списка</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation>Переместить строку на одну строку вверх</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation>Переместить строку на одну строку вниз</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation>Переместить строку в конец списка</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation>Стаус:</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation>Готово!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation>Внутренние контуры</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation>Контур прибавок на швы составляет основной контур</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation>Включенные</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation>Скрыть основной контур если включены прибавки на швы</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation>Автоматические</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation>Расчёт</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation>Узлы</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation>Узел:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation>До:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation>Восстоновить значение ширины по умолчанию</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation>Использовать по Умолчанию</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation>После:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation>Пользовательские</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation>Стартовая точка:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation>Конечная точка:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation>Включить как:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation>Метка детали</translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation>Редактировать метку выкройки</translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation>Редактировать шаблон</translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation>Показать метку выкройки</translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation>Шпильки</translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation>Метка выкройки</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation>Показать метку выкройки</translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation>Показать Направление долевой нити</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation>Стрелки</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation>Надсечка:</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation>Щель</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation>Т надсечка</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation>U - надсечка</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation>V Внутренний </translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation>V Внешний</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation>Замок</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation>Алмаз</translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation>Прямой</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation>Биссектриса</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation>Выберите, чтобы обозначить угловую точку как надсечку</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation>Пересечение</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation> Ширина:</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation>Восстановить длину надсечки по умолчанию.</translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation>Восстановить ширину надсечки по умолчанию.</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation>Восстановить угол надсечки по умолчанию.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation>Число:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation>Выберите объекты основного контура по часовой стрелке. Используйте &lt;b&gt;SHIFT&lt;/b&gt;, чтобы изменить направление кривой, или &lt;b&gt;CTRL&lt;/b&gt;, чтобы сохранить направление кривой. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание детали </translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation>Нажмите на ОК, чтобы создать выкройку</translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation>Изменить направление</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation>Дубликат</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation>Надсечка</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation>Т-Надсечка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation>U-Надсечка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation>V Внутренний</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation>V Внешний</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation>Исключён</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation>Параметры</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation>Ошибка. Не удалось сохранить контур детали.</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation>Недопустимый/неизвестный результат</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation>Значение длины должно быть положительным числом</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation>Ошибка синтаксического анализа: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation>Редактировать длину</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation>Редактрировать угол</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation>Редактировать высоту</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation>Редактировать ширину</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation>Текущая прибавка на швы</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation>Редактировать ширину прибавки на швы</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation>Редактировать ширину прибавки на швы до точки</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation>Редактировать ширину прибавки на швы после точки</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation>Долевая нить</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation>Вам нужно выбрать больше точек!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation>Необхадимо выбирать точки по часовой стрелке!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation>Первая точка не может совпадать с последней!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation>Повторяются две точки подряд!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation>Каждая точка в контуре должна быть единственной!</translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation>Пусто</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation>главный контур</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation>пользовательская прибавка на швы</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation>Обе</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation>Только верхняя</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation>Только нижняя</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation>Показать надсечку на линии разреза.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation>Показать надсечку на линии разреза</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation>Показать надсечку на линии шва.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation>Показать надсечку на линии шва</translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation>Показать линию разреза</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation>Скрыть линию шва</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation>Прибавка на швы</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation>Контуры</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation>Метки</translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation>Выберите Цвет</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation>Переворачивание:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation>Запретить</translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation>Центр:</translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation>Верхний левый:</translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation>Внизу справа:</translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation>Верхний:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation>Нижнее:</translation>
     </message>
@@ -10944,218 +8456,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation>Текущая прибавка на швы</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation>переместить метку детали выкройки</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation>изменить размер метки детали выкройки</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation>повернуть метку детали выкройки</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation>переместить информацию о выкройке</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation>изменить размер информации метки выкройки</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation>повернуть информацию о метке выкройки</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation>переместить линию долевой нити</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation>изменить размер линии долевой нити</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation>повернуть линию долевой нити</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation>Заблокировать Деталь Выкройки</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation>Включить в макет раскладки</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation>Запретить переворачивание</translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation>Поднять на верх</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation>Спустить вниз</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation>Скрыть линию шва</translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation>Показать Припуски на Швы</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation>Показать Направление долевой нити</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation>Показать Метку Выкройки</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation>Показать Метку Детали Выкройки</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation>Переименовать...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation>Запретить переворачивание изменено: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation>Включено</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation>Отключено</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation>Изменена видимость линии шва: </translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation>Скрыть</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation>Показать</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation>Показать припуски на швы</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation>Изменена видимость припусков на швы: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation>Показать Направление долевой нити</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation>Изменена видимость линии направления долевой нити: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation>Показать метку выкройки</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation>Изменена видимость метки выкройки: </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation>Показать метку детали выкройки</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation>Изменена видимость метки детали: </translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation>Название детали:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation>Переименовать детали выкройки</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation>Переименовать детали выкройки</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation>Деталь переименована в: </translation>
     </message>
@@ -11163,27 +8623,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation>Текущий цвет линии</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation>Текущий тип линии</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation>Текущая толщина линии</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation>Сбросить текущее перо к настройкам по умолчанию</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation>Сохранить текущую настройку пера</translation>
     </message>
@@ -11191,77 +8646,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation>Без заполнения</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation>Плотное</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation>Плотность 1</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation>Плотность 2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation>Плотность 3</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation>Плотность 4</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation>Плотность 5</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation>Плотность 6</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation>Плотность 7</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation>Горизонтальная Линия</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation>Вертикальная Линия</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation>Квадратики</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation>Заштрихованное с лева на право</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation>Заштрихованное с права на лево</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation>Квадратики по диагонали</translation>
     </message>
@@ -11269,139 +8709,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation>Включить все детали</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation>Исключить все детали</translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation>Инвертировать включенные детали</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation>Заблокировать все группы детали</translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation>Разблокировать все детали</translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation>Инвертировать заблокированные детали</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation>Переключатель включения деталей выкройки в макет раскладки</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation>Выберите Цвет</translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation>Редактирование свойств детали выкройки</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation>Включен</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation>Деталь выкройки включена в макет</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation>Заблокировано</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation>Деталь выкройки заблокирована</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation>Цвет детали выкройки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation>Деталь</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation>Буквенное обозначение детали выкройки</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation>Название детали выкройки</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation>Включатель блокировки детали выкройки</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation>Двойной щелчок открывает выбор цвета</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation>Двойной щелчок открывает диалоговое окно свойств детали выкройки</translation>
     </message>
@@ -11409,62 +8804,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation>Точка Пересечения XY</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation>1-ая точка:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation>2-ая точка:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation>Выберите точку для по горозинтали(Y)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation>Уникальное название</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation>Выберите уникальное название.</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
@@ -11472,316 +8855,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation>Интервал:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>Язык интерфейса:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation>Единица измерения по умолчанию:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>Единицы измерения обновлены и будут применены при следующем создании выкройки.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation>Сантиметры</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Дюймы</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation>Редактирование</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation>Шаг подсчёта:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation> (0 - до бесконечности)</translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation>Предупреждения о редактировании выкроек</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation>Подтвердите удаление элемента</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation>Подтвердить перезапись формата</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation>Суффикс операций по умолчанию</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation>Суффикс отражения по оси:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation>Суффикс отражения по линии:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation>Суффикс перемещения:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation>Суффикс вращения:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation>Обработка файлов</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation>Включить автосохранение</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation> минимум</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation>Каждый </translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation>Экспортировать формат</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation>Добавить тип режима в имя файла</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation>Сохранить последний использованный</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation>По умолчанию:</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation>Десятичный Разделитель:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation>Никакой</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation>_M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation>_MOV</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation>_R</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation>_ROT</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation>_MA</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation>_MBA</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation>_MB</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation>_MBL</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation>Миллиметры</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation>Выбора Звука</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation>Звук:</translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation>Информация о дизайнере</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation>Информация о компании / дизайнере</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation>Компания / Дизайнер:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation>Контакт:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>City:</source>
         <translation>Город:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation>Штат::</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation>почтовый индекс:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation>Страна:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation>Телефон:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation>Факс:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation>Эл. почта:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation>Веб-сайт:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation>Проверка электронной почты</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-184"/>
         <source>Address:</source>
         <translation>Адрес:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-38"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation>Пользовательская локаль</translation>
     </message>
     <message>
-        <location line="-110"/>
         <source>Email format is not valid.</source>
         <translation>Формат электронной почты не соответствует действительности.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1031"/>
         <source>Startup</source>
         <translation>Стартап</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation>Добро пожаловать</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation>Не показывать экран приветствия</translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11789,583 +9106,415 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation>Вид</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation>Панели инструментов</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation>Под значком появляется текстовая подсказка (рекомендуется для новичков)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation>Показать панели инструментов</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation>Коробка инструментов</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation>Линия</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation>Кривая</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation>Дуга</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation>Операции</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation>Деталь</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation>Подробности</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation>Макет</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation>Графический вывод</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation>Использовать сглаживание</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation>Шрифты</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation>Метка</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation>Шрифт:</translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation>6</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation>7</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation>8</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation>9</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation>10.5</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation>11</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation>12</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation>13</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation>14</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation>15</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation>16</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation>18</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation>20</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation>22</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation>24</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation>26</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation>28</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation>32</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation>36</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation>44</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation>48</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation>54</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation>60</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation>66</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation>72</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation>80</translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation>96</translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation>Пример шрифта: Быстрая лиса прыгает через ленивую собаку</translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation>Названия точек</translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation>GUI</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation>Цвета</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation>Зум Руббербранд</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation>Положительный:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation>Отрицательный:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation>По умолчанию:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation>Наведите указатель мыши</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation>Рисование</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation>Начало оси</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation>Начальный:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation>Вторичный:</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation>Третичный:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation>Навигация</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation>Полосы прокрутки</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation>Показать полосы прокрутки</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation> пиксели</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation>Продолжительность:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation>Продолжительность анимации прокрутки</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translatorcomment>миллисекунды</translatorcomment>
         <translation> миллисекунды</translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation>Интервал обновления:</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation>Время в миллисекундах между каждым обновлением анимации</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation>Скорость:</translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation>Зум</translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation>Используйте модификатор CTRL</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation>Поведение</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation>Ограничения</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation>Угол шага:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation> градусы</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation>Масштабировать выбранное двойным щелчком мыши</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation>Панорамирование активно, пока нажата клавиша пробела</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
         <translation>Качество:</translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation>Пути, что использует Валентина</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Пути</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation>Открыть директорию</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation>Мои индивидуальные мерки</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>Мои мультиразмерные мерки</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation>Мои выкройки</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation>Мои макеты раскладки</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation>Мои шаблоны</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation>Мои шаблоны этикеток</translation>
     </message>
@@ -12373,272 +9522,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation>Запретить переворачивание</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation>По умолчанию запретить поворот для всех вновь созданных заготовок деталей</translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation>По умолчанию спрятать главный контур если была включена прибавка на швы</translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation>Прибавка на швы</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation>Значение по умолчанию:</translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation>Дата:</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation>Редактировать форматы</translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation>Время:</translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation>Деталь Выкройки</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation>Надсечки</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation>Показать надсечку как на припуске на швы, так и на линии шва.</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation>Направление долевой нити</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation>Показать Направление долевой нити</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation>x 3</translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation>Контуры</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation>Линию Шва</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation>Толщина Линии</translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation>Линия Разреза</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation>Вырезы</translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation>Метки</translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation>Данные метки (формат даты/времени)</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation>Щель</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation>Т надсечка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation>U надсечка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation>V Внутренний</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation>V Внешний</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation>Замок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation>Алмаз</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation>Показать метки выкройки</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation>Показать метки детали</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation>Ширина</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation>Рост</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation>Шаблоны</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation>Метка выкройки:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation>Метка детали:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation>Шаблон метки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation>Импортировать шаблон</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation>Показать надсечку на линии разреза</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation>Показать надсечку на линии шва</translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation>Внутренние</translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation>Показать линию разреза</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation>Скрыть линию шва</translation>
     </message>
@@ -12646,7 +9725,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>Базируется на Qt %1 (%2, %3 bit)</translation>
     </message>
@@ -12654,155 +9732,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Создайте новую выкройку для начала работы.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>см</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>дюймы</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Значение</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation>добавить узел</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation>Изменения применены.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Неверное название метки «%1».</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation>Невозможно конвертировать в UInt параметр</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation>Невозможно преобразовать в логический параметр</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation>Получен пустой параметр</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation>Невозможно конвертировать toDouble параметр</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation>Получен неправельный параметр id. Допустимы только id &gt; 0.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation>Ткань</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation>Подкладка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation>Флезелин</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation>Дублерин</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation>Разрезать</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation>на сгибе</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation>Соеденить деталь</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation>переместить деталь</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation>Сплошная линия</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation>Пунктирная линия</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation>Точки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation>Пунктир Точка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation>Пунктир Точка Точка</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation>Без карандаша</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation>%1</translation>
     </message>
@@ -12810,15 +9857,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation>слишком мало аргументов для функции sum.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation>слишком мало аргументов для функции min.</translation>
@@ -12827,217 +9870,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Неожиданный токен &quot;$TOK$&quot; найден в позиции $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Внутренняя ошибка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Неверное имя функции, переменной или константы: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Неверный идентификатор бинарного оператора: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Неверный идентификатор инфиксного оператора: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Неверный идентификатор постфиксного оператора: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Неверный указатель на функцию обратного вызова.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>Выражение пустое.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Неверный указатель на переменную.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Неожиданный оператор &quot;$TOK$&quot; найден в позиции $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Неожиданный конец выражения в позиции $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Неожиданный разделитель аргументов в позиции $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Неожиданная скобка &quot;$TOK$&quot; в позиции $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Неожиданная функция &quot;$TOK$&quot; в позиции $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Неожиданное значение &quot;$TOK$&quot; найденое в позиции $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Неожиданная переменная &quot;$TOK$&quot; найденая в позиции $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Аргументы функции используются без функции (позиция: $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Отсутствует скобка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Слишком много параметров для функции &quot;$TOK$&quot; в выражении в позиции $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Слишком мало параметров для функции &quot;$TOK$&quot; в выражении в позиции $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Деление на ноль</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Ошибка домена</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Конфликт имени</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>Неверное значение для определения приоритетов оператора (должна быть больше или равна нулю).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Определенный пользователем бинарный оператор &quot;$TOK$&quot; конфликтует с встроенным оператором.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Неожиданный строковый токен находящийся в позиции $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Незавершенная строка, начиная с позиции $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>Функция, которая принимает строковое значение, вызвана с нестроковым типом аргумента.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>Строковое значение используется там, где ожидается числовой параметр.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Нет подходящего кандидата для перегрузки оператора &quot;$TOK$&quot; в позиции $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>Результат функции строковой.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Ошибка синтаксического анализа.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>Десятичный разделитель идентичен разделителю аргументов функции.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Оператору &quot;$TOK$&quot; должна предшествовать закрывающаяся скобка.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>В операторе if-then-else пропущен else</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Неправильное расположение двоеточия в позиции $POS$</translation>
@@ -13046,7 +10053,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation>Удалить Группу элементов</translation>
     </message>
@@ -13054,7 +10060,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation>переименовать деталь выкройки</translation>
     </message>
@@ -13062,12 +10067,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13075,7 +10078,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation>опция сохранения подробностей</translation>
     </message>
@@ -13083,7 +10085,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation>сохранить параметры контура</translation>
     </message>
@@ -13091,7 +10092,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation>сохранить параметры инструмента</translation>
     </message>
@@ -13099,88 +10099,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>Язык интерфейса:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation>Система создания выкроек</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation>Система:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation>Автор:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation>Книга:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation>Редактирование мерок</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation>Сбросить предупреждения</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation>Панель инструментов</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation>Текст отображается под иконками (рекомендуется для начинающих).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation>Размер и рост по умолчанию</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation>Рост:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation>Стартап</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation>Не показывать экран приветствия</translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation>Десятичный Разделитель:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation>Пользовательская локаль</translation>
     </message>
@@ -13188,52 +10170,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Путь</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation>Открыть директорию</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation>Мои индивидуальные мерки</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>Мои мультиразмерные мерки</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation>Мои шаблоны</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation>Пути, которые использует SeamlyME</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation>Сканирование моего тела</translation>
     </message>
@@ -13241,102 +10213,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Добро пожаловать</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation>Добро пожаловать в SeamlyME</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation>Пользователи 3D Look</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation>Чтобы использовать сканирование тела 3DLook, файл необходимо преобразовать в формат SeamlyME. </translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation>Прикрепите файл 3DLook к электронному письму и отправьте его на адрес convert@seamly.io.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation>Вы получите электронное письмо с преобразованным файлом, который затем можно загрузить в SeamlyME, как обычно.</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation>Выберите желаемые единицы измерения, десятичный разделитель и язык. (Вы можете изменить их позже.)</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation>Единицы измерения:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Устанавливает единицы измерения по умолчанию для нового файла измерений.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Десятичный Разделитель:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation>Язык интерфейса:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation>Устанавливает язык, используемый для SeamlyMe.</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation>Больше не показывать</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Пользовательская локаль</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Сантиметры</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Миллиметры</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Дюймы</translation>
     </message>
@@ -13344,92 +10295,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation>Добро пожаловать</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation>Добро пожаловать в Seamly2D</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation>Единицы измерения:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation>Устанавливает единицы измерения по умолчанию для нового файла измерений.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation>Десятичный Разделитель:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>GUI language:</source>
         <translation>Язык интерфейса:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation>Больше не показывать</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation>Пользовательская локаль</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation>Сантиметры</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation>Миллиметры</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation>Дюймы</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation>Устанавливает язык, используемый для Seamly2D.</translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation>Выберите желаемые единицы измерения, десятичный разделитель, язык и звук выбора. (Вы можете изменить их позже.)</translation>
     </message>
     <message>
-        <location line="+159"/>
         <source>Sound:</source>
         <translation>Звук:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation>Устанавливает звук щелчка при выборе узла.</translation>
     </message>
@@ -13437,12 +10369,10 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation>Изменить цвет детали</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation>Цвет Детали изменен: </translation>
     </message>
@@ -13450,1071 +10380,854 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation>Скопировать ярлыки в буфер обмена</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation>Экспортировать ярлыки в формате PDF</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation>Отправить ярлыки на принтер</translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation>Ярлыки Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation>Файл</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation>Новый</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation>Ctrl+W</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation>Настройки выкройки</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation>Ctrl+Shift+Запятая</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation>Информация о документе</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation>Выход</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation>Ctrl+Z</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation>Вернуть</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation>Ctrl+Y</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation>Просмотр</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation>Режим Чертежа</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation>Shift+D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation>Режим Деталь</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation>Режим Макет</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation>Shift+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation>Приблизить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation>Ctrl++</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation>Уменьшить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation>Ctrl+-</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation>Зум 1:1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation>Ctrl+0</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation>Зум до точки</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation>Ctrl+Alt+P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation>Подходит всем</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation>Ctrl+=</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation>Предыдущий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation>Ctrl+Left</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation>Выбрано</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation>Ctrl+Right</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation>Область</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation>Pan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation>Z, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation>Показать текстовое название</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation>V, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation>Увеличить размер текста</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation>Ctrl+]</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation>Уменьшить размер текста</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation>Ctrl+[</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation>Использовать инструмента цвета</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation>Каркасный режим</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation>V, W</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation>Контрольные точки кривой</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation>V, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation>Начало оси</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation>V, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation>Прибавка на швы</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation>V, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation>Направление долевой нити</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation>V, G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation>Метки</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation>V, L</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation>Мерки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation>Открыть SeamlyMe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation>Таблица переменных</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation>Экспорт таблицу переменных в CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation>Инструменты</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation>Новый блок чертежа</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation>Ctrl+Shift+N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation>Переименовать блок чертежа</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation>F2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation>Длина и Угол</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation>L, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation>На Линии</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation>O, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation>на Перпендикуляре</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation>O, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation>на биссектрисе</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation>O, B</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation>Длина на линии</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation>P, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation>Пересечение Дуги и Линии</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation>A, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation>Пересечение Оси и Треугольника</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation>X, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation>Пересечение XY</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation>X, Y</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation>Пересечение Линии и Перпендикуляра</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation>L, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation>Пересечение Линии и Оси</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation>L, X</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation>Точка на середине линии</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation>Shift+O, Shift+L</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation>Линия</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation>Alt+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation>Точка — на пересечении линий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation>I, L</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation>Кривые</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation>Кривая — Интерактивная</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation>Alt+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation>Интерактивный сплайн</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation>Кривая - фиксированная</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation>Alt+Shift+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation>Сплайн- Фиксированный</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation>Alt+Shift+S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation>Точка - на кривой</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation>O, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation>Точка - на сплайне	</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation>O, S</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation>Точка — Пересечения Кривых</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation>I, C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation>Точка Пересечения Кривой и Оси</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation>C, X</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation>Дуги</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation>Дуга - радиус и углы</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation>Дуга - Радиус и Длина</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation>Alt+Shift+A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation>Точка на дуге</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation>O, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation>Точка — Пересечения Дуги и Линии</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation>A, X</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation>Точка - Пересечения дуг</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation>I, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation>Точка - Пересечения Окружностей</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation>Shift+I, Shift+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Точка - Пересечения Окружности и Касательной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation>C, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Точка — пересечения дуги и касательной</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation>A, T</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation>Дуга – Эллиптическая</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation>Alt+E</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation>Операции</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation>Добавить объект в группу</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation>G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation>Вращение</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation>Отражение по Линии</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation>M, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation>Отражение по Оси</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation>M, A</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation>Переместить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation>Alt+M</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation>Правильная вытачка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation>T, D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation>Экспорировать  блоки чертежа</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation>E, D</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation>Изображения</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation>Alt + I</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation>Деталь Выкройки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation>Новая Деталь выкройки</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation>N, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation>Шпилька</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation>A, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation>Внутренний контур</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation>I, P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation>I, N</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation>Редактор свойств</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation>P</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation>Переключатель Блокировки</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation>Ctrl+L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation>Включить в макет раскладки</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation>Запретить переворачивание</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation>F</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation>Поднять на верх</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation>Ctrl+Home</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation>Спустить вниз</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation>Ctrl+End</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation>Подробности</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation>Соеденить детали</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation>U</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation>Экспортировать детали</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation>E, P</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation>Макет</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation>Новый макет</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation>N, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation>Экспорт макета</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation>E, L</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation>Последний инструмент</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation>Ctrl+Shift+L</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation>История</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation>Ctrl+H</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation>Утилиты</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation>Калькулятор</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation>Ctrl+Shift+C</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation>Десятичная диаграмма</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation>Ctrl+Shift+D</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation>Помощь</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation>Горячие клавиши</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation>Shift+P</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation>T</translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation>Экспортировать PDF</translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation>Вставить узлы</translation>
     </message>
@@ -14522,12 +11235,10 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation>переключить видимость первой вытачки</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation>переключить видимость второй вытачки</translation>
     </message>
@@ -14535,42 +11246,34 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation>Информация о документе</translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation>Скопировать информвцию в буфер обмена</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation>Экспортировать как PDF</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation>Отправить информацию на принтер</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Компания: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt; b&gt;Клиент: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Название выкройки:&lt;/b&gt;&lt;/td&gt;&lt;td&gt; %3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Номер выкройки: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Версия: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Единицы измерения: &lt;/b&gt;&lt;/td&gt; &lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Мерки:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt; tr&gt;&lt;td align = right&gt;&lt;b&gt;Описание: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Примечания: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Изображение: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10 &lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation>Информационные файлы</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation>Экспортировать PDF</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation>_ИНФО</translation>
     </message>
@@ -14578,7 +11281,6 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation>переключить видимость точки</translation>
     </message>
@@ -14586,7 +11288,6 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation>переключить видимость точки</translation>
     </message>
@@ -14594,813 +11295,621 @@ You can change this setting in the Seamly2D preferences.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Выберите Новый для создания файла мерок.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation>Рассчитанное значение</translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Формула</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Базовое значение</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>В размерах</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>В высотах</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Подробности</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Формула:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation>Базовое значение:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation>В размерах:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation>В высотах:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Описание:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation>Переместить мерку выше</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Переместить мерку ниже</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Рассчитанное значение:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation>Полное имя:</translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation>Тип мерки</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Путь:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Показать в файловом менеджере</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Базовый размер:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation>Значение базового размера</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Базовая высота:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation>Значение базовой высоты</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Фамилия:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation>Дата рождения:</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>Эл. почта:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>Заметки:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>Файл</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Окно</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Помощь</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Мерки</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation>Меню</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation>Градация</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation>Открыть индивидуальные...</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation>Сохранить как...</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>О &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>О SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Новый</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation>Добавить известные</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation>Добавить специальные</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation>Только для чтения</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>База данных</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation>Показать информацию о всех известных мерках</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation>безымянный %1</translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>Этот файл уже открыт в другом окне.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Ошибка файла.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Невозможно сохранить файл</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation>&amp;Новое окно</translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation>Изменить мерку</translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Пустое поле.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Ошибка синтаксического анализа: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Индивидуальные мерки</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>безымянный</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation>Несохранённые изменения</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Мерки были изменены.
 Хотите сохранить изменения?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Пустое поле</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation>Импорт из выкройки</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation>Единицы измерения выкройки:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Найти:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation>Найти предыдущий</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation>Найти следующий</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation>Невозможно заблокировать. Этот файл уже открыт в другом окне.</translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation>Файл содержит неправильные мерки.</translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation>Неизвестный формат файла.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Полное имя</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation>Файл «%1» не существует!</translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation>Нельзя изменить название известной мерки.</translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation>Невозможно найти мерку «%1».</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation>Нельзя изменить полное название известной мерки.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation>Мастер функций</translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation>Переместить наверх</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation>Переместить вниз</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation>Удалить мерку</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation>неизвестный</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>мужской</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>женский</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation>Пол:</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation>Система конструирования:</translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation>Создать из существующего ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation>Создать из существующего файла</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation>Выберите файл</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation>Диаграмма мерок</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Неизвестная мерка&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Неизвестная мерка&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>Про Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>Файл ещё не был сохранен.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation>Название мерки в формуле</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation>Название мерки в формуле.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation>Удобное для чтения название мерки.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>Сохранить...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Не сохранять</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Файл блокировки</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Этот файл уже открыт в другом окне. Игнорируйте, если вы хотите продолжить (не рекомендуется, может привести к повреждению данных).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Файл блокировки не может быть создан из-за отсутствия разрешений. Игнорируйте, если вы хотите продолжить (не рекомендуется, может привести к повреждению данных).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Произошла неизвестная ошибка, например, полностью заполненный раздел предотвращает запись файла блокировки. Игнорируйте, если вы хотите продолжить (не рекомендуется, может привести к повреждению данных).</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Не удалось создать файл блокировки из-за отсутствия разрешений.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Произошла неизвестная ошибка, например, полностью заполненный раздел предотвращает запись lock файла.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation>Экспорт в CSV</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Показать в Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation>Имя клиента</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation>Фамилия клиента</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation>Адрес электронной почты клиента</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Высота:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation>Все файлы</translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation>Документ мерок не имеет прав на запись.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Невозможно установить разрешения для %1 для записи.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Не удалось сохранить файл.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation>Не удалось сохранить файл</translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation>только для чтения</translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation>Мультиразмерные мерки</translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Недопустимый результат. Значение бесконечность или нечисловое. Пожалуйста, проверьте расчеты.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation>Пусто</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation>Открыть Мультиразмерные мерки...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation>Экспорт из мультиразмерных мерок не поддерживается.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation>Выход</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation>Ctrl+Shift+O</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation>Ctrl+,</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation>Ярлыки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation>K</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation>Не удалось заблокировать. Этот файл уже открыт в другом окне. Ожидайте коллизий при запуске двух копий программы.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation>Число</translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation>Скопировать в буфер обмена</translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation>Открыть шаблон ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation>Ctrl+Alt+O</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation>Файлы выкроек</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation>Импортируйте сканирование тела как</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation>3D Measure Up</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation>3D Look</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1064"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation>Чтобы использовать сканирование тела 3DLook, файл необходимо преобразовать в формат SeamlyME.
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
@@ -15409,7 +11918,6 @@ Do you want to save your changes?</source>
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15420,7 +11928,6 @@ load in SeamlyME as usual.
 </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation>Конвертируйте файл 3DLook:</translation>
     </message>
@@ -15428,22 +11935,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation>Деталь в списке макетов</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation>Включение детали в макет изменено: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation>Включить</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation>Исключить</translation>
     </message>
@@ -15451,22 +11954,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation>Заблокировать Деталь Выкройки</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation>Блокировка Детали изменена: </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation>Заблокировано</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation>Разаблокировано</translation>
     </message>
@@ -15474,47 +11973,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation>Первая точка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation>Вторая точка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation>Самая высокая точка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation>Самая низкая точка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation>Самая левая точка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation>Самая правая точка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation>Вертикальные оси</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation>Горизонтальные оси</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation>Линия_</translation>
     </message>
@@ -15522,47 +12012,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation>Инструмент объединения деталей</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Вы действительно хотите объединить детали?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation>Сохранить оригинальную выкройку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation>Выберите первую точку</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation>Часть выкройки должна иметь как минимум две точки и три объекта</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation>Выберите вторую точку</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation>Выберите уникальную точку</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation>Выберите деталь</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation>Выберите точку на ребре</translation>
     </message>
@@ -15570,7 +12051,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation>Соединение деталей</translation>
     </message>
@@ -15578,17 +12058,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Не спрашивать снова</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Не &amp;спрашивать снова</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>Не по&amp;казывать снова</translation>
     </message>
@@ -15596,57 +12073,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Не удалось получить информацию о версии.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>В файле слишком много меток &lt;%1&gt;.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Версия &quot;%1&quot; недействительная.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Версия &quot;0.0.0&quot; недействительная.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Недействительная версия. Минимально поддерживаемая %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Недействительная версия. Максимально поддерживаемая %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Ошибка, неуникальный id.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>Не удалось изменить версию.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation>Ошибка создания резервной копии: %1.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Неизвестная версия &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation>Ошибка открытия временного файла: %1.</translation>
     </message>
@@ -15654,7 +12120,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation>Невозможно вырезать кривую</translation>
     </message>
@@ -15662,22 +12127,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation>Подтвердить перезапись формата</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation>Этот файл использует предыдущую версию формата v%1. Текущая версия v%2. При сохранении файла с этой версией приложения, версия формата этого файла будет обновлена. Это может помешать вам открыть файл в более старых версиях приложения. Хотите продолжить?</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation>Значения, разделенные запятыми</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation>Экспорт в CSV</translation>
     </message>
@@ -15685,13 +12146,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
@@ -15699,23 +12157,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>Невозможно найти инструмент в таблице.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation>Ошибка создания или обновления группы</translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>Новая группа</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation>Новая группа 2</translation>
     </message>
@@ -15723,7 +12176,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation>Деталь</translation>
     </message>
@@ -15731,12 +12183,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
@@ -15744,283 +12194,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Подтвердите удаление</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Вы точно хотите удалить?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation>Редактировать неправильную формулу</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation>Зеленый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation>Синий</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation>Темно-красный</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation>Темно-зеленый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation>Темно-синий</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation>Желтый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation>Светлый розовый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation>Золотистый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation>Оранжевый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation>Темно-розовый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation>Фиолетовый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation>Темно-фиолетовый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation>Зеленый Морской</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation>Салатовый</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation>Голубой</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation>Сине-Фиолетовый</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation>Черный</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation>Золотой</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation>Темно-зелёный</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation>Зелёный Травяной</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation>Светло-салатовый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation>Зелёный Желтоватый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation>Каштановый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation>Оранжевый Красноватый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation>Бордовый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation>Розовый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation>Ярко-Розовый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation>Сине-Фиолетовый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation>Красно-Фиолетовый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation>Темно-Синий</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation>Тёмно-Фиолетовый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation>Сливовый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation>Бирюзовый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation>Тёмно-Бирюзовый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation>Пудрово-голубой</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation>Светло-голубой</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation>Тёмно-Синий</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation>Пурпурный</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation>Темно-Серый</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation>Серый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation>Серый гэинсборо</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation>Зелёный Морской</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation>Светло-Серый</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation>Светло-стальной синий</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation>Бежевый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation>Чертополох</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation>Серебрянный</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation>Белый дым</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation>Белый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation>Темно-Серый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation>Синий Сероватый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation>Хаки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation>Светло-Бежевый</translation>
     </message>
@@ -16028,302 +12421,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation>Путь файла пользовательских мерок (режим экспорта).</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation>Файл мерок</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation>Номер формата</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation>Номер шаблона</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>Ширина страницы</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation>Единицы измерения</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation>Автоматически обрезать неиспользуемую длину (режим экспорта).</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation>Единицы измерения раскладки (как для бумаги, кроме пикселей, режим экспорта).</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation>Единицы измерения</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation>Ширина зазора</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation>Тип группировки</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation>Невозможно одновременно использовать формат страницы и явно указанный размер страницы.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation>Должны быть указаны: высота, ширина и единицы измерения.</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation>Неправильное значение поворота. Значение должно быть одно из предопределённых.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation>Выбрана страница с неизвестным шаблоном.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation>Неподдерживаемые единицы измерения для бумаги.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation>Неподдерживаемые единицы измерения для макета раскладки.</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation>Параметры экспорта могут использоваться только с одним входным файлом.</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation>Параметр проверки может быть использован только для одного входного файла.</translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation>Базовое имя экспортируемых файлов раскладки. Используйте для консольного режима экспорта.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation>Базовое имя файлов макета раскладки</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>Папка назначения</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation>Значение размера</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation>Значение высоты</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Ширина страницы в текущих единицах измерения, например 12.0 (не может быть использована с &quot;%1&quot;, режим экспорта).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Высота страницы в текущих единицах измерения, например 12.0 (не может быть использована с &quot;%1&quot;, режим экспорта).</translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation>Неверная градация значения размера.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation>Неверная градация значения высоты.</translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Программа создания выкроек.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Файл выкройки.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation>Ширина зазора между деталями должна быть использована вместе с единицами измерения смещения.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation>Левое поле принтера должно быть использовано вместе с единицами измерения страницы.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation>Правое поле принтера должно быть использовано вместе с единицами измерения страницы.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation>Верхнее поле принтера должно быть использовано вместе с единицами измерения страницы.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation>Нижнее поле принтера должно быть использовано вместе с единицами измерения страницы.</translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation>Путь к папке назначения вывода. По умолчанию папка, в котором программа была запущена.</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation>Единицы измерения высоты и ширины страницы (невозможно использовать с &quot;%1&quot;, режим экспорта). Допустимые значения: %2.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation>Игнорировать поля печати (режим экспорта). Отключает значения ключей: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Устанавливает все поля в 0.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Левое поле страницы в текущих единицах, например 3.0 (режим экспорта). Если не установлено, будет использовано значение из принтера по умолчанию. Или 0, если принтеры не были обнаружены. Значение будет проигнорировано, если был использован ключ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Правое поле страницы в текущих единицах, например 3.0 (режим экспорта). Если не установлено, будет использовано значение из принтера по умолчанию. Или 0, если принтеры не были обнаружены. Значение будет игнорировано, если был использован ключ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Верхнее поле страницы в текущих единицах, например 3.0 (режим экспорта). Если не установлено, будет использовано значение из принтера по умолчанию. Или 0, если принтеры не были обнаружены. Значение будет игнорировано, если был использован ключ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Нижнее поле страницы в текущих единицах, например 3.0 (режим экспорта). Если не установлено, будет использовано значение из принтера по умолчанию. Или 0, если принтеры не были обнаружены. Значение будет игнорировано, если был использован ключ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation>Вращение в градусах (одно из предварительно заданных значений, режим экспорта). Значение по умолчанию 180. 0 - нет поворота. Допустимые значения: %1. Каждое значение показывает сколько раз деталь будет повернута. Например 180 означает поворот два раза (360/180 = 2) на 180 градусов.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation>Объединить страницы, если это возможно (режим экспорта). Максимальное значение ограничено QImage, который поддерживает только максимум 32768х32768 пиксельные изображения.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation>Сохранить длину листа, если установлен (режим экспорта). Эта опция указывает программе использовать как можно больше ширины листа. Качество раскладки может быть хуже во время использования этой опции.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation>Ширина зазора ×2 в единицах раскладки (режим экспорта). Устанавливает дистанцию между деталями и дистанцию между деталью и краем листа.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation>Устанавливает тип группировки раскладки (режим экспорта): %1.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation>Запускает программу в тестовом режиме. Программа в этом режиме загружает один файл выкройки и молча завершается, не показывая главное окно. Ключ имеет приоритет перед ключом &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation>Смещение/сдвиг в единицах раскладки (режим экспорта). Указывает как много точек вдоль края будет создано при создании раскладки.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation>Длина сдвига/смещения</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation>Длина сдвига/смещения должна быть использована вместе с единицами измерения смещения.</translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation>Номер выходного формата (по умолчанию 0 — режим экспорта):</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation>Номер, соответствующий шаблону страницы (по умолчанию = 0, режим экспорта):</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Отключить масштабирование с высоким разрешением. Вызовите эту опцию, если есть проблема с масштабированием (по умолчанию масштабирование включено). Также вы можете использовать %1 переменную среды.</translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation>Экспортировать dxf в бинарном формате.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation>Экспортировать текст как пути.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation>Экспортируйте только детали. Экспортируйте детали в том виде, в котором они расположены в режиме деталей. Любые параметры, связанные с макетом, будут игнорироваться.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation>Установите значение размера файла выкройки, который был открыт с мультиразмерными измерениями (режим экспорта). Допустимые значения: %1см.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation>Установить значение высоты файла выкройки, который был открыт с мультиразмерными измерениями (режим экспорта). Допустимые значения: %1см.</translation>
     </message>
@@ -16331,43 +12664,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation>Мерки</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation>индивиндуальные</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation>мультиразмерные</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation>шаблоны</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation>Шаблоны метки</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation>бодискан</translation>
     </message>
@@ -16375,55 +12699,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>Невозможно найти объект</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation>Невозможно cбросить объект</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation>Невозможно найти объект. Несоответствие типа.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation>Количество свободных идентификаторов исчерпано.</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation>Невозможно создать кривую типа &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation>Невозможно найти объект: </translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation>Невозможно найти деталь: </translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation>Невозможно найти контур: </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation>Невозможно найти объект id: </translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation>Невозможно cбросить объект.</translation>
     </message>
@@ -16431,12 +12742,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation>Недостаточно точек для создания кривой.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation>Этот сплайн не существует.</translation>
     </message>
@@ -16444,52 +12753,42 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>Невозможно открыть файл %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Невозможно открыть файл схемы %1:
 %2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation>Ошибка валидации файла %3 в строке %1 столбца %2</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation>Ошибка разбора файла %3 в строке %1 столбца %2</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation>Не удалось получить узел</translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>Этот id не уникальный.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation>Не удалось открыть файл схемы &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation>Не удалось записать канонический XML.</translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation>&lt;пусто&gt;</translation>
     </message>
@@ -16497,27 +12796,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation>Показать Название Точки</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation>Добавить Группу Объектов</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation>Удалить Группу Объектов</translation>
     </message>
@@ -16525,7 +12819,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation>Исключение: %1</translation>
     </message>
@@ -16533,11 +12826,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
@@ -16545,7 +12833,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation>Формула:</translation>
     </message>
@@ -16553,7 +12840,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation>Деталь %1 не имеет формы.</translation>
     </message>
@@ -16561,7 +12847,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation>Показать Название Точки</translation>
     </message>
@@ -16569,12 +12854,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>Верно</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>Неверно</translation>
     </message>
@@ -16582,12 +12865,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Папка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Открыть файл</translation>
     </message>
@@ -16595,335 +12876,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Ошибка парсинга файла.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Ошибка, невозможно преобразовать значение.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Ошибка, пустой параметр.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Ошибка, неправильный id.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Ошибка парсинга файла (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Ошибка создания или обновления базовой точки</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Ошибка создания или обновления точки на конце линии</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Ошибка создания или обновления точки вдоль линии</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Ошибка создания или обновления точки плеча</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation>Ошибка создания или обновления точки нормы</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Ошибка создания или обновления точки биссектрисы</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Ошибка создания или обновления точки соприкосновения</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation>Ошибка создания или обновления точки</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Ошибка создания или обновления высоты</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Ошибка создания или обновления треугольника</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation>Ошибка создания или обновления точки разреза сплайна</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation>Ошибка создания или обновления точки разра сплайна</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation>Ошибка создания или обновления точки разреза дуги</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation>Ошибка создания или обновления точки пересечения линии и оси</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation>Ошибка создания или обновления точки пересечения кривой и оси</translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Ошибка создания или обновления линии</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Ошибка создания или обновления кривой</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Ошибка создания или обновления контура кривой</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation>Ошибка создания или обновления моделирования кривой</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation>Ошибка создания или обновления моделирования контура кривой</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Ошибка создания или обновления дуги</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation>Ошибка создания или обновления моделирования дуги</translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation>Ошибка создания или обновления точки пересечения дуг</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation>Ошибка создания или обновления точки пересечения окружностей</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation>Ошибка создания или обновления точки окружности и касательной</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation>Ошибка при создании или обновлении точки дуги и касательной</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation>Ошибка создания или обновления правильной вытачки</translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Неверное название метки «%1».</translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation>Неизвестный тип точки «%1».</translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation>Неизвестный тип сплайна &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation>Неизвестный тип дуги «%1».</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation>Неизвестный тип инструмента «%1».</translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation>Ошибка. Не уникальный id.</translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation>Ошибка создания или обновления точки пересечения кривых</translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation>Ошибка создания или обновления простой интерактивной кривой</translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation>Ошибка создания или обновления интерактивной сложной кривой</translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation>Ошибка создания или обновления кубической кривой Безье</translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation>Ошибка создания или обновления сложной кубической кривой Безье</translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation>Ошибка выполнения или обновления операции вращения</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation>Неизвестный тип операции &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation>Ошибка создания или обновления операции по перемещению</translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation>Ошибка создания или обновления точки пересечения линий</translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation>Ошибка при создании или редактировании эллиптической дуги</translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation>Неизвестный тип эллиптической дуги &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation>Ошибка при создании или редактировании модели эллиптической дуги</translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation>Безымянный контур</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation>Ошибка создания или обновления контура детали</translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation>Ошибка создания или обновления шпильки</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation>Ошибка создания или обновления инструмента пересечения XY</translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation>Ошибка выполнения или обновления операции отражения по линии</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation>Ошибка выполнения или обновления операции отражения по оси</translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation>Деталь</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation>Белый</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation>нет кисти</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation>Ошибка создания или обновления детали</translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation>Ошибка создания или обновления соединения деталей</translation>
     </message>
@@ -16931,17 +13123,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation>Сетка ( %1 , %2 )</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation>Страница %1 из %2</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation>Лист %1 из %2</translation>
     </message>
@@ -16949,12 +13138,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation>выкройки</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation>макеты раскладки</translation>
     </message>
@@ -16962,14 +13149,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>Недостаточно точек для создания кривой.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>Этот сплайн не существует.</translation>
     </message>
@@ -16977,17 +13160,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
@@ -16995,27 +13175,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation>Начальный угол</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation>     Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation>     Радиус</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Конечный угол</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation>      Метка</translation>
     </message>
@@ -17023,37 +13198,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation>Начальный угол</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation>     Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation>     Радиус</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Конечный угол</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation>      Название</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation>      Инструмент</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation>Дуга - Радиус и Длина</translation>
     </message>
@@ -17061,7 +13229,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
@@ -17069,12 +13236,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Невозможно создать точку пересечения %1 из точки %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;с кривой %3 с углом оси %4°&lt;/big&gt; &lt;/b&gt;&lt;br&gt;&lt;br&gt;Используйте исходную точку в качестве заполнителя до тех пор, пока выкройка не будет исправлена.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation>Точка Пересечения Кривой и Оси</translation>
     </message>
@@ -17082,32 +13247,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation>Дуга</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation>Начальный угол</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation>Конечный угол</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation>Радиус</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation>Метка</translation>
     </message>
@@ -17115,18 +13274,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation>Кривая</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation>Метка</translation>
     </message>
@@ -17134,18 +13289,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation>Кривая</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation>Метка</translation>
     </message>
@@ -17153,7 +13304,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
@@ -17161,28 +13311,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation>Начальный угол</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation>     Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation>    Радиус</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation>  Конечный угол</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation>      Метка</translation>
     </message>
@@ -17190,17 +13334,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
@@ -17208,12 +13349,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
@@ -17221,7 +13360,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
@@ -17229,27 +13367,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Невозможно найти точку пересечения %1&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;линии и оси&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Используйте исходную точку до тех пор, пока выкройка не будет исправлена.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation>Пересечение Линии и Оси</translation>
     </message>
@@ -17257,17 +13390,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
@@ -17275,7 +13405,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation>Начальная точка</translation>
     </message>
@@ -17283,12 +13412,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation>Первая точка линии</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation>Вторая точка линии</translation>
     </message>
@@ -17296,27 +13423,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Центральная точка</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation>Точка вращения</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation>Угол поворота</translation>
     </message>
@@ -17324,714 +13446,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Базовая точка</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation>Правильные Вытачки</translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation>Базовая точка:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation>Центральная точка:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation>Радиус:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation>Первый угол:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Второй угол:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation>Третья точка:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Метка точки 1:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation>Метка точки 2:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation>Первая базовая точка:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation>Вторая базовая точка:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation>Первая точка вытачки:</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation>Дуга:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation>Кривая:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation>Первая точка линии:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Вторая точка линии:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Центр дуги:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation>Первая дуга:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation>Вторая дуга:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation>Взять:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation>Первая кривая:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation>Вторая кривая:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation>Точка касательной:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation>Радиус окружности:</translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation>Название:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>С1: угол:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation>С1: длина:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>С2: угол:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation>С2: длина:</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation>Точка оси:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation>Суффикс:</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation>Начальная точка:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation>Тип оси:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation>Угол поворота:</translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation>Четвертая точка:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation>Точка - Пересечения XY</translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation>Вращение</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation>Точка вращения:</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation>Переместить</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation>Отражение по Линии</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation>Отражение по Оси</translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation>Координаты</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation>Точка — на Расстоянии и под Углом</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation>Точка - на линии</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation>Дуга - Радиус и Углы</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation>Дуга - Радиус и Длина</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation>Точка – на биссектрисе</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation>Вторая точка вытачки:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation>Третья точка вытачки:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation>Точка - на дуге</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation>Точка - на кривой</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation>Точка - на сплайне</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation>Точка — пересечения линии и перпендикуляра</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation>Линия</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation>Точка — на пересечении линий</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation>Первая линия</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation>Вторая линия</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation>Точка – на Перпендикуляре</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation>Вращение:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation>Точка — Пересечения Дуги и Линии</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation>1-я точка линии:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation>2-ая точка линии:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation>Точка - Пересечения Дуг</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation>Точка - Пересечения Окружностей</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation>Первая окружность:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation>Центр:</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation>Вторая окружность:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation>Точка — Пересечения Кривых</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation>Взять Вертикаль:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation>Взять Горизонталь:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation>Точка - Пересечения Окружности и Касательной</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation>Точка — пересечения дуги и касательной</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation>Точка - в доль линии</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation>Кривая — Интерактивная</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation>Кривая - фиксированная</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation>Интерактивный сплайн</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation>Сплайн- Фиксированный</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation>Точка — Пересечения Оси и Треугольника</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation>1-я точка оси:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation>2-ая точка оси:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation>Точка - Пересечения Линии и Оси</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation>Точка - Пересечения Кривой и Оси</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation>Дуга – Эллиптическая</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation>Дуга_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation>Спл_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation>Линия_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Центральная точка</translation>
     </message>
@@ -18039,12 +13845,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Невозможно найти точку пересечения %1&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 и касательную&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt; Используйте исходную точку до тех пор, пока выкройка не будет исправлена.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation>Пересечение Дуги и Касательной</translation>
     </message>
@@ -18052,17 +13856,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
@@ -18070,12 +13871,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Невозможно найти точку пересечения %1 дуг&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Используйте исходную точку до тех пор, пока выкройка не будет исправлена.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation>Точка Пересечения Дуг</translation>
     </message>
@@ -18083,12 +13882,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation>&lt;b&gt;&lt;big&gt;Невозможно найти точку пересечения %1 кривых&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Используйте исходную точку до тех пор, пока выкройка не будет исправлена.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation>Точка Пересечения Кривых</translation>
     </message>
@@ -18096,12 +13893,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation>  Начальная точка</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation>Угол вращения</translation>
     </message>
@@ -18109,17 +13904,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation>Длина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation>Угол</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
@@ -18127,1557 +13919,1300 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation>Бунка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation>Bunka Fashion College</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation>Основы конструирования одежды</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation>Barnfield and Richard</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation>Jo Barnfield и Andrew Richards</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation>Pattern Making Primer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation>Friendship/Женщины</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation>Elizabeth Friendship</translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries (Создание исторической одежды - шаблоны одежды 16-19 веков)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation>Morris, K.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation>Karen Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation>Sewing Lingerie that Fits</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation>Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation>Lucia Mors de Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation>Patternmaking in Practic (Практическое изготовление выкроек)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation>Kim &amp; Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation>Injoo Kim and Mykyung Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation>Apparel Making in Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation>Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation>Norah Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation>Corsets and Crinolines</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation>Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation>Frances Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation>Fashions of the Gilded Age</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation>Thornton&apos;s International System</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation>The Great War: Styles and Patterns of the 1910s
 (Великая война: стили и модели 1910-х годов)</translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation>Hillhouse &amp; Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation>Marion S. Hillhouse and Evelyn A. Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation>Dress Design: Draping and Flat Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation>Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation>Esther Kaplan Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation>How to Design Beautiful Clothes: Designing and Pattern Making (Как создать красивую одежду: проектирование и конструирование выкроек)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation>Minister &amp; Son</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>Edward Minister &amp; Son, ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation>The Complete Guide to Practical Cutting (1853)
 (Полное руководство по практической резке (1853))</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation>Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation>Gertrude Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation>A Tailoring Manual
 (Руководство по шитью)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation>Loh &amp; Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation>May Loh and Diehl Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternless Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation>Morris, F. R.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation>F. R. Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation>Ladies Garment Cutting and Making
 (Кройка и создание женской одежды)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation>Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation>Gertrude Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation>Gertrude Mason&apos;s Patternmaking Book</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation>Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation>K. Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation>Master Designer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation>The Master Designer (Chicago, IL)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation>Master Designer&apos;s System of Designing, Cutting and Grading</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation>Kopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation>How to Draft Basic Patterns (Создание основных выкроек)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation>Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation>Doris Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation>Slacks Cut-to-Fit for Your Figure</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation>Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation>Sarah J. Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation>Sarah&apos;s Key to Pattern Drafting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation>Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation>Karla J. Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation>Design and Sew Jeans
 (Кройка и шитьё джинс)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Lady Boutique magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation>Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation>M. Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation>Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation>Dorothy Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation>Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation>Bina Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation>Integrating Draping, Drafting and Drawing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation>Sue S. Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Dressmaking International magazine (Япония)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation>Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation>Mabel D. Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation>Практическое проектирование одежды</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation>Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation>E. L. G. Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>Принципы кройки одежды</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation>Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation>Elizabeth M. Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation>European Cut</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation>McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation>Donald H. McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation>Как создать ваши собственные выкройки для шитья</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation>Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation>Zarapkar System of Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation>Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation>Philip Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation>Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation>Jack Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation>Профессиональное создание выкроек для модельеров: женская одежда, мужская повседневная одежда</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation>Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation>R. I. Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation>Мужские костюмы, кройка и мода 17 и 18 веков</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation>MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation>Jason MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation>The Victorian Tailor: An Introduction to Period Tailoring</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation>Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation>Helen Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation>Supreme System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation>Frederick T. Croonberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation>Sugino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation>Создание одежды</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation>Создание выкроек, тома I, II и III (Япония)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation>Centre Point System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation>Louis Devere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation>The Handbook of Practical Cutting on the Centre Point System</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation>Aldrich/Мужчины</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation>Winifred Aldrich</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation>Создание выкроек мужской одежды по меркам</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation>Aldrich/Женщины</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation>Создание выкроек женской одежды по меркам</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation>Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation>Gareth Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation>Создание выкроек для мужской одежды</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation>Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation>Teresa Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation>Наброски выкроек по моде: основы</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation>Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation>Dennic Chunman Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation>Создание выкроек</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation>Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation>Проектирование выкроек одежды: основные принципы кройки и примерки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation>Knowles/Мужчины</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation>Lori A. Knowles</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation>Практическое руководство по созданию выкроек для модельеров: мужчины</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation>Friendship/Мужчины</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation>Выкройки мужских костюмов</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation>Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation>P. Clement Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation>Искусство одежды</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation>Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation>Jno. J. Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation>ГОСТ 17917-86</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation>Министерство лёгкой промышленности СССР</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation>Стандартные фигуры мальчиков</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation>Eddy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation>Josephine F. Eddy и Elizabeth C. B. Wiley</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation>Проектирование выкроек и одежды</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation>Knowles/Женщины</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation>Практическое руководство по созданию выкроек для модельеров: дети, девушки и женщины</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation>Закройщик американской одежды</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation>Внутреняя</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation>Команда Seamly2D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation>Внутренний стандарт Seamly2D</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>см</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>мм</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>дюйм</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>СлСпл</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Угол1СлСпл</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Угол2СлСпл</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation>Сег_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation>ТекущаяДлина</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation>размер</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation>Рост</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>С1ДлинаСлСпл</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>С2ДлинаСлСпл</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation>ТекущаяПрибавкаНаШов</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation>дата</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation>время</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation>названиевыкройки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation>номервыкройки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation>автор</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation>клиент</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation>pExt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation>pНазваниеФайла</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation>mНазваниеФайла</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation>mExt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation>pБуква</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation>pПримечания</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation>pОриентация</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation>pВращение</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation>pНаклон</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation>pПоложениенаСгибе</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation>pНазвание</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation>pКоличество</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation>mТкань</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation>mПодкладка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation>mФлезелин</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation>mДублерин</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation>сРазрез</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation>сНа Сгиб</translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation>degTorad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation>radTodeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation>sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation>cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation>tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation>asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation>acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation>atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation>sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation>cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation>tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation>asinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation>acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation>atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation>sinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation>cosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation>tanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation>asinD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation>acosD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation>log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation>log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation>ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation>exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation>sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation>sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation>rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation>abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation>min</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation>max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation>sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation>avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation>fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>М_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Переменная_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Линия_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>УголЛинии_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Дуга_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Дуга_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Спл_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>РадиусДуги_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Радиус1Дуги_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Радиус2Дуги_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Улог1Дуги_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Угол2Дуги_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Улог1Дуги_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Угол2Дуги_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Угол1Спл_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>Угол2Спл_</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>С1ДлинаСпл_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation>С2ДлинаСпл_</translation>
@@ -19686,17 +15221,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation>&lt;b&gt;Сложная кривая&lt;/b&gt;: выберите семь или больше точек</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation>&lt;b&gt;Сложная кривая&lt;/b&gt;: выберите больше точек для завершения</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Траектория Кривой&lt;/b&gt;: выберите семь или более точек. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание</translation>
     </message>
@@ -19704,7 +15236,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation>&lt;b&gt;Пересечение Кривой и Оси&lt;/b&gt;: угол = %1°. Удерживайте клавишу &lt;b&gt;SHIFT&lt;/b&gt;, чтобы ограничить угол. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание </translation>
     </message>
@@ -19712,7 +15243,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Точка на расстоянии и под углом&lt;/b&gt;: угол = %1°, длина = %2%3; Удерживайте клавишу&lt;b&gt;SHIFT&lt;/b&gt;, чтобы ограничить угол. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание</translation>
     </message>
@@ -19720,7 +15250,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Пересечение линии и оси&lt;/b&gt;: угол = %1°. Удерживайте клавишу&lt;b&gt;SHIFT&lt;/b&gt;, чтобы ограничить угол. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание</translation>
     </message>
@@ -19728,12 +15257,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation>Длина = %1%2, угол = %3°, &lt;b&gt;Удерживайте Shift&lt;/b&gt;, чтобы ограничить угол, &lt;b&gt;щелкните мышкой&lt;/b&gt; для завершения выбора позиции</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation>Длина = %1%2, угол = %3°, угол вращения = %4° Удерживайте &lt;b&gt;SHIFT&lt;/b&gt;, чтобы ограничить угол, &lt;b&gt;CTRL&lt;/b&gt; чтобы изменить исходную точку вращения, &lt;b&gt;щелкните мышкой&lt;/b&gt; чтобы завершить создание</translation>
     </message>
@@ -19741,7 +15268,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation>Угол вращения = %1°. Удерживайте &lt;b&gt;SHIFT&lt;/b&gt;, чтобы ограничить угол. &lt;b&gt;Щелкните мышкой&lt;/b&gt; чтобы завершить создание</translation>
     </message>
@@ -19749,7 +15275,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation>Удерживайте клавишу&lt;b&gt;SHIFT&lt;/b&gt;, чтобы ограничить угол</translation>
     </message>
@@ -19757,17 +15282,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Контур кривой&lt;/b&gt;: выберите три или больше точек</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation>&lt;b&gt;Контур Кривой &lt;/b&gt;: выберите три или более точек. Нажмите &lt;b&gt;ENTER&lt;/b&gt;, чтобы завершить создание</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation>Удерживайте клавишу&lt;b&gt;SHIFT&lt;/b&gt;, чтобы ограничить угол</translation>
     </message>
@@ -19775,47 +15297,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>ОТЛАДКА:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>ПРЕДУПРЕЖДЕНИЕ:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>КРИТИЧЕСКИЙ:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>ФАТАЛЬНЫЙ:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>ИНФОРМАЦИЯ:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation>Внимание</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation>Критическая ошибка</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation>Фатальная Ошибка</translation>
     </message>
@@ -19823,47 +15336,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>ОТЛАДКА:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>ПРЕДУПРЕЖДЕНИЕ:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>КРИТИЧЕСКАЯ:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>ФАТАЛЬНАЯ:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>ИНФО:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation>Внимание</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation>Критическая Ошибка</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation>Фатальная Ошибка</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>Про Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation>Веб сайт : %1</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation>Не можу відкрити браузер по замовчуванню</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished">Автоматична</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Зібрано %1 в %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation>Перевірити наявність оновлень</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished">невідомий</translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation>додати групу</translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation>додати об&apos;єкт</translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished">Точка:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished">Деталь:</translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Помилка парсінгу файла. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Помилка неправильний id. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Помилка конвертації значення. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Помилка пустий параметр. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Помилка неправильний id. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Щось не так!!</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Помилка парсінгу: %1. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Програмне виключення: %1. Програма буде закрита.</translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation>Помилка парсінгу файла. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation>Помилка неправильний id. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation>Помилка конвертації значення. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation>Помилка пустий параметр. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation>Помилка неправильний id. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation>Щось не так!!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation>Помилка парсінгу: %1. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation>Виключення: %1. Програма буде закрита.</translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation>Редактор мірок.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation>Файл мірок.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation>Базовий зріст</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation>Базовий розмір</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation>Встановити одиниці виміру файлу лекала: см, мм, дюйми.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation>Одиниці вимірювання лекала</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation>Не дійсний аргумент базового розміру. Має бути cm, mm, inch.</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation>Не вдається почати слухати вхідні з&apos;єднання за іменем &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation>Тестовий режим не підтримує відкриття одночасно декількох файлів.</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation>Будь ласка, надайте один вхідний файл.</translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation>Відкриття з базовим розміром. Дійсні значення: %1 см.</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation>Недійсний аргумент базової висоти. Має бути %1 см.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation>Недійсний аргумент базового розміру. Має бути %1 см.</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation>Відкрити з базовим розміром. Дійсні значення: %1 см.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation>Використовуеється для тестування. Запускає програму і відкриває файл без показу головного вікна.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Відключити масштабування з високим розширенням. Викличте цю функцію якщо маєте проблему з масштабуванням (за замовчуванням масштабування увімкнено). Альтернативно ви можете використовувати перемену оточення %1.</translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation>видалити групу</translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>видалити інструмент</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation>видалити інструмент</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished">Про SeamlyMe</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished">Версія SeamlyMe</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished">Ревізія: %1</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished">Ця програма є частиною проекту Seamly2D.</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished">Перевірити наявність оновлень</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished">Не можу відкрити браузер по замовчуванню</translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Зібрано %1 в %2</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished">Веб сайт : %1</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished">невідомий</translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation>Виберіть другу точку лінії</translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>Редагувати довжину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation>Перша точка лінії</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation>Друга точка лінії</translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Радіус не може мати від&apos;ємне значення</translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Кути однакові</translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation>Редагувати радіус</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Редагувати перший кут</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Редагувати другий кут</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>Радіус:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation>Перший кут:</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation>Другий кут:</translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>Точка центру:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation>Виберіть центральну точку дуги</translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>Колір:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation>Редагувати радіус</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation>Редагувати перший кут</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation>Редагувати довжину дуги</translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Радіус не може мати від&apos;ємне значення</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>Довжина не може бути 0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>Радіус:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation>Перший кут:</translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>Точка центру:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>Колір:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation>Виберіть другу точку кута</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation>Виберіть третю точку кута</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Редагувати довжину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Третя точка:</translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>Колір:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation>Імя:</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation>Третя точка:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation>Четверта точка:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation>Виберіть другу точку кривої</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation>Виберіть третю точку кривої</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation>Виберіть четверту точку кривої</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation>Неправильна крива</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation>Точка:</translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation>Список точок</translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>Колір:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation>Імя:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation>Неправильна складна крива</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished">Шлях:</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation>Виберіть точку осі</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation>Редагувати кут</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation>Кут:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation>Точка осі:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation>Крива:</translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>Редагувати довжину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation>Дуга:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Редагувати довжину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation>Крива:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>Редагувати довжину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation>Крива:</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation>Радіус1:</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation>Радіус2:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation>Перший кут:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation>Другий кут:</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation>Кут обертання:</translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation>Точка центру:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation>Виберіть центральну точку дуги</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation>Колір:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation>Радіус не може мати від&apos;ємне значення</translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation>Кути однакові</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation>Редагувати радіус1</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation>Редагувати радіус2</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation>Редагувати перший кут</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation>Редагувати другий кут</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation>Редагувати кут обертання</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation>Редагувати кут</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Редагувати довжину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation>Кут:</translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation>Базова точка:</translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation>Властивості експорту</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation>Експорт</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation>Із заголовком</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation>Кодек:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation>Розділювач</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation>Табуляція</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation>Кома</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation>Двокрапка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation>Пробіл</translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation>Виберість першу точку лінії</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Виберіть другу точку лінії</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation>Базова точка:</translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished">Перша точка:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">Друга точка:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished">Контур</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished">Контур без назви</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished">Створіть імя для вашого контуру</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished">Тип:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished">Деталь:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished">Готовий!</translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Прибавка на шви</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">Ширина:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished">Значення</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished">Розрахунок</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished">Вузли</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished">Вузел:</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished">Перед:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished">Повернутися до ширини по замовчуванню</translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished">По замовчуванню</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished">Після:</translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished">Кут:</translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished">Надсічки</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished">Надсічка:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished">Тип</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished">Пряма</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished">Бісектриса</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished">Перетин</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">Довжина:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished">Протилежний напрямок</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">Видалити</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Поточна прибавка на шви</translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Редагувати ширину прибавки на шви</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Редагувати ширину прибавки на шви перед</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Редагувати ширину прибавки на шви після</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished">Внутрішній контур</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished">Користувацька прибавка на шви</translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished">Потрібно більше точок!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished">Перша точка &lt;b&gt;користувацької прибавки на шви&lt;/b&gt; не може дорівнювати останній!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Одна точка не може бути використана два рази підряд!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished">Кожна точка в &lt;b&gt;користувацькій прибавці на шви&lt;/b&gt; повинна бути унікальною!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished">Список деталей пустий!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished">Будьласка, виберіть деталь для вставки!</translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Не вдалося підготувати данні для створення розкладки</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation>Створити розкладку</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation>Укладання деталей: %1 з %2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Зачекайте, відбувається пошук найкращої позиції для деталі.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation>Виберіть другу точку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished">Лінія_</translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation>Перша лінія</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation>Друга лінія</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation>Виберіть другу точка першої лінії</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation>Виберіть першу точку другої лінії</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation>Виберіть другу точку другої лінії</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation>Перша точка лінії</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation>Виберіть другу точку лінії</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation>Виберіть точку осі</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation>Точка осі</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation>Друга точка лінії</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation>Редагувати кут</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation>Кут:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation>Точка осі:</translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished">Перша точка:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished">Друга точка:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>Мірки</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished">Знайти:</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished">Пошук</translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished">Точка осі:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished">Суфікс:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished">Тип вісі:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Вертикальна вісь</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Горизонтальна вісь</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished">Перша точка лінії:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished">Друга точка лінії:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished">Суфікс:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation>Кут:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation>Суфікс:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation>Редагувати кут</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>Редагувати довжину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation>Перемістити</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished">Осьова точка:</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished">Обертання:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation>Точка центру</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation>Одинці виміру:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>Сантиметри</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Дюйми</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation>Унікальне ім&apos;я лекала</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation>Виберіть унікальне ім&apos;я лекала.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation>Нове лекало</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation>Виберіть другу точку лінії</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>Редагувати довжину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished">Обертання:</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation>Опис лекала</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation>Зрости і розміри</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation>Всі зрости (см)</translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation>Всі розміри (см)</translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation>Стандартний зріст і розмір</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation>Користувацькі</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation>Зріст:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation>Розмір:</translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation>Безпека</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation>Відкрити тільки для читання</translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation>Виклечіть контекстне меню для редагування</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation>Зображення відсутнє</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Видалити зображення</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation>Змінити зображення</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation>Зберегти зображення до файлу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation>Показати позбраження</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation>Зображення викрійки</translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation>Зображення</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation>Зберегти файл</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation>без імені</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation>Шлях:</translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation>Показати в Провіднику</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation>&lt;Пусто&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation>Файл ще не було збережено.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation>Показати в програмі Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation>Ім&apos;я лекала:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation>Номер лекала:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation>Компанія/дезайнер:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation>Ім&apos;я клієнта:</translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>Лекало</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation>Виберіть дугу</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation>Точка дотичної:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation>Дуга:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Взяти:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation>Виберіть точку центру дуги</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation>Виберіть другу точку лінії</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation>Редагувати радіус</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>Радіус:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation>Центер дуги:</translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation>Виберіть другу дугу</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation>Перша дуга:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation>Друга дуга:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation>Взяти:</translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation>Перша крива:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation>Друга крива:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation>Виберіть другу криву</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>Лекало</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished">Загальні</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation>Поворот</translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation>Кут:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Майстер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation>Суфікс:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation>Редагувати кут</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished">Властивості</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished">Налаштування</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation>Виберість першу точку лінії</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation>Виберіть другу точку лінії</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>Редагувати довжину</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation>Мастер формул</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation>Третя точка:</translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation>Координати на листі</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation>Координати</translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished">Базова точка</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>Перша точка</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>Друга точка</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation>Виберість останню точку кривої</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>Колір:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation>Кут:</translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation>Імя:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation>Неправильна крива</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Майстер формул</translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation>Редагувати кут першої контрольної точки</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation>Редагувати кут другої контрольної точки</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation>Редагувати довжину першої контрольної точки</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation>Редагувати довжину другої контрольної точки</translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation>Довжина не може мати від&apos;ємне значення</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation>Список точок</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation>Виберіть точку складної кривої</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>Колір:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation>Точка:</translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation>Перша контрольна точка</translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation>Кут:</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation>Друга контрольна точка</translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation>Імя:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation>Неправильна складна крива</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation>Майстер формул</translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;р&gt;Показати повний розрахунок у вікні повідомлення&lt;/p&gt;&lt;/body&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation>Редагувати кут першої контрольної точки</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation>Редагувати кут другої контрольної точки</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation>Редагувати довжину першої контрольної точки</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation>Редагувати довжину другої контрольної точки</translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation>Довжина не може мати від&apos;ємне значення</translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation>Не використовується</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation>Розрахунок</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished">Шлях:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation>Пусте поле</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation>Значення не може бути 0</translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Помилка синтаксичного аналізу: %1</translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>Перша точка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>Друга точка</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation>Найвища точка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation>Найнища точка</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation>Сама ліва точка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation>Сама права точка</translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation>за довжиною</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation>за точками перетину</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation>за симетрією першого ребра</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation>за симетрією другого ребра</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation>за прямим кутом першого ребра</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation>за прямим кутом другого ребра</translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Недійсний результат. Значення безкінечність чи NaN, перевірте ваші розрахунки.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation>Значення не може бути менше ніж 0</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation>Виберіть другу точку вісі</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation>Виберість першу точку</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation>Виберіть другу точку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation>Вибрати другу базову точку</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation>Виберіть першу точку виточки</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation>Виберіть другу точку виточки</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation>Виберіть третю точку виточки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation>Зламана формула</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation>&amp;Відмінити</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation>&amp;Виправити формулу</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Відмінити</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Помилка при розрахунку формули. Ви можете попробувати відмінити останню операцію чи виправити поламану формулу.</translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Фільтрувати список за ключовим словом</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished">Розраховане значення</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished">Формула</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished">Перемістити мірку вгору</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished">Перемістити мірку вниз</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished">Деталь</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished">Розраховане значення:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished">Формула:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished">Розрахунок</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished">Опис:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">Лінія</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished">Кут</translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished">Крива</translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished">Дуга</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished">Радіус</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">Помилка</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished">Порожнє поле.</translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished">Пусте поле</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished">Недійсний результат. Значення безкінечність чи NaN, перевірте ваші розрахунки.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished">Значення</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Помилка синтаксичного аналізу: %1</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">Інструмент</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished">Редагувати формулу</translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">Мірки</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished">Функції</translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished">Формула:</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished">Значення</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished">Розрахунок</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished">Вставити змінну у формулу</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished">Сховати пусті мірки</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished">Повне ім&apos;я</translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished">Фільтрувати список за ключовим словом</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished">Довжина лінії</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished">Довжина кривої</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished">Кут лінії</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished">Радіус дуги</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished">Кут кривої</translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished">Унікальне ім&apos;я лекала</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished">Редагувати</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished">Не вдалося зберегти файл</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished">Помилка файла.</translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">Розмір</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">Зріст</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished">Тканина</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished">Підклада</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished">Дублерін</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished">Вирізати</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished">на згиб</translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished">Шлях:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished">Папка призначення</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished">Шлях до теки призначення</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished">Вибрати шлях до папки призначення</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished">Переглянути...</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished">Формат файлу:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished">Назва файлу:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished">Базова назва файлу</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished">Праве:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished">Ліве:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished">Верхнє:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished">Нижнє:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished">Формат листу</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished">Базове імя файлу не відповідає регулярному виразу.</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished">Вибрати папку</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished">Спроба використати значення формату, що виходить за межі діапазону.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished">Вибрано не існуючий формат.</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation>Завантаження feed зазнало невдачі: %1.</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation>Інформація</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished">Групи</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">Видалити</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished">%1 - Базова точка</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished">Спл_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished">Дуга_</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished">Редагувати</translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished">Історія</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished">Знайти:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished">Базова точка</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished">Спл_</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished">Дуга_</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished">Опис</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished">Одинця виміру:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">піксел</translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Ширина:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished">Обертання:</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">Видалити</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished">Підтвердіть видалення</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Ви дійсно хочете видалити?</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished">Деталь:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished">Протилежний напрямок</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished">Надсічка</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Видалити</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Програма надається ЯК Є без ГАРАНТІЙ БУДЬ-ЯКОГО РОДУ, ВКЛЮЧАЮЧИ ГАРАНТІЙ ДИЗАЙНУ, КОМЕРЦІЙНОЇ ЦІННОСТІ І ПРИДАТНОСТІ ДЛЯ КОНКРЕТНИХ ЦІЛЕЙ.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished">Взяти:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished">Точка центру:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished">Точка дотичної:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">Радіус:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished">Значення</translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished">Розрахунок</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished">Виберіть центр кола</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished">Редагувати радіус</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">Помилка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Радіус не може мати від&apos;ємне значення</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished">Взяти:</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation>Центр:</translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">Радіус:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished">Значення</translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished">Розрахунок</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished">Виберіть центр другого кола</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished">Редагувати радіус першого кола</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished">Редагувати радіус другого кола</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">Помилка</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished">Радіус не може мати від&apos;ємне значення</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation>Шаблони:</translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>Ширина:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation>Висота:</translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation>Повертати деталі</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation>Повертати на</translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation>градуси</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation>Три групи: великі, середні, малі</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation>Дві групи: великі, малі</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation>За спаданням площі</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>Сантиметри</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>Дюйми</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation>Пікселі</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation>Автоматично обрізати невикористану довжину</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation>Обєднати сторінки (якщо це можливо)</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation>Ширина розриву:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation>Зберегти довжину аркушу</translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation>Формат листу</translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation>Ліве:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation>Праве:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation>Верхнє:</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation>Нижнє:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation>Неправильні поля.</translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6626,84 +5194,67 @@ Apply settings anyway?</source>
 ⇥За зменшенням площі = 2</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation>Параметри розкладки</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation>Довжина зміщення:</translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation>Принцип вибору настпної деталі</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation>Розділити на полоси</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation>Множник</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation>Встановить множник для найбільшої деталі в розкладці.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation>При ввімкненні для листів що мають велику довжину пришвидшує створення.</translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation>Принтер:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation>Жодного</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6711,32 +5262,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,2659 +5289,2000 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation>Seamly2D</translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation>Інструмент створення точок.</translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation>Точка</translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation>Інструменти для створення ліній.</translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>Лінія</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation>Інструменти для створення кривих.</translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation>Крива</translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation>Інструменти для створення дуг.</translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation>Дуга</translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation>&amp;Допомога</translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>Мірки</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>Новий</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Новий</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation>Створити нове лекало</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation>&amp;Відкрити</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation>Відкрити файл з лекалами</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>Зберегти</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation>&amp;Зберегти</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation>Зберегти лекало</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation>Зберегти &amp;як...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation>Зберегти ще не збережене лекало</translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation>Деталь</translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation>Інструмент вказівник</translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation>Історія</translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation>Про &amp;Qt</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation>&amp;Про Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation>&amp;Вихід</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation>Властивості</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation>Повідомити про помилку</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation>Показати довідку</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation>Про Qt</translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation>Зберегти як</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation>Не вдалося зберегти файл</translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation>Помилка парсингу файла.</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Помилка, не можу конвертувати значення.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation>Помилка, пустий параметр.</translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>Помикла, неправильний id.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Помилка парсінгу файлу (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation>Поганий id.</translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation>Файл збережено</translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation>безімений.sm2d</translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation>Лекало було змінено. Ви хочете зберегти ваші зміни?</translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation>&amp;Відмінити</translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation>&amp;Повторити</translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>Цей файл вже відкрито в іншому вікні.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation>Неправильні одиниці виміру.</translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation>Файл завантажено</translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation>Валентина не була закрита правильно. Ви хочете знову відкрити ці файли (%1)?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation>Відкрити знову файли.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation>Розкладка</translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation>Друк</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation>Друк PDF плиткою</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation>Розділити і надрукувати розкладку на сторінках меншого розміру (для звичайних принтерів)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation>Попередній перегляд</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation>Попередній перегляд оригінальної розкладки</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation>Експортувати як...</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation>Режим розкладки</translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation>Незбережені зміни</translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation>Мірки завантажено</translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation>Ви не можете експортувати пусту сцену.</translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation>Файл мірок містить недійсні відомі мірки.</translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation>Файл мірок має невідомий формат.</translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation>Типи файлів мірок не співпадають.</translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation>Не вдалося синхронізувати мірки.</translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation>Не вдалося оновити мірки.</translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation>Файл мірок &apos;%1&apos; не вдалося знайти.</translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation>Завантаження файлу мірок</translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation>Не підтримуване значення розміру &apos;%1&apos; для цього файлу лекала.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation>Не вдалося встановити розмір. Файл не було відкрито.</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation>Метод %1 не працює в графічному режимі</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation>Не підтримуване значення висоти &apos;%1&apos; для цього файлу лекала.</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation>Не вдалося встановити зріст. Файл не було відкрито.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation>Будь ласка, надайте один вхідний файл.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation>Друк оригінальної розкладки</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation>Попередній перегляд PDF плиткою</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation>Попередній перегляд розкладки плиткою</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation>Мірки вивантажено</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation>Не вдалося вивантажити мірки. Деякі з них використовуються у лекалі.</translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation>Нове лекало</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation>Відкрити лекало</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation>Створити/Редагувати мірки</translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>Зберегти...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Не зберігати</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Блокування файлу</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Цей файл вже відкритий в іншому вікні. Ігноруйте якщо ви хочете продовжити (не рекомендується, може призвести до втрати даних).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Не вдалося створити lock файл через відсутність дозволів. Ігноруйте якщо хочете продовжити (не рекомендується, може призвести до втрати даних).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Сталася невідома помилка, наприклад переповнення розділу попередило запис lock файлу. Ігноруйте якщо бажаєте продовжити (не рекомендується, може призвести до втрати даних).</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Не вдалося створити lock файл через відсутність дозволів.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Сталася невідома помилка, наприклад переповнення розділу попередило запис lock файлу.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation>Операції</translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation>Закрити викрійку</translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation>Вказівник</translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation>Початковий масштаб</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation>Висота:</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation>Розмір:</translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation>Файл мірок &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; не вдалося знайти. Ви хочете оновити місце знаходження?</translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation>Мірки були змінені. Бажаєте синхронізувати мірки зараз?</translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation>Програма не підтримує стандарнту таблицю з дюймами</translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation>Мірки було синхронізовано</translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation>Документ не має прав на запис.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Не вдалося встановити права для %1 на запис.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Не вдалося зберегти файл.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation>Не вдалося зберегти файл</translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation>тільки читання</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation>Завантажити індивідуальні</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation>Завантажити файл індивідуальних мірок</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation>Завантажити стандартні</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation>Завантажити файл стандартних мірок</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation>Відкрити SeamlyMe</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation>Редагувати поточну</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation>Редагувати зєднані з лекалом мірки</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation>Синхронізувати</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation>Синхронізувати з&apos;єднані з лекалом мірки після зміни</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation>Вивантажити поточні</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation>Вивантажити мірки якщо вони не були використані в лекалі</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation>Індивідуальні мірки</translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation>Стандартні мірки</translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation>Файли лекал</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation>Вікі</translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation>Форум</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation>Ім&apos;я</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation>Розраховане значення</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation>Формула</translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation>Ви не можете використовувати Режим розкладки зараз.</translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished">Редагувати</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished">Поворот</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Перемістити</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">Про Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished">Мітки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished">Експорт</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">Видалити</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished">Зображення</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished">Точка:</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished">Ctrl+E</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished">без імені</translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>лекало</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished">По замовчуванню</translation>
     </message>
@@ -9404,86 +7290,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation>Створення файлу &apos;%1&apos; не вдалося! %2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation>Критична помилка!</translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation>Помилка друку</translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation>Не можливо виконати тому що не знайдено доступних принтерів у вашій системі.</translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation>неназваний</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation>Розкладка застаріла.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation>Розкладка не була оновлена з часу останніх змін креслення. Ви хочете продовжити?</translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation>Не вдалося підготувати данні для створення розкладки</translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation>Не вдалося відкрити принтер %1</translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation>Для перегляду багатосторінкового документу всі листи повинні мати той самий розмір.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation>Для друку багатосторінкового документа всі сторінки мають бути одного розміру.</translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation>Сторінки будуть обрізані тому що вони не відповідають формату паперу принтера.</translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation>Не вдалося встановити поля принтеру</translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>Лекало</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9491,148 +7357,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished">Файл</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Новий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Друк</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Зберегти</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Зберегти як</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Експортувати до CSV</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished">Ctrl+E</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished">Допомога</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished">Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished">Ctrl+G</translation>
     </message>
@@ -9640,123 +7476,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished">Звернути всі</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished">Розкрити всі</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished">Відмітити все</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished">Зняти виділення з усіх</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Висота</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Ширина</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Положення корпусу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Кисть</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Стопа</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Голова</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Обхвати і напівобхвати</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Вертикаль</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Горизонталь</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Грудь</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Баланс</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Рука</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Нога</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Промежина</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Чоловіки і пошив одягу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Історичні і спеціальні</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished">Мірки лекала</translation>
@@ -9765,18 +7580,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation>Не вдалося знайти мірку &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation>Ім&apos;я мірки порожнє!</translation>
     </message>
@@ -9784,37 +7591,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished">Форма</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished">Одинці виміру:</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9822,12 +7622,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation>переміщення першої мітки виточки</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation>переміщення другої мітки виточки</translation>
     </message>
@@ -9835,7 +7633,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9843,7 +7640,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation>перемістити мітку точки</translation>
     </message>
@@ -9851,7 +7647,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished">перемістити мітку точки</translation>
     </message>
@@ -9859,7 +7654,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation>переміщення базової точки</translation>
     </message>
@@ -9867,7 +7661,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation>перемістити сплайн</translation>
     </message>
@@ -9875,7 +7668,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation>переміщення складного сплайну</translation>
     </message>
@@ -9883,52 +7675,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation>Новий файл мірок</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation>Тип мірок:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation>Одинця виміру:</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation>Базовий розмір:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation>Базовий зріст:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation>Індивідуальні</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>Сантиметри</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>Дюйми</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9936,87 +7718,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished">Лист</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished">Legal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished">Рулон 24 дюйми</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished">Рулон 30 дюймів</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished">Рулон 36 дюймів</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished">Рулон 42 дюйми</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished">Рулон 44 дюйми</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished">Користувацькі</translation>
     </message>
@@ -10024,887 +7789,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished">Ім&apos;я не може бути пустим</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished">Літера:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished">Символ креслення</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished">Розташування:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished">на згиб</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished">Обертання:</translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished">Заборонити відображення деталі в розкладці.</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished">Головний контур</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished">Всі обєкти в контурі повинні слідувати за годинниковою стрілкою.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished">Готовий!</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished">Внутрішні шляхи</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">Прибавка на шви є частиною основного контуру</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished">Вбудована</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Ховати головний контур якщо прибавка на шви була увімкнута</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished">Автоматична</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished">По замовчуванню</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">Ширина:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished">Значення</translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished">Розрахунок</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished">Вузли</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished">Вузел:</translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished">Перед:</translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished">Повернутися до ширини по замовчуванню</translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished">Після:</translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished">Кут:</translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished">Користувацькі</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished">Стартова точка:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished">Кінцева точка:</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished">Вставити як:</translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Довжина:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished">Тип:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished">Надсічка:</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished">Тип</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished">Пряма</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished">Бісектриса</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished">Перетин</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished">Протилежний напрямок</translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished">Надсічка</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished">Виключений</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">Видалити</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished">Параметри</translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished">Помилка. Не вдалося зберегти контур деталі.</translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished">Безкінечний/не визначений результат</translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished">Довжина повинна додатнє значення</translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">Помилка</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished">Помилка синтаксичного аналізу: %1</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished">Редагувати довжину</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished">Редагувати кут</translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished">Редагувати висоту</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished">Редагувати ширину</translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Поточна прибавка на шви</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished">Редагувати ширину прибавки на шви</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished">Редагувати ширину прибавки на шви перед</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished">Редагувати ширину прибавки на шви після</translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished">Нитка основи</translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished">Потрібно більше точок!</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished">Одна точка не може бути використана два рази підряд!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished">Кожна точка в контурі повинна бути унікальною!</translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished">Пусто</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished">головний контур</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished">користувацька прибавка на шви</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished">В обидві сторони</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished">Тільки верхня</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished">Тільки нижня</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">Шляхи</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished">Мітки</translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation>Центр:</translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation>Внизу праворуч:</translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation>Верхнє:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation>Нижнє:</translation>
     </message>
@@ -10912,218 +8424,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished">Поточна прибавка на шви</translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished">перемістити мітку деталі</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished">змінити розмір мітки деталі</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished">повернути мітку деталі</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished">перемістити мітку деталі</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished">змінити розмір мітки деталі</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished">повернути мітку деталі</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished">перемістити нитку основи</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished">змінити розмір нитки основи</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished">обернути нитку основи</translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">Видалити</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11131,27 +8591,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11159,77 +8614,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11237,139 +8677,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished">Форма</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished">Iмя</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11377,62 +8772,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished">Виберіть точку на горизонталі</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished">Імя:</translation>
     </message>
@@ -11440,316 +8823,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation>Інтервал:</translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>Мова інтерфейсу:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation>Одиниця виміру по замовчуванню:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>Одиниці вимірювання по замовчуванню були оновлені і будуть використанні як основні наступного разу при створенні нової викрійки.</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation>Сантиметри</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>Дюйми</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished">Відмінити</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished">Email:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11757,582 +9074,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished">Точка</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">Лінія</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished">Крива</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished">Дуга</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished">Операції</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished">Деталь</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished">Розкладка</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished">Графічний вивід</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished">Розмір:</translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">Ширина:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished">Експорт</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation>Шляхи, що використовує Валентина</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation>Контур</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation>По замовчуванню</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation>Редагувати</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation>Відкрити директорію</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation>Мої індивідуальні мірки</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation>Мої стандартні мірки</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation>Мої лекала</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation>Мої розкладки</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation>Мої шаблони</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12340,272 +9489,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation>Заборонити відзеркалення</translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation>За замовчуванням заборонити віддзеркалення для всіх нових створених деталей</translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation>За замовчуванням ховати головний контур якщо прибавка на шви була включена</translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished">Прибавка на шви</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished">Надсічки</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished">Тип:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished">Колір:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">Довжина:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">Ширина:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">Шляхи</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished">Мітки</translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">Ширина</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">Зріст</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished">Шаблони</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12613,7 +9692,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation>Базується на Qt %1 (%2, %3 bit)</translation>
     </message>
@@ -12621,155 +9699,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation>Створіть нове креслення для початку роботи.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation>см</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation>дюйми</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation>Властивості</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation>Значення</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation>піксел</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation>додати вузол</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation>Зміни застосовано.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Не правильне ім&apos;я тегу &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation>Не можу конвертувати toUInt параметр</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation>Не вдається перетворити параметр toBool</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation>Отримано пустий параметр</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation>Не можу конвертувати toDouble параметру</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation>Отримано неправильний id. Допускаються тільки id &gt; 0.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished">Тканина</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished">Підклада</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished">Дублерін</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished">Вирізати</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished">на згиб</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12777,15 +9824,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation>занадто мало аргументів для функції sum.</translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation>занадто мало аргументів для функції min.</translation>
@@ -12794,217 +9837,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Несподіваний токен &quot;$TOK$&quot; знейдено в позиції $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation>Внутрішня помилка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Невірне ім&apos;я функції, змінної або константи: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Невірний ідентифікатор бінарного оператора: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Невірний ідентифікатор інфіксного оператора: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>Невірний ідентифікатор постфіксного оператора: &quot;$TOK$&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation>Невірний покажчик на функцію зворотного виклику.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation>Вираз порожній.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation>Невірний покажчик на змінну.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Несподіваний оператор &quot;$TOK$&quot; знайдено в позиції $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Несподіваний кінець виразу в положенні $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Несподіваний розділювач аргументів у позиції $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Несподівана дужка &quot;$TOK$&quot;в позиції $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Несподівана функція &quot;$TOK$&quot;в позиції $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Несподіване значення &quot;$TOK$&quot; знайдено в позиції $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Несподівана змінна &quot;$TOK$&quot; знайдена в позиції $POS$</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Аргументи функції використовуються без функції (позиція: $POS$)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation>Відсутня дужка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Занадто багато параметрів для функції &quot;$TOK$&quot; у виразі в позиції $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Занадто мало параметрів для функції &quot;$TOK$&quot; у виразі в позиції $POS$</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation>Ділення на нуль</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation>Помилка домену</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation>Конфлікт імені</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation>Неправильне значення для визначення пріоритетів оператора (повинно бути більше або дорівнює нулю).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>назначений користувачем бінарний оператор &quot;$TOK$&quot; конфліктує з вбудованим оператором.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Несподіваний рядковий токен, що знаходиться в позиції $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Незавершений рядок, починаючи з позиції $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation>Функція, що приймає рядковий тип, викликана з не рядковим типом аргументу.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation>Рядкове значення використовується там, де очікується числовий параметр.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation>Не знайдено підходящого перевантаження оператора &quot;$TOK$&quot;в позиції $POS$.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation>Результат функції рядоковий.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation>Помилка синтаксичного аналізу.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation>Десятковий роздільник ідентичний роздільнику аргументів функції.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation>&quot;$TOK$&quot; оператор повинен передувати закриваючій дужці.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation>Для оператора If-then-else відсутній пункт else</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation>Неправильне положення двокрапки в позиції $POS$</translation>
@@ -13013,7 +10020,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13021,7 +10027,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished">перейменувати лекало</translation>
     </message>
@@ -13029,12 +10034,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13042,7 +10045,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation>зберегти параметри деталі</translation>
     </message>
@@ -13050,7 +10052,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation>зберегти параметри контуру</translation>
     </message>
@@ -13058,7 +10059,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation>зберегти параметри інструменту</translation>
     </message>
@@ -13066,88 +10066,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">Мова</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">Мова інтерфейсу:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished">Система створення викрійок</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished">Система:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">Автор:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished">Книга:</translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished">Редагування мірок</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished">Скинути попередження</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished">Панель інструментів</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished">Текст відображається під іконкою (рекомендується для новачків).</translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished">Стандартний зріст і розмір</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished">Висота:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished">Розмір:</translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13155,52 +10137,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished">Тип</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished">Контур</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished">По замовчуванню</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished">Редагувати</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished">Відкрити директорію</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished">Мої індивідуальні мірки</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished">Мої стандартні мірки</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished">Мої шаблони</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13208,102 +10180,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished">Одинці виміру:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished">Мова інтерфейсу:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Сантиметри</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Дюйми</translation>
     </message>
@@ -13311,92 +10262,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished">Одинці виміру:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished">Мова інтерфейсу:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">Сантиметри</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">Дюйми</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13404,12 +10336,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13417,1071 +10347,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished">Файл</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">Новий</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished">Відкрити</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">Зберегти</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished">Зберегти як</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished">Друк</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished">Редагувати</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished">Відмінити</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished">Мітки</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">Мірки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished">Відкрити SeamlyMe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished">Ctrl+E</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished">Точка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">Лінія</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished">Операції</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished">Поворот</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished">Перемістити</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished">Зображення</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished">Перейменувати</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">Видалити</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished">Деталь</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished">Розкладка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished">Історія</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished">Допомога</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14489,12 +11202,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14502,42 +11213,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14545,7 +11248,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14553,7 +11255,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14561,819 +11262,626 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Виберіть Новий для створення файлу мірок.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation>Позначення</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation>Розраховане значення</translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation>Формула</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation>Базове значення</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation>В розмірах</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation>В ростах</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation>Деталь</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation>Імя:</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation>Формула:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation>Базове значення:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation>В розмірах:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation>В ростах:</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation>Опис:</translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation>Перемістити мірку вгору</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation>Перемістити мірку вниз</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation>Розраховане значення:</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation>Повне ім&apos;я:</translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>Інформація</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation>Тип мірок</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation>Шлях:</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation>Показати в Провіднику</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation>Базовий розмір:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation>Значення базового розміру</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation>Базовий зріст:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation>Значення базового росту</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation>Імя:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation>Прізвище:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation>Дата народження:</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>Email:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>Примітки:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation>Файл</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation>Вікно</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>Допомога</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>Мірки</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation>Меню</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation>Градація</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation>Відкрити індивідуальні ...</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>Зберегти</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation>Зберегти як ...</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation>Про &amp;Qt</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation>Про SeamlyMe</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>Новий</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation>Додати відомі</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation>Додати спеціальні</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation>Тільки читання</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>База даних</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation>Показати інформацію про всі відомі мірки</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation>Властивості</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation>безіменний %1</translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>Цей файл вже відкрито в іншому вікні.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation>Помилка файла.</translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation>Не вдалося зберегти файл</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation>Зберегти як</translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation>&amp;Нове вікно</translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation>Редагувати мірки</translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation>Порожнє поле.</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation>Помилка синтаксичного аналізу: %1</translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation>Індивідуальні мірки</translation>
     </message>
     <message>
-        <location line="-1492"/>
         <source>untitled</source>
         <translation>без імені</translation>
     </message>
     <message>
-        <location line="+1709"/>
         <source>Unsaved changes</source>
         <translation>Не збереженні змінення</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation>Мірки були змінені.
 Бажаєте зберегти зміни?</translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation>Пусте поле</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation>Значення</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation>Імпорт з викрійки</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation>Одиниці вимірювання викрійки:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation>Знайти:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation>Знайти попередній</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation>Ctrl+Shift+G</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation>Знайти наступний</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation>Неможливо заблокувати. Цей файл вже був відкритий в іншому вікні.</translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation>Файл містить неправильні мірки.</translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation>Невідомий формат файлу.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation>Повне ім&apos;я</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation>Файл &apos;%1&apos; не існує!</translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation>Неможливо змінити назву відомої мірки.</translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation>Неможливо знайти мірку &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation>Неможливо змінити повну назву відомої мірки.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation>Мастер функцій</translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation>Перемістити вище</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation>Перемістити нижче</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation>Видалити мірку</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation>невідомий</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation>чоловік</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation>жінка</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation>Стать:</translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation>Система конструювання:</translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation>Створити із існуючого ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation>Створити із існуючого файла</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation>Вибрати файл</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation>Діаграма мірок</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Невідома мірка&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Невідома мірка&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation>Про Qt</translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation>Файл ще не було збережено.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation>Пошук</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation>Ім&apos;я мірки у формулі</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation>Ім&apos;я мірки у формулі.</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation>Ім&apos;я мірки, зручне для сприйняття людиною.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>Зберегти...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>Не зберігати</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation>Файл блокування</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation>Файл блокування не може бути створений, не вистачає прав доступу.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation>Виникла невідома помилка, наприклад, повністю заповнений розділ заважає запису файла блокування.</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation>Експортувати до CSV</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation>Показати в програмі Finder</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation>Ім&apos;я клієнта</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation>Прізвище клієнта</translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation>Email клієнта</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation>Висота:</translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation>Розмір:</translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation>Всі файли</translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation>Документ мірок не має прав на запис.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation>Не вдалося встановити права для %1 на запис.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation>Не вдалося зберегти файл.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation>Не вдалося зберегти файл</translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation>тільки читання</translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation>Стандартні мірки</translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation>Недійсний результат. Значення безкінечність чи NaN, перевірте ваші розрахунки.</translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation>Пусто</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished">Друк</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation>Відкрити шаблон ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation>Ctrl+Alt+O</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+434"/>
         <source>Pattern files</source>
         <translation>Файли лекал</translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Цей файл вже відкритий в іншому вікні. Ігноруйте якщо ви хочете продовжити (не рекомендується, може призвести до втрати даних).</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Не вдалося створити lock файл через відсутність дозволів. Ігноруйте якщо хочете продовжити (не рекомендується, може призвести до втрати даних).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation>Сталася невідома помилка, наприклад переповнення розділу попередило запис lock файлу. Ігноруйте якщо бажаєте продовжити (не рекомендується, може призвести до втрати даних).</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15381,7 +11889,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15389,22 +11896,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15412,22 +11915,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15435,47 +11934,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">Перша точка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">Друга точка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished">Найвища точка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished">Найнища точка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished">Сама ліва точка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished">Сама права точка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished">Вертикальна вісь</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished">Горизонтальна вісь</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished">Лінія_</translation>
     </message>
@@ -15483,47 +11973,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished">Інструмент об&apos;єднання</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Чи ви справді хочете об&apos;єднати деталі?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished">Зберегти оригінальні деталі</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished">Виберіть другу точку</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished">Виберіть унікальну точку</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished">Виберіть точку на ребрі</translation>
     </message>
@@ -15531,7 +12012,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15539,17 +12019,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation>Не питати знову</translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation>Не &amp;питати знову</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation>Не по&amp;казувати знову</translation>
     </message>
@@ -15557,57 +12034,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation>Не вдалося отримати інформацію про версію.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation>За надто багато тегів &lt;%1&gt; у файлі.</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation>Версія &quot;%1&quot; має неправильне значення.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation>Версія &quot;0.0.0&quot; не дійсне.</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation>Не правильна весрія. Мінімально підтримувана %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation>Неправильна версія. Максимально підтримувана %1</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation>Помилка не унікальний id.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation>Не давлося змінити версію.</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation>Помилка створення резервної копії: %1.</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation>Неочікувана версія &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation>Помилка відкриття тимчасового файлу: %1.</translation>
     </message>
@@ -15615,7 +12081,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation>Не вдається розрізати криву</translation>
     </message>
@@ -15623,22 +12088,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished">Експортувати до CSV</translation>
     </message>
@@ -15646,13 +12107,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
@@ -15660,23 +12118,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation>Не можу знайти інструмент в таблиці.</translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation>Помилка створення чи оновлення групи</translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation>Нова група</translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15684,7 +12137,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15692,12 +12144,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
@@ -15705,283 +12155,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation>Підтвердіть видалення</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation>Ви дійсно хочете видалити?</translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation>Редагувати неправильну формулу</translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15989,302 +12382,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation>Розташування файла користувацьких мірок (режим експорту).</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation>Файл мірок</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation>Номер формату</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation>Номер шаблону</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation>Ширина аркушу</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation>Одиниця вимірюванния мірок</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation>Кут</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation>Автоматично обрізати невикористану довжину (режим експорту).</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation>Одиниці вимірювання розкладки (як для паперу, окрім пікселей, режим експорту).</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation>Одиниця вимірювання</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation>Ширина проміжку</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation>Тип групування</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation>Неможливо одночасно використовувати формат сторінки і явно вказаний розмір сторінки.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation>Повинні бути указані: висота, ширина та одиниці виміру.</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation>Неправильне значення повороту. Значення повинне бути одне із наперед визначених.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation>Обрано сторінку з невідомим шаблоном.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation>Не підтримувані одиниці вимірювання для паперу.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation>Не підтримувані одиниці вимірювання для розкладки.</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation>Параметри експорту можуть використовуватися тільки з одним вхідним файлом.</translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation>Параметр перевірки може бути використаний тільки для одного вхідного файлу.</translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation>Базове ім&apos;я експортуємих файлів розкладки. Використовуйте для консольного режиму експорту.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation>Базове ім&apos;я файлів розкладки</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation>Папка призначення</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation>Значення розміру</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation>Значення росту</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Ширина сторінки в поточних одиницях вимірювання, наприклад 12.0 (не може бути використана з &quot;%1&quot;, режим експорту).</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation>Висота сторінки в поточних одиницях вимірювання, наприклад 12.0 (не може бути використана з &quot;%1&quot;, режим експорту).</translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation>Неправильна градація значень розміру.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation>Неправильна градація значень росту.</translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation>Програма створення викрійок.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation>Файл лекала.</translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation>Ширина зазору повинна бути використана разом з одиницями виміру зсуву.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation>Ліве поле повинно бути використано разом з одиницями виміру сторінки.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation>Праве поле повинно бути використано разом з одиницями виміру сторінки.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation>Верхнє поле повинно бути використано разом з одиницями виміру сторінки.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation>Нижнє поле повинно бути використано разом з одиницями виміру сторінки.</translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation>Шлях до папки призначення виводу. За замовчуванням, це каталог, в якому була запущена програма.</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation>Одиниці вимірювання висоти та ширини сторінки (неможливо використовувати разом з &quot;%1&quot;, режим експорту). Допустимі значення: %2.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation>Ігнорувати поля друку (режим експорту). Вимикає значення ключей: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Встановлює всі поля в 0.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Ліве поле сторінки в поточних одиницях, наприклад, 3.0 (режим експорту). Якщо не встановлено, буде використане значення із принтера за замовчуванням. Або 0, якщо принтери не були виявлені. Значення будет проігноровано якщо був використан ключ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Праве поле сторінки в поточних одиницях, наприклад, 3.0 (режим експорту). Якщо не встановлено, буде використане значення із принтера за замовчуванням. Або 0, якщо принтери не були виявлені. Значення будет проігноровано якщо був використан ключ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Верхнє поле сторінки в поточних одиницях, наприклад, 3.0 (режим експорту). Якщо не встановлено, буде використане значення із принтера за замовчуванням. Або 0, якщо принтери не були виявлені. Значення будет проігноровано якщо був використан ключ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation>Нижнє поле сторінки в поточних одиницях, наприклад, 3.0 (режим експорту). Якщо не встановлено, буде використане значення із принтера за замовчуванням. Або 0, якщо принтери не були виявлені. Значення будет проігноровано якщо був використан ключ &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation>Обертання в градусах (одне із наперед заданих значень, режим експорту). Значення за замовчуванням 180. 0 - немає повороту. Допустимі значення: %1. Кожне значення показує скільки разів деталь буде повернута. Наприклад, 180 означає поворот два рази (360/180=2) на 180 градусів.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation>Об&apos;єднувати сторінки (якщо можливо). Максимальне значення обмежене QImage який підтримує тільки максимум 32768x32768 пікселів для зображення.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation>Зберігає довжину листа якщо встановлено (режим експорту). Опція наказує програмі використовувати максимально ширину листа. Якість розкладки при цьому може погіршитися.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation>Проміжок розкладки х2, виміряний у одиницях виміру розкладки (режим експорту). Встановлює відстань між деталями і деталлю і краєм листа.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation>Встановлює тип групування розкладки (режим експорту): %1.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation>Запускає програму в тестовому режимі. Програма в цьому режимі завантажує один файл лекала і мовчки завершується, не показуючи головне вікно. Ключ має пріорітет перед ключем &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation>Довжина зміщення розкладки у одиницях виміру розкладки (режим експорту). Опція показує як багато точок уздовж ребра буде створено під час створення розкладки.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation>Довжина зміщення</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation>Довжина зміщення має бути разом з одиницями виміру зміщення.</translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation>Номер вихідного формату (за замовчуванням = 0, режим експорту):</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation>Номер, відповідаючий шаблону (за замовчуванням = 0, режим експорту):</translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation>Відключити масштабування з високим розширенням. Викличте цю функцію якщо маєте проблему з масштабуванням (за замовчуванням масштабування увімкнено). Альтернативно ви можете використовувати перемену оточення %1.</translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16292,43 +12625,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation>мірки</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation>індивідуальні</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation>стандартні</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation>шаблони</translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16336,55 +12660,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation>Не можу знайти об&apos;єкт</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation>Не можу привести об&apos;єкт</translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation>Не можу знайти об&apos;єкт. Невідповідність типу.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation>Число вільних id вичерпано.</translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation>Не вдалося створити криву з типом &apos;%1&apos;</translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16392,12 +12703,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation>Не достатньо точок для створення кривої.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation>Цей сплайн не існує.</translation>
     </message>
@@ -16405,51 +12714,41 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation>Не можу відкрити файл%1:
 %2.</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation>Не можу відкрити файл схеми %1:\n%2.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation>Помилка валідації файлу %3 в рядку %1 стовпця %2</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation>Помилка розбору файлу %3 в рядку %1 стовпця %2</translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation>Не вдалося отримати вузол</translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation>Цей id не унікальний.</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation>Не вдалося завантажити файл схеми &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation>Не вдалося записати канонічний XML.</translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16457,27 +12756,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16485,7 +12779,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation>Виключення: %1</translation>
     </message>
@@ -16493,11 +12786,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
@@ -16505,7 +12793,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished">Формула:</translation>
     </message>
@@ -16513,7 +12800,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation>Деталь %1 не має форми.</translation>
     </message>
@@ -16521,7 +12807,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16529,12 +12814,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation>Вірно</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation>Невірно</translation>
     </message>
@@ -16542,12 +12825,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>Директорія</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>Відкрити файл</translation>
     </message>
@@ -16555,335 +12836,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation>Помилка парсингу файла.</translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation>Помилка, не можу конвертувати значення.</translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation>Помилка, пустий параметр.</translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>Помикла, неправильний id.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation>Помилка парсінгу файлу (std::bad_alloc).</translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation>Помилка створення чи оновлення простої точки</translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation>Помилка створення чи оновлення точки кінця відрізку</translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation>Помилка створення чи оновлення точки вздовж лінії</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation>Помилка створення чи оновлення точки плеча</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation>Помилка створення чи оновлення точки нормалі</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation>Помилка створення чи оновлення точки бісектриси</translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation>Помилка створення чи оновлення точки дотику</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation>Помилка створення чи оновлення модельної точки</translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation>Помилка створення чи оновлення висоти</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation>Помилка створення чи оновлення трикутника</translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation>Помилка створення чи оновлення точки розрізання кривої</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation>Помилка створення чи оновлення точки розрізаня складної кривої</translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation>Помилка створення чи оновлення точки розрізання дуги</translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation>Помилка створення чи оновлення точки перетину лінії і осі</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation>Помилка створення чи оновлення точки перетину кривої і осі</translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation>Помилка створення чи оновлення лінії</translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation>Помилка створення чи оновлення кривої</translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation>Помилка створення чи оновлення шляху кривих</translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation>Помилка створення чи оновлення модельної кривої</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation>Помилка створення чи оновлення модельного шляху кривих</translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation>Помилка створення чи оновлення дуги</translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation>Помилка створення чи оновлення модельної дуги</translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation>Помилка створення чи оновлення точки перетину дуг</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation>Помилка створення чи оновлення точки перетину кіл</translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation>Помилка створення чи оновлення точки кола та дотичної</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation>Помилка створення чи оновлення точки дуги та дотичної</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation>Помилка створення чи оновлення виточок</translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation>Не правильне ім&apos;я тегу &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation>Невідомий тип точки &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation>Невідомий тип сплайна &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation>Невідомий тип дуги &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation>Невідомий тип інструмента &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation>Помилка, не унікальний id.</translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation>Помилка створення чи оновлення точки перетину кривих</translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation>Помилка створення чи оновлення кривої</translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation>Помилка створення чи оновлення складної кривої</translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation>Помилка створення чи оновлення кубічної кривої безье</translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation>Помилка створення чи оновлення складної кубічної кривої безье</translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation>Помилка створення чи оновлення повороту</translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation>Невідома операція &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation>Помилка створення чи оновлення операції переміщення</translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation>Помилка створення чи оновлення точки перетину ліній</translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation>Помилка створення чи оновлення простої еліптичної дуги</translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation>Невідомий тип еліптичної дуги &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation>Помилка створення чи оновлення модельної еліптичної дуги</translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation>Контур без назви</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation>Помилка створення чи оновлення контуру деталі</translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16891,17 +13083,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation>Сітка ( %1 , %2 )</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation>Сторінка %1 з %2</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation>Аркуш %1 з %2</translation>
     </message>
@@ -16909,12 +13098,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation>лекала</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation>розкладки</translation>
     </message>
@@ -16922,14 +13109,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation>Не достатньо точок для створення кривої.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation>Цей сплайн не існує.</translation>
     </message>
@@ -16937,17 +13120,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Кут</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
@@ -16955,27 +13135,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16983,37 +13158,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17021,7 +13189,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
@@ -17029,12 +13196,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17042,32 +13207,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished">Дуга</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17075,18 +13234,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished">Крива</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17094,18 +13249,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished">Крива</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17113,7 +13264,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
@@ -17121,28 +13271,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17150,17 +13294,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Кут</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
@@ -17168,12 +13309,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Кут</translation>
     </message>
@@ -17181,7 +13320,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
@@ -17189,27 +13327,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Кут</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17217,17 +13350,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Кут</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
@@ -17235,7 +13365,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17243,12 +13372,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished">Перша точка лінії</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished">Друга точка лінії</translation>
     </message>
@@ -17256,27 +13383,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation>Точка центру</translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished">Кут</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17284,714 +13406,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation>Базова точка</translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation>Виточка</translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation>Базова точка:</translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation>Кут:</translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation>Точка центру:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation>Радіус:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation>Перший кут:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Другий кут:</translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation>Колір:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation>Третя точка:</translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Ім&apos;я точки 1:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation>Ім&apos;я точки 2:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation>Перша базова точка:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation>Друга базова точка:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation>Перша точка виточки:</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation>Дуга:</translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation>Крива:</translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation>Перша точка лінії:</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Друга точка лінії:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Центер дуги:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation>Перша дуга:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation>Друга дуга:</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation>Взяти:</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation>Перша крива:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation>Друга крива:</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation>Точка дотичної:</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation>Радіус кола:</translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation>Імя:</translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>С1: кут:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation>С1: довжина:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>С2: кут:</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation>С2: довжина:</translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation>Точка осі:</translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation>Суфікс:</translation>
     </message>
     <message>
-        <location line="-32"/>
         <source>Origin point:</source>
         <translation>Початкова точка:</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Axis type:</source>
         <translation>Тип вісі:</translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation>Кут обертання:</translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation>Четверта точка:</translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Поворот</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished">Перемістити</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Координати</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished">Друга точка виточки:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished">Третя точка виточки:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">Лінія</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished">Перша лінія</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished">Друга лінія</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished">Обертання:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation>Центр:</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished">Дуга_</translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished">Спл_</translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished">Лінія_</translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation>Точка центру</translation>
     </message>
@@ -17999,12 +13805,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18012,17 +13816,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished">Кут</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
@@ -18030,12 +13831,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18043,12 +13842,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18056,12 +13853,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18069,17 +13864,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">Довжина</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished">Кут</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished">імя</translation>
     </message>
@@ -18087,1552 +13879,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation>Bunka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation>Bunka Fashion College</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation>Основи конструювання одягу</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation>Barnfield and Richard</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation>Jo Barnfield and Andrew Richards</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation>Pattern Making Primer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation>Friendship/Жінки</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation>Elizabeth Friendship</translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation>Morris, K.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation>Karen Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation>Sewing Lingerie that Fits</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation>Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation>Lucia Mors de Castro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation>Patternmaking in Practic (Практичне виготовлення викрійок)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation>Kim &amp; Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation>Injoo Kim and Mykyung Uh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation>Apparel Making in Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation>Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation>Norah Waugh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation>Corsets and Crinolines</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation>Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation>Frances Grimble</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation>Fashions of the Gilded Age</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation>Thornton&apos;s International System</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation>The Great War: Styles and Patterns of the 1910s (Велика війна: стилі та моделі 1910-х років)</translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation>Hillhouse &amp; Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation>Marion S. Hillhouse and Evelyn A. Mansfield</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation>Dress Design: Draping and Flat Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation>Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation>Esther Kaplan Pivnick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation>How to Design Beautiful Clothes: Designing and Pattern Making</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation>Minister &amp; Son</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation>Edward Minister &amp; Son, ed. R. L. Shep</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation>The Complete Guide to Practical Cutting (1853)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation>Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation>Gertrude Strickland</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation>A Tailoring Manual (Посібник по шиттю)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation>Loh &amp; Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation>May Loh and Diehl Lewis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternless Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation>Morris, F. R.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation>F. R. Morris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation>Ladies Garment Cutting and Making (Кроєння та створення жіночого одягу)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation>Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation>Gertrude Mason</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation>Gertrude Mason&apos;s Patternmaking Book</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation>Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation>K. Kimata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation>Master Designer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation>The Master Designer (Chicago, IL)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation>Master Designer&apos;s System of Designing, Cutting and Grading</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation>Kopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation>How to Draft Basic Patterns</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation>Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation>Doris Ekern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation>Slacks Cut-to-Fit for Your Figure</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation>Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation>Sarah J. Doyle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation>Sarah&apos;s Key to Pattern Drafting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation>Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation>Karla J. Shelton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation>Design and Sew Jeans (Кроєння та пошиття джинсів)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation>Lady Boutique</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Lady Boutique magazine (Japan)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation>Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation>M. Rohr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation>Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation>Dorothy Moore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation>Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation>Bina Abling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation>Integrating Draping, Drafting and Drawing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation>Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation>Sue S. Fukomoto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation>Dressmaking International</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation>Dressmaking International magazine (Японія)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation>Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation>Mabel D. Erwin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation>Практичне проектування одягу</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation>Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation>E. L. G. Gough</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>Принципи кроєння одягу</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation>Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation>Elizabeth M. Allemong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation>European Cut</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation>McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation>Donald H. McCunn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation>Як створити ваші власні викрійки для шиття</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation>Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation>Zarapkar System of Cutting</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation>Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation>Philip Kunick</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation>Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation>Jack Handford</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation>Професійне створення викрійок для модельєрів: жіночий одяг, чоловічий повсякденний одяг</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation>Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation>R. I. Davis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation>Чоловічі костюми, кроєння та мода 17 та 18 столітть</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation>MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation>Jason MacLochlainn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation>The Victorian Tailor: An Introduction to Period Tailoring</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation>Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation>Helen Joseph-Armstrong</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation>Patternmaking for Fashion Design</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation>Supreme System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation>Frederick T. Croonberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation>Sugino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation>Створення одягу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation>Створення викрійок, тома I, II и III (Японія)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation>Centre Point System</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation>Louis Devere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation>The Handbook of Practical Cutting on the Centre Point System</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation>Aldrich/Чоловіки</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation>Winifred Aldrich</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation>Створення викрійок чоловічого одягу за мірками</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation>Aldrich/Жінки</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation>Створення викрійок жіночого одягу за мірками</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation>Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation>Gareth Kershaw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation>Створення викрійок для чоловічого одягу</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation>Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation>Teresa Gilewska</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation>Нариси викрійок за модою: основи</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation>Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation>Dennic Chunman Lo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation>Створення викрійок</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation>Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation>Natalie Bray</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation>Проектування викрійок одягу: основні принципи кроєння та примірки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation>Knowles/Чоловіки</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation>Lori A. Knowles</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation>Практичне керівництво по створенню викрійок для модельєрів: чоловіки</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation>Friendship/Чоловіки</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation>Викрійки чоловічих костюмів</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation>Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation>P. Clement Brown</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation>Мистецтво одягу</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation>Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation>Jno. J. Mitchell</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation>ГОСТ 17917-86</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation>Міністерство легкої промисловості СССР</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation>Стандартні фігури хлопчиків</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation>Eddy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation>Josephine F. Eddy and Elizabeth C. B. Wiley</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation>Проектування викрійок та одягу</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation>Knowles/Жінки</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation>Практичне керівництво по створенню викрійок для модельєрів: діти, дівчини та жінки</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation>Закрійник американського одягу</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation>Внутрішня</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation>Команда Seamly2D</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation>Внутрішній стандарт Seamly2D</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation>см</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation>мм</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation>дюйм</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>СкСпл</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Кут1СклСпл</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>Кут2СклСпл</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation>Сегм_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation>ПоточнаДовжина</translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation>Сг</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation>Р</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>К1ДовжинаСклСпл</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation>К2ДовжинаСклСпл</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation>ПоточнаПрибавкаНаШви</translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation type="unfinished">sin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation type="unfinished">cos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation type="unfinished">tan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation type="unfinished">asin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation type="unfinished">acos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation type="unfinished">atan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation type="unfinished">sinh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation type="unfinished">cosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation type="unfinished">tanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation type="unfinished">acosh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation type="unfinished">atanh</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation>atanD</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation>log2</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation type="unfinished">log10</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation type="unfinished">log</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation type="unfinished">ln</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation type="unfinished">exp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation type="unfinished">sqrt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation type="unfinished">sign</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation type="unfinished">rint</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation type="unfinished">abs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">max</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">sum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished">avg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation type="unfinished">fmod</translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">М_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Лінія_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">КутЛінії_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Дуга_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Спл_</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">РадіусДуги_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Кут1Дуги_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Кут2Дуги_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Кут1Спл_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">Кут2Спл_</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">К1ДовжинаСпл_</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished">К2ДовжинаСпл_</translation>
@@ -19641,17 +15176,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation>&lt;b&gt;Складна крива&lt;/b&gt;: виберіть сім чи більше точок</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation>&lt;b&gt;Складна крива&lt;/b&gt;: виберіть більше точок для завершення сегменту</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19659,7 +15191,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19667,7 +15198,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19675,7 +15205,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19683,12 +15212,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19696,7 +15223,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19704,7 +15230,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19712,17 +15237,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation>&lt;b&gt;Складна крива&lt;/b&gt;: виберіть три чи більше точок</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19730,47 +15252,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>ВІДЛАДКА:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>ПОПЕРЕДЖЕННЯ:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation>КРИТИЧНО:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation>ФАТАЛЬНО:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>ІНФО:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation>Попердження</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation>Інформація</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19778,47 +15291,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>ВІДЛАДКА:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>ПОПЕРЕДЖЕННЯ:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation>КРИТИЧНО:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation>ФАТАЛЬНО:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>ІНФО:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished">Попердження</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished">Інформація</translation>
     </message>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -4,193 +4,150 @@
 <context>
     <name>About2DAppDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+41"/>
         <source>About Seamly2D</source>
         <translation>关于Seamly2D</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+113"/>
         <source>Web site : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Right to left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.ui" line="+66"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Copy build data to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seamly 2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+428"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-310"/>
-        <location line="+380"/>
         <source>Build date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Qt Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+381"/>
-        <location line="+125"/>
         <source>CPU:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
-        <location line="+289"/>
         <source>Compiler:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Revision:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-499"/>
-        <location line="+615"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Architecture</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>OS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>OS Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Decimal point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Script name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>System codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Text direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Positive sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Negative sign:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="-45"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -198,7 +155,6 @@
 <context>
     <name>AddDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_draftblock.cpp" line="+67"/>
         <source>add draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,7 +162,6 @@
 <context>
     <name>AddGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addgroup.cpp" line="+69"/>
         <source>add group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -214,7 +169,6 @@
 <context>
     <name>AddGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/add_groupitem.cpp" line="+43"/>
         <source>Add item to group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +176,6 @@
 <context>
     <name>AddPiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addpiece.cpp" line="+64"/>
         <source>add piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +183,6 @@
 <context>
     <name>AddToCalc</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/addtocalc.cpp" line="+68"/>
         <source>add object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -238,12 +190,10 @@
 <context>
     <name>AddToGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/addtogroup_dialog.ui" line="+32"/>
         <source>Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -251,22 +201,18 @@
 <context>
     <name>AnchorPointDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/anchorpoint_dialog.ui" line="+20"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Anchor Point tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -274,42 +220,34 @@
 <context>
     <name>Application2D</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="+350"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -317,122 +255,98 @@
 <context>
     <name>ApplicationME</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="+302"/>
         <source>Error parsing file. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error bad id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error can&apos;t convert value. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error empty parameter. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Error wrong id. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Something&apos;s wrong!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Parser error: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Exception thrown: %1. Program will be terminated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
         <source>Seamly2D&apos;s measurements editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The base size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Set pattern file unit: cm, mm, inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The pattern unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Invalid base size argument. Must be cm, mm or inch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Can&apos;t begin to listen for incoming connections on name &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Test mode doesn&apos;t support Opening several files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
         <source>Open with the base size. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Invalid base height argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Invalid base size argument. Must be %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Open with the base height. Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Use for unit testing. Run the program and open a file without showing the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -440,7 +354,6 @@
 <context>
     <name>CalculatorDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/calculator_dialog.ui" line="+35"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,106 +361,78 @@
 <context>
     <name>CalculatorUtil</name>
     <message>
-        <location filename="../../src/libs/vwidgets/calculator/calculator.cpp" line="+88"/>
-        <location line="+210"/>
         <source>.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>±</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>MC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>MS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+307"/>
         <source>÷</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-306"/>
-        <location line="+304"/>
         <source>×</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-303"/>
-        <location line="+208"/>
-        <location line="+93"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-300"/>
-        <location line="+298"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-296"/>
-        <location line="+74"/>
         <source>Sqrt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
-        <location line="+79"/>
         <source>x²</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+80"/>
         <source>1/x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
         <source>=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>####</source>
         <translation type="unfinished"></translation>
     </message>
@@ -555,12 +440,10 @@
 <context>
     <name>DecimalChartDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/decimalchart_dialog.ui" line="+29"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -576,7 +459,6 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -588,7 +470,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelGroup</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delgroup.cpp" line="+69"/>
         <source>delete group</source>
         <translation type="unfinished"></translation>
     </message>
@@ -596,7 +477,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DelTool</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deltool.cpp" line="+66"/>
         <source>delete tool</source>
         <translation>删除工具</translation>
     </message>
@@ -604,7 +484,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeleteDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/delete_draftblock.cpp" line="+69"/>
         <source>delete draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -612,7 +491,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DeletePiece</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/deletepiece.cpp" line="+75"/>
         <source>delete tool</source>
         <translation type="unfinished">删除工具</translation>
     </message>
@@ -620,52 +498,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAboutSeamlyMe</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+26"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>SeamlyMe version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+171"/>
         <source>Build revision: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.ui" line="+28"/>
         <source>This program is part of Seamly2D project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Downloading installer %p% complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="-81"/>
         <source>Cannot open your default browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Web site : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,107 +541,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.cpp" line="+216"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Edit length</source>
         <translation>修长度</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogalongline.ui" line="-93"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="-296"/>
         <source>First point:</source>
         <translation>第一点:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>First point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Second point:</source>
         <translation>第二点:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Second point of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+286"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-577"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-473"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -781,137 +628,103 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="+319"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.cpp" line="+526"/>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-144"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarc.ui" line="-481"/>
         <source>Radius:</source>
         <translation>半径:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-417"/>
-        <location line="+197"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-225"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-509"/>
         <source>Center point:</source>
         <translation>中点:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+790"/>
         <source>Color:</source>
         <translation>颜色:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-792"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-806"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -919,126 +732,95 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="+308"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp" line="+374"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit the arc length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+18"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Length can&apos;t be equal 0</source>
         <translation>长度不能是0</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogarcwithlength.ui" line="-482"/>
         <source>Radius:</source>
         <translation>半径:</translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-418"/>
-        <location line="+197"/>
-        <location line="+198"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-295"/>
-        <location line="+395"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="-326"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+198"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="-507"/>
         <source>Center point:</source>
         <translation>中点:</translation>
     </message>
     <message>
-        <location line="+815"/>
         <source>Color:</source>
         <translation>颜色:</translation>
     </message>
     <message>
-        <location line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-786"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-803"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1046,107 +828,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogBisector</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="+441"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.cpp" line="+221"/>
         <source>Select second point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select third point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>修长度</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogbisector.ui" line="-90"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="-349"/>
         <source>First point:</source>
         <translation>第一点:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>第二点:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+311"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-642"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1154,77 +915,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezier</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+452"/>
         <source>Color:</source>
         <translation>颜色:</translation>
     </message>
     <message>
-        <location line="-387"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>First point:</source>
         <translation>第一点:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>第二点:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp" line="+211"/>
         <source>Select the second point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select the third point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the fourth point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezier.ui" line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-314"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+257"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1232,57 +978,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+106"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>List of points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Color:</source>
         <translation>颜色:</translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp" line="+313"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui" line="+160"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-205"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1290,98 +1025,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="+373"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp" line="+310"/>
         <source>Select axis point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui" line="-81"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-249"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+362"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-584"/>
         <source>Intersect - Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-374"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1389,67 +1105,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.cpp" line="+119"/>
         <source>Edit length</source>
         <translation>修长度</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutarc.ui" line="-90"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1457,67 +1160,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="+323"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>修长度</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutspline.ui" line="-90"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-99"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1525,67 +1215,54 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="+317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp" line="+218"/>
         <source>Edit length</source>
         <translation>修长度</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui" line="-90"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-93"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1593,22 +1270,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogDateTimeFormats</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.ui" line="+14"/>
         <source>Label date time editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert a format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogdatetimeformats.cpp" line="+119"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,170 +1289,122 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="+445"/>
         <source>Radius1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-787"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-664"/>
-        <location line="+191"/>
         <source>Calulation</source>
         <translation type="unfinished">打算</translation>
     </message>
     <message>
-        <location line="-226"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-660"/>
         <source>Radius2:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1090"/>
         <source>Center point:</source>
         <translation type="unfinished">中点:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select center point of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp" line="+458"/>
-        <location line="+12"/>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Error</source>
         <translation type="unfinished">错误</translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+12"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
-        <location line="+5"/>
         <source>Angles equal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Edit radius1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit radius2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit first angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogellipticalarc.ui" line="-118"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-193"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+567"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;First Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Second Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1787,106 +1412,83 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="+332"/>
-        <location line="+206"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.cpp" line="+192"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation>修长度</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogendline.ui" line="-296"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+206"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-238"/>
-        <location line="+209"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-100"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-321"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+521"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-743"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+406"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1894,47 +1496,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogExportToCSV</name>
     <message>
-        <location filename="../../src/libs/vmisc/dialogs/dialogexporttocsv.ui" line="+17"/>
         <source>Export options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>With header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Codec:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Separator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Semicolon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Space</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,72 +1535,58 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.cpp" line="+261"/>
         <source>Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogheight.ui" line="+118"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-382"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>First point:</source>
         <translation type="unfinished">第一点:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation type="unfinished">第二点:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2015,356 +1594,274 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogInternalPath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui" line="+26"/>
         <source>Internal Path Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create name for your path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Type:</source>
         <translation type="unfinished">类型:</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row to bottom of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>The path is a cut contour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cut on fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Staus:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+1238"/>
         <source>Ready!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-116"/>
         <source>Seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Width:</source>
         <translation type="unfinished">宽度:</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>Calculation</source>
         <translation type="unfinished">打算</translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+236"/>
-        <location line="+199"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+199"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
-        <location line="+199"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
-        <location line="+618"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-572"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="+5"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select to designate the corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Geomtery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show second notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>Length:</source>
         <translation type="unfinished">长度:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp" line="-956"/>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location line="+344"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Internal path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+342"/>
         <source>You need more points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>List of details is empty!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Please, select a detail to insert into!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2372,28 +1869,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLayoutProgress</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+115"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+17"/>
         <source>Create a Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="-42"/>
-        <location line="+31"/>
         <source>Arranged workpieces: %1 from %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.ui" line="+19"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Finding best position for workpieces. Please, wait.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialoglayoutprogress.cpp" line="+14"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,58 +1892,46 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="+278"/>
         <source>Select second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.ui" line="+112"/>
         <source>First point:</source>
         <translation>第一点:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second point:</source>
         <translation>第二点:</translation>
     </message>
     <message>
-        <location line="+90"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-341"/>
         <source>Line - Between Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogline.cpp" line="-129"/>
-        <location line="+87"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2460,64 +1939,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="+129"/>
         <source>First line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.cpp" line="+136"/>
         <source>Select second point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point of second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersect.ui" line="-93"/>
-        <location line="+122"/>
         <source>First point:</source>
         <translation>第一点:</translation>
     </message>
     <message>
-        <location line="-78"/>
-        <location line="+122"/>
         <source>Second point:</source>
         <translation>第二点:</translation>
     </message>
     <message>
-        <location line="-298"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2525,123 +1990,99 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+423"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-215"/>
         <source>First point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+328"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select axis point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="-53"/>
         <source>Axis Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp" line="+80"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui" line="+87"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-625"/>
         <source>Intersect - Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>First point:</source>
         <translation type="unfinished">第一点:</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second point:</source>
         <translation type="unfinished">第二点:</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+179"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-518"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2649,22 +2090,18 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMDataBase</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.ui" line="+91"/>
         <source>Measurements</source>
         <translation>尺寸</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>ME Database - Add known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2672,47 +2109,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="+20"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.cpp" line="+214"/>
         <source>Select axis rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Select axis rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui" line="-99"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,47 +2148,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui" line="+20"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmirrorbyline.cpp" line="+210"/>
         <source>Select first mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select first mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Select second mirror line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Select second mirror line point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2768,93 +2187,71 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogMove</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+251"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-360"/>
-        <location line="+169"/>
-        <location line="+168"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>Length:</source>
         <translation type="unfinished">长度:</translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="+406"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit length</source>
         <translation type="unfinished">修长度</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="+430"/>
         <source>Calculation</source>
         <translation type="unfinished">打算</translation>
     </message>
     <message>
-        <location line="-499"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Origin Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+400"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.cpp" line="-287"/>
-        <location line="+356"/>
         <source>Center point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogmove.ui" line="-238"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+337"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotation Angle Calculation&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot; style=&quot;vertical-align: middle;&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,42 +2259,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNewPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+52"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="+142"/>
         <source>Centimeters</source>
         <translation>公分</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation>英寸</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="-10"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique pattern piece name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.cpp" line="-1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialognewpattern.ui" line="+18"/>
         <source>Draft block name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,107 +2294,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogNormal</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="+393"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.cpp" line="+214"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Edit length</source>
         <translation>修长度</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialognormal.ui" line="-87"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="-290"/>
         <source>First point:</source>
         <translation>第一点:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>第二点:</translation>
     </message>
     <message>
-        <location line="+439"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-552"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+223"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;table border=&quot;0&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;&quot; width=&quot;370&quot; cellspacing=&quot;2&quot; cellpadding=&quot;0&quot;&gt;&lt;tr&gt;&lt;td width=&quot;300&quot;&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Rotatation Angle&lt;/span&gt;&lt;br/&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an angle means counter-clockwise while a negative value means the clockwise direction. &lt;br/&gt;&lt;br/&gt;Rotation angle is added to the angle of the perpendicular.&lt;/p&gt;&lt;/td&gt;&lt;td style=&quot; vertical-align:middle;&quot;&gt;&lt;p align=&quot;right&quot;&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3013,210 +2381,166 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPatternProperties</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+105"/>
         <source>Pattern description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Heights and Sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>All heights (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+457"/>
         <source>All sizes (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-540"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+933"/>
         <source>Security</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open only for read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1039"/>
         <source>Call context menu for edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+7"/>
         <source>Change image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Save image to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Image for pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
-        <location line="+46"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-114"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="-776"/>
         <source>&lt;Empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="+1177"/>
         <source>Pattern name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Pattern number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Company/Designer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Customer name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1126"/>
         <source>From multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>Pattern</source>
         <translation>样板</translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>For technical notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1022"/>
-        <location line="+46"/>
         <source>Label data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Label template:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Date format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Time format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+781"/>
         <source>Save label data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label data were changed. Do you want to save them before editing label template?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.ui" line="-1351"/>
         <source>Pattern preferences</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3224,47 +2548,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.cpp" line="+171"/>
         <source>Select an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui" line="+124"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3272,87 +2587,70 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="+456"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp" line="+208"/>
         <source>Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofcontact.ui" line="-87"/>
         <source>Radius:</source>
         <translation>半径:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="-358"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-113"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-229"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3360,47 +2658,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.cpp" line="+173"/>
         <source>Select second an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui" line="+124"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-198"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3408,52 +2697,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="+133"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.cpp" line="+198"/>
         <source>Select second curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui" line="-166"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3461,27 +2740,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogPreferences</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpreferences.ui" line="+93"/>
         <source>Pattern</source>
         <translation>样板</translation>
     </message>
     <message>
-        <location line="-61"/>
         <source>Application Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3489,62 +2763,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+20"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+222"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-146"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="+354"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="-76"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Rotation pt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.cpp" line="-127"/>
         <source>Select rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Select rotation point that is not part of the list of objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogrotation.ui" line="+168"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;table width = 370&gt;&lt;tr&gt;&lt;td align = left width =300&gt;&lt;b&gt;Angle Calculation&lt;/b&gt;&lt;br&gt;Angles are specified in degrees, i.e. a full circle equals 360 deg. Positive values for an  angle means counter-clockwise while a negative value means the clockwise direction. Zero degrees is at the 3 o&apos;clock position.&lt;/td&gt;&lt;td align = right valign = middle&gt;&lt;img src=&quot;:/icon/64x64/rotation.png&quot;/&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
@@ -3553,17 +2815,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSeamlyMePreferences</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogseamlymepreferences.ui" line="+26"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>File Paths</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,107 +2830,86 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="+426"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp" line="+220"/>
         <source>Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select second point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>Edit length</source>
         <translation>修长度</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui" line="-87"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Calculation</source>
         <translation>打算</translation>
     </message>
     <message>
-        <location line="-340"/>
         <source>First point:</source>
         <translation>第一点:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Second point:</source>
         <translation>第二点:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+302"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-627"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+218"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3679,47 +2917,38 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSinglePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsinglepoint.ui" line="+141"/>
         <source>Coordinates on the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
         <source>Base Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>X coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Y coordinate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-128"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3727,148 +2956,106 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+438"/>
         <source>First point</source>
         <translation>第一点</translation>
     </message>
     <message>
-        <location line="+409"/>
         <source>Second point</source>
         <translation>第二点</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+211"/>
         <source>Select last point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-466"/>
         <source>Color:</source>
         <translation>颜色:</translation>
     </message>
     <message>
-        <location line="-259"/>
         <source>First point:</source>
         <translation>第一点:</translation>
     </message>
     <message>
-        <location line="+576"/>
-        <location line="+409"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-941"/>
         <source>Second point:</source>
         <translation>第二点:</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="+321"/>
         <source>Invalid spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="+420"/>
-        <location line="+409"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-629"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.cpp" line="-199"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">错误</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogspline.ui" line="-565"/>
-        <location line="+197"/>
-        <location line="+212"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished">打算</translation>
     </message>
     <message>
-        <location line="-972"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,163 +3063,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+191"/>
         <source>List of points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+282"/>
         <source>Select point of curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+177"/>
         <source>Color:</source>
         <translation>颜色:</translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+312"/>
         <source>First control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+262"/>
-        <location line="+413"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Second control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-772"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+502"/>
         <source>Invalid spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="+424"/>
-        <location line="+413"/>
         <source>Length:</source>
         <translation>长度:</translation>
     </message>
     <message>
-        <location line="-362"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-633"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-551"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="-234"/>
         <source>Edit first control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit first control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Edit second control point length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
-        <location line="+31"/>
         <source>Error</source>
         <translation type="unfinished">错误</translation>
     </message>
     <message>
-        <location line="-30"/>
-        <location line="+31"/>
         <source>Length can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+152"/>
         <source>Not used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.ui" line="-569"/>
-        <location line="+197"/>
-        <location line="+216"/>
-        <location line="+197"/>
         <source>Calculation</source>
         <translation type="unfinished">打算</translation>
     </message>
     <message>
-        <location line="-990"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-230"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogsplinepath.cpp" line="+1"/>
         <source>Result value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4040,108 +3182,78 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTool</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtool.cpp" line="+757"/>
-        <location line="+4"/>
-        <location line="+21"/>
-        <location line="+4"/>
-        <location line="+31"/>
-        <location line="+19"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+15"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location line="-105"/>
-        <location line="+26"/>
-        <location line="+29"/>
         <source>Empty field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Value can&apos;t be 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-495"/>
         <source>First point</source>
         <translation>第一点</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second point</source>
         <translation>第二点</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+326"/>
         <source>by length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by points intersetions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge symmetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by first edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>by second edge right angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Value can&apos;t be less than 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Result Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4149,62 +3261,50 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTriangle</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.cpp" line="+128"/>
         <source>Select second point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtriangle.ui" line="+193"/>
         <source>First point:</source>
         <translation>第一点:</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Second point:</source>
         <translation>第二点:</translation>
     </message>
     <message>
-        <location line="-211"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-82"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4212,79 +3312,62 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogTrueDarts</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.cpp" line="+254"/>
         <source>Select the second base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Select the first dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Select the second dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select the third dart point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/dialogtruedarts.ui" line="+48"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>1st base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>2nd base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>1st dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>2nd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>3rd dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
-        <location line="+44"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
-        <location line="+44"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>Point name 1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Point name 2:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,27 +3375,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogUndo</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/dialogundo.ui" line="+17"/>
         <source>Broken formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Fix formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;取消</translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4320,214 +3398,162 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DialogVariables</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.ui" line="+20"/>
         <source>Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Custom variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Add custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Remove custom variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unique variable name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Calculation</source>
         <translation type="unfinished">打算</translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Refresh a pattern with all changes you made</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Line lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
         <source>Line</source>
         <translation type="unfinished">线</translation>
     </message>
     <message>
-        <location line="-43"/>
-        <location line="+96"/>
-        <location line="+96"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="-177"/>
         <source>Line angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+96"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-81"/>
         <source>Curve lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+48"/>
-        <location line="+48"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-76"/>
         <source>Curve angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Control point lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Arc radiuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogvariables.cpp" line="+394"/>
-        <location line="+24"/>
-        <location line="+11"/>
-        <location line="+380"/>
         <source>Error</source>
         <translation type="unfinished">错误</translation>
     </message>
     <message>
-        <location line="-415"/>
-        <location line="+415"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-414"/>
         <source>Empty field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Edit variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4535,17 +3561,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DoubleLinePointTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.cpp" line="+220"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tool</source>
         <translation type="unfinished">工具</translation>
     </message>
@@ -4553,148 +3576,118 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditFormulaDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.ui" line="+35"/>
         <source>Edit formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+115"/>
         <source>Measurements</source>
         <translation type="unfinished">尺寸</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Custom Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Line Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Line Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Curve Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> Control Point Lengths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Arc Radii</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Calculation</source>
         <translation type="unfinished">打算</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Clear formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Reset to original formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Insert variable into formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Hides measurement variables that have no value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Hide empty measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <location line="+16"/>
         <source>Filter variable list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Filter list by keyword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/edit_formula_dialog.cpp" line="+218"/>
         <source>Measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Custom Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Line Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Arc radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Curve angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4702,37 +3695,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditGroupDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/editgroup_dialog.ui" line="+32"/>
         <source>Add Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Unique pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unique group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-44"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,296 +3726,236 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>EditLabelTemplateDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.ui" line="+17"/>
         <source>Edit label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Clear current and begin new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Import from label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Export label as template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bold</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Italic</source>
         <comment>Font formatting</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Centers horizontally in the available space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Aligns with the right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Additional font size. Use to make a line bigger.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line of text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Insert placeholders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Insert...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp" line="+176"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Create new template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Creating new template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+70"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Export label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+11"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Import template will overwrite the current, do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>File error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+95"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Company name or designer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Customer name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurments file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Size</source>
         <translation type="unfinished">尺码</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Height</source>
         <translation type="unfinished">高度</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurments extension</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece annotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece tilt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece fold position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quantity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Material: Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Word: on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5037,12 +3963,10 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/export_format_combobox.cpp" line="+204"/>
         <source>(flat) files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5050,163 +3974,130 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ExportLayoutDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="+40"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Binary form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Select path to destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>File format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>File name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+3"/>
         <source>File base name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Quality (0-100):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Templates: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Orientation: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.cpp" line="+89"/>
         <source>The base filename does not match a regular expression.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Select folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Tried to use out of range format number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Selected not present format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>The destination directory doesn&apos;t exist or is not readable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>%1 already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 files with basename %2 already exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Do you want to replace them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Confirm Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/export_layout_dialog.ui" line="-312"/>
         <source>Export files:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,52 +4105,42 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
         <source>Feed download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error</source>
         <translation type="unfinished">错误</translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+16"/>
         <source>Information</source>
         <translation type="unfinished">信息</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Unable to open file
 %1
 for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>No new releases available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation type="unfinished"></translation>
@@ -5268,369 +4149,286 @@ Do you want to download it?</source>
 <context>
     <name>GroupsWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.ui" line="+27"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Show All Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+3"/>
         <source>Hide all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Lock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Unlock all groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Add a new group to the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Delete active group from the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Edit group properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Group list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Group object list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="+637"/>
         <source>Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
         <source>Double clicking zooms to object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/groups_widget.cpp" line="-280"/>
-        <location line="+96"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
-        <location line="+96"/>
         <source>The action can&apos;t be completed because the group name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Edit Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show which groups in the list are visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Show which groups in the list are locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Show which groups contain objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Unknown Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>%1 - Base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Point On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Arc Radius &amp; Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+9"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 - Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Arc &amp; Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Line &amp; Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Axis &amp; Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>%1 - Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 - Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Line &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 - True Dart %2_%3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 - Arc Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 - Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>%1 - Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Move Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-647"/>
-        <location line="+134"/>
-        <location line="+22"/>
         <source>Group color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+18"/>
         <source>Group name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+106"/>
         <source>Visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is visible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Group is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Group has objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5638,265 +4436,186 @@ Do you want to download it?</source>
 <context>
     <name>HistoryDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+98"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Search text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+630"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-327"/>
-        <location line="+6"/>
-        <location line="+17"/>
-        <location line="+8"/>
-        <location line="+6"/>
-        <location line="+8"/>
-        <location line="+9"/>
-        <location line="+13"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+10"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+11"/>
-        <location line="+11"/>
-        <location line="+12"/>
-        <location line="+7"/>
-        <location line="+9"/>
-        <location line="+7"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+6"/>
-        <location line="+18"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-250"/>
         <source>Base Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line_%1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Line from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Line %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point On Perpendicular %1_%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point On Bisector %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Lines %1_%2 and %3_%4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+10"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Curve Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Curve Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
-        <location line="+1"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Arc Radius &amp; Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Arc Radius &amp; Length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+10"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Spline Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Spline Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arc with center %1 &amp; Line %2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Line %1_%2 &amp; Perpendicular %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Axis %1_%2 &amp; Triangle points %3 and %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point Intersect XY of points %1 and %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Point On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%Point Intersect Line &amp; %1_%2 and Axis through point %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Point Intersect Curve &amp; Axis through point %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 - Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Circle &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Point Intersect Arc &amp; Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>True Dart %1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ElArc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc Elliptical with length %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Rotation around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Mirror by Line %1_%2. Suffix %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Mirror by Axis through %1 point. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Move - rotate around point %1. Suffix %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.ui" line="+10"/>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="+44"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/history_dialog.cpp" line="-321"/>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5904,127 +4623,98 @@ Do you want to download it?</source>
 <context>
     <name>ImageDialog</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_dialog.ui" line="+35"/>
         <source>Image Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Id:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Switch between px and pattern units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>PX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>X Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+67"/>
-        <location line="+179"/>
-        <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Lock aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Lock Aspect:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">宽度:</translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>X Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+64"/>
-        <location line="+177"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-210"/>
         <source>Y Scale:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Opacity:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6032,110 +4722,85 @@ Do you want to download it?</source>
 <context>
     <name>ImageItem</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_item.cpp" line="+333"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Change Origin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
         <source>Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bring to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Send to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location line="+329"/>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source> - &lt;b&gt;Aspect ratio locked&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Origin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImageTool</name>
     <message>
-        <location filename="../../src/libs/tools/images/image_tool.cpp" line="+54"/>
-        <location line="+25"/>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
-        <location line="+25"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
-        <location line="+9"/>
         <source>Could not read the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>File may be corrupted...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>File may be corrupted or empty...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Images will not be saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Please note that the images can not be saved and that they are not affected by the undo and redo functions in the current version of the software.
 
 You may want to take a screenshot of the image properties dialog before closing the software to be able to recreate identically the image when opening the software again.</source>
@@ -6145,102 +4810,82 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InsertNodesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="+42"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Piece:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Nodes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>msg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp" line="+317"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>No nodes selected. Press Cancel to continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+169"/>
         <source> was auto reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source> may need to be manually reversed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui" line="-167"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6248,12 +4893,10 @@ You may want to take a screenshot of the image properties dialog before closing 
 <context>
     <name>InternalStrings</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp" line="+9"/>
         <source>The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/about2d_dialog.cpp" line="+11"/>
         <source>Seamly2D is an application for computer-aided design of garment patterns.
 
 Seamly2D is a free (open source) software.
@@ -6271,87 +4914,70 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="+53"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+85"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Center point:</source>
         <translation type="unfinished">中点:</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Radius:</source>
         <translation type="unfinished">半径:</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Calculation</source>
         <translation type="unfinished">打算</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp" line="+211"/>
         <source>Select a circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Edit radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Error</source>
         <translation type="unfinished">错误</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui" line="-481"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6359,12 +4985,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCircleTangentTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp" line="+160"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Circle and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6372,110 +4996,82 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="+50"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+79"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Circle 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location line="+298"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
-        <location line="+298"/>
         <source>Radius:</source>
         <translation type="unfinished">半径:</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+298"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
-        <location line="+298"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-237"/>
-        <location line="+298"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-252"/>
-        <location line="+298"/>
         <source>Calculation</source>
         <translation type="unfinished">打算</translation>
     </message>
     <message>
-        <location line="-276"/>
         <source>Circle 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp" line="+240"/>
         <source>Select second circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Edit first circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Edit second circle radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished">错误</translation>
     </message>
     <message>
-        <location line="-18"/>
-        <location line="+19"/>
         <source>Radius can&apos;t be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui" line="-464"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6483,12 +5079,10 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>IntersectCirclesTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp" line="+166"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Circles&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6496,126 +5090,100 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 <context>
     <name>LayoutSettingsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+57"/>
         <source>Templates:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+77"/>
         <source>Width:</source>
         <translation>宽度:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+282"/>
         <source>Rotate workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rotate by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
         <source>degree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Three groups: big, middle, small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Two groups: big, small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Descending area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
         <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+16"/>
         <source>Centimeters</source>
         <translation>公分</translation>
     </message>
     <message>
-        <location line="-15"/>
-        <location line="+17"/>
         <source>Inches</source>
         <translation>英寸</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>Pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+25"/>
         <source>Auto crop unused length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unite pages (if possible)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-278"/>
         <source>Gap width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Save length of the sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-384"/>
         <source>Paper format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-120"/>
         <source>Wrong fields.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-129"/>
         <source>
 	Three groups: big, middle, small = 0;
 	Two groups: big, small = 1;
@@ -6623,84 +5191,67 @@ Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+62"/>
         <source>Layout options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Shift/Offset length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+208"/>
         <source>Rule for choosing the next workpiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Divide into strips</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set multiplier for length of the biggest workpiece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Enabling for sheets that have big height will speed up creating.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-450"/>
         <source>Printer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+288"/>
         <source>None</source>
         <comment>Printer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.ui" line="+101"/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Text will be converted to paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Export text as paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Ignore margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-293"/>
         <source>Layout print settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="-42"/>
-        <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6708,32 +5259,26 @@ Apply settings anyway?</source>
 <context>
     <name>LineTypeComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/linetype_combobox.cpp" line="+82"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6741,2659 +5286,2000 @@ Apply settings anyway?</source>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+17"/>
         <source>Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+920"/>
         <source>Tools for creating points.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-728"/>
-        <location line="+735"/>
-        <location line="+3"/>
-        <location line="+3786"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3461"/>
         <source>Tools for creating lines.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1032"/>
-        <location line="+1039"/>
-        <location line="+3"/>
-        <location line="+2906"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2973"/>
         <source>Line</source>
         <translation>线</translation>
     </message>
     <message>
-        <location line="-2812"/>
         <source>Tools for creating curves.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1125"/>
-        <location line="+1132"/>
-        <location line="+3"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+244"/>
         <source>Tools for creating arcs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1362"/>
-        <location line="+1369"/>
-        <location line="+3"/>
         <source>Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1568"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2706"/>
         <source>Measurements</source>
         <translation>尺寸</translation>
     </message>
     <message>
-        <location line="+2504"/>
         <source>New</source>
         <translation>新</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create a new pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open file with pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4890"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save &amp;As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Save not yet saved pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2476"/>
-        <location line="+2160"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+394"/>
         <source>Pointer tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2641"/>
-        <location line="+2725"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+686"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&amp;About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-4850"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>Report bug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show online help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+5863"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2183"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2026"/>
-        <location line="+46"/>
-        <location line="+2130"/>
-        <location line="+2760"/>
-        <location line="+20"/>
-        <location line="+29"/>
         <source>Open file</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location line="-2668"/>
-        <location line="+52"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+119"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-106"/>
         <source>Error wrong id.</source>
         <translation>错误:编码错误.</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Bad id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+573"/>
         <source>File saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2339"/>
         <source>untitled.sm2d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2213"/>
         <source>The pattern has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3313"/>
-        <location line="+3395"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3394"/>
-        <location line="+3406"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2281"/>
         <source>This file already opened in another window.</source>
         <translation>这个文件已经在别的窗李打开的.</translation>
     </message>
     <message>
-        <location line="-7032"/>
         <source>Wrong units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5942"/>
         <source>File loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>Seamly2D didn&apos;t shut down correctly. Do you want reopen files (%1) you had open?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Reopen files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3448"/>
-        <location line="+2218"/>
-        <location line="+3"/>
-        <location line="+365"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-335"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2477"/>
-        <location line="+3745"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Print tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Split and print a layout into smaller pages (for regular printers)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Print preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Export As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-3007"/>
-        <location line="+20"/>
-        <location line="+23"/>
-        <location line="+2747"/>
         <source>Layout mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1493"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3125"/>
-        <location line="+56"/>
         <source>Measurements loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5062"/>
         <source>You can&apos;t export empty scene.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6659"/>
-        <location line="+6568"/>
         <source>Measurement file contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6585"/>
-        <location line="+6546"/>
         <source>Measurement file has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6419"/>
         <source>Measurement files types have not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1637"/>
         <source>Couldn&apos;t sync measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2484"/>
-        <location line="+30"/>
         <source>Couldn&apos;t update measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1634"/>
-        <location line="+11"/>
         <source>The measurements file &apos;%1&apos; could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+517"/>
         <source>Loading measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+315"/>
         <source>Not supported size value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set size. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+43"/>
         <source>The method %1 does nothing in GUI mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Not supported height value &apos;%1&apos; for this pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Couldn&apos;t set height. File wasn&apos;t opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Please, provide one input file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-69"/>
         <source>Print an original layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Preview tiled PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Print preview tiled layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5182"/>
         <source>Measurements unloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Couldn&apos;t unload measurements. Some of them are used in the pattern.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1833"/>
         <source>New pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Open pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Create/Edit measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4854"/>
         <source>Save...</source>
         <translation>保存...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>不保存</translation>
     </message>
     <message>
-        <location line="+2329"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-1967"/>
-        <location line="+3"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1818"/>
         <source>Close pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2893"/>
         <source>Tool pointer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2835"/>
-        <location line="+3"/>
         <source>Original zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5247"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4609"/>
         <source>The measurements file &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6634"/>
         <source>Measurements were changed. Do you want to sync measurements now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+261"/>
         <source>Gradation doesn&apos;t support inches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1687"/>
         <source>Measurements have been synced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1882"/>
         <source>The document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3273"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+234"/>
         <source>Load Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Load Individual measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Load Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Load multisize measurements file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Edit Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit linked to the pattern measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Sync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Synchronize linked to the pattern measurements after change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unload Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unload measurements if they were not used in a pattern file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5428"/>
-        <location line="+4956"/>
-        <location line="+25"/>
         <source>Individual measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4928"/>
-        <location line="+4891"/>
-        <location line="+40"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3014"/>
-        <location line="+203"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-264"/>
         <source>Wiki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Forum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2231"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1964"/>
         <source>You can&apos;t use Layout mode yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3402"/>
         <source>Application doesn&apos;t support multisize table with inches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6734"/>
         <source>Couldn&apos;t set size. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Couldn&apos;t set height. Need a file with multisize measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3935"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&amp;Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+93"/>
-        <location line="+1853"/>
-        <location line="+617"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2418"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>File Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Mode ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Pattern Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Edit Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Property Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-5427"/>
-        <location line="+1888"/>
         <source>Group Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Zoom ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Toolbox ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Points Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Lines ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Arcs ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Operations ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Piece ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Details ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Layout ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Point Name ToolBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Toolbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+512"/>
-        <location line="+2885"/>
         <source>Line between 2 Points (Alt+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2287"/>
         <source>Tools for performing operations on objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location line="+969"/>
         <source>Rotate Selected Objects (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2541"/>
         <source>Export Draft Blocks (E, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2503"/>
         <source>Tools for adding pattern pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+250"/>
         <source>Add Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Tools for adding details to pattern pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+1982"/>
         <source>Unite 2 Pieces (U)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1777"/>
         <source>View Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+117"/>
-        <location line="+3"/>
         <source>Draft</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with draft blocks. These draft blocks are the base for going to the next stage &amp;quot;Piece mode&amp;quot;. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for working with pattern pieces. Before you will be able to enable the &amp;quot;Piece mode&amp;quot; you need to create at least one pattern piece on the stage &amp;quot;Draft mode&amp;quot;. Pattern pieces created on this stage will be used for creating a layout. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add new draft block (Ctrl+Shift+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change the name of the draft block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Variables table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mode for creating a layout of pattern pieces. This mode is available if at least one pattern piece was created in &amp;quot;Piece mode&amp;quot;. The layout can be exported to your preferred file format and saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-574"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-275"/>
         <source>Midpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+132"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+6"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+188"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-78"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-96"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
         <source>Tools for inserting or modifying images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+999"/>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+290"/>
         <source>About Seamly2D</source>
         <translation type="unfinished">关于Seamly2D</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Exit the Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Application Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Pattern Preferences...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom In (Ctrl++)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom Out (Ctrl+-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Fit All(Ctrl+=)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Report bug...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+3"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Last tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Control Points and Curve Direction (V, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Open SeamlyMe measurements app (Ctrl+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Export Variables to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Label Template Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to Previous (Ctrl+Left)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zoom to 100 percent (Ctrl+0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Line Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-28"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Curve Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arc Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Operations Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Layout Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Piece tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+242"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+74"/>
         <source>New Print Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Detail tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Increase Text Size (Ctrl+])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decrease Text Size (Ctrl+[)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use Tool Color (T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Axis Origin </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Axis Origin (V, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Wireframe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Wireframe Mode (V, W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Grainlines (V, G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Toggle Labels (V, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2840"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2970"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Document Info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Display document Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2512"/>
         <source>Measurement file doesn&apos;t include all the required measurements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+759"/>
         <source>&lt;b&gt;Tool::Operations - Create Group:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to finish group creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>&lt;b&gt;Tool::Operations - Rotation:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Line:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Operations - Mirror by Axis:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Operations - Move:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Operations - TrueDarts:&lt;/b&gt; Select the first base line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Could not load the image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
-        <location line="+594"/>
         <source>Draft Block:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+723"/>
         <source>Rotate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Add AnchorPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Create Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Insert Nodes in Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Union Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1590"/>
-        <location line="+1646"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+450"/>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>You can&apos;t use Piece mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1922"/>
-        <location line="+1962"/>
         <source>Pattern Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You can&apos;t use Layout mode yet. Please, create at least one pattern piece.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>You can&apos;t use Layout mode yet. Please, include at least one pattern piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2349"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Draft block.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Name Exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The action can&apos;t be completed because the Draft Block name already exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
         <source>You don&apos;t have any pieces to export. Please, include at least one piece in layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Export pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Can&apos;t export pieces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5105"/>
         <source>&lt;b&gt;Tool::Piece - Add New Pattern Piece:&lt;/b&gt; Select main path of objects clockwise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Piece - Add Anchor Point:&lt;/b&gt; Select anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;b&gt;Tool::Piece - Internal Path:&lt;/b&gt; Select path objects, use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;b&gt;Tool::Piece - Insert Nodes:&lt;/b&gt; Select one or more objects - Hold &lt;b&gt;%1&lt;/b&gt; for multiple selection, Press &lt;b&gt;ENTER&lt;/b&gt; to confirm selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
         <source>&lt;b&gt;Tool::Details - Union:&lt;/b&gt; Select pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2926"/>
         <source>Draft block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1088"/>
         <source>Draft Block %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-3777"/>
-        <location line="+2145"/>
         <source>Point - On Bisector (O, B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2119"/>
-        <location line="+2137"/>
         <source>Point - Length to Line (P, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2111"/>
-        <location line="+2129"/>
         <source>Point - Intersect Arc and Line (A, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2103"/>
-        <location line="+2121"/>
         <source>Point - Intersect Axis and Triangle (X, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2095"/>
-        <location line="+2113"/>
         <source>Point - Intersect XY (X, Y)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2087"/>
-        <location line="+2105"/>
         <source>Point - Intersect Line and Perpendicular (L, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2079"/>
-        <location line="+2097"/>
         <source>Point - Intersect Line and Axis (L, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2071"/>
-        <location line="+1945"/>
         <source>Point - On Perpendicular (O, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1919"/>
-        <location line="+1901"/>
         <source>Point - Length and Angle (L, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1875"/>
-        <location line="+1854"/>
         <source>Point - On Line (O, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+1810"/>
         <source>Point - Midpoint on Line (Shift+O, Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1712"/>
-        <location line="+1913"/>
         <source>Point - Intersect Lines (I, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1835"/>
-        <location line="+1853"/>
         <source>Curve - Interactive (Alt+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1827"/>
-        <location line="+1881"/>
         <source>Spline - Interactive (Alt+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1855"/>
-        <location line="+1837"/>
         <source>Curve - Fixed (Alt+Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1811"/>
-        <location line="+1865"/>
         <source>Spline - Fixed (Alt+Shift+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1839"/>
         <source>Point - On Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1834"/>
         <source>Point - Intersect Curves (I, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1808"/>
-        <location line="+1829"/>
         <source>Point - Intersect Curve and Axis (C, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1803"/>
         <source>Point - On Curve (O, C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
-        <location line="+1752"/>
         <source>Arc - Radius and Angles (Alt+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1726"/>
         <source>Point - On Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Point - Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1699"/>
         <source>Arc - Radius and Length (Alt+Shift+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1673"/>
-        <location line="+1154"/>
         <source>Arc - Elliptical (Alt+E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
-        <location line="+961"/>
         <source>Mirror Objects by Line (M, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-935"/>
-        <location line="+953"/>
         <source>Mirror Objects by Axis (M, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-927"/>
-        <location line="+945"/>
         <source>Move Objects (Alt+M)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-919"/>
-        <location line="+937"/>
         <source>True Darts (T, D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
-        <location line="+2118"/>
         <source>Add New Pattern Piece (N, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2092"/>
-        <location line="+2146"/>
         <source>Add Anchor Point (A, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2120"/>
-        <location line="+2156"/>
         <source>Insert Nodes (I, N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2130"/>
-        <location line="+2112"/>
         <source>Add Internal Path (I, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2055"/>
-        <location line="+2453"/>
         <source>Import Image (Alt + I)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2315"/>
-        <location line="+1968"/>
         <source>Export Pieces (E, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1857"/>
         <source>New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+1320"/>
-        <location line="+424"/>
         <source>Export Layout (E, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1474"/>
         <source>Contains information about custom and internal variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2575"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-149"/>
         <source>Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc -Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Midpoint on Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-125"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Intersect  Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+2"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+82"/>
         <source>Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+104"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+4"/>
         <source>Point on Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Spline (O, S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+3"/>
         <source>Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+3"/>
         <source>Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-83"/>
         <source>Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Point on Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Point on Arc (O, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Axis (A, X)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arcs (I, A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circles (Shift+I, Shift+C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Circle and Tangent (C, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Intersect Arc and Tangent (A, T)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1"/>
         <source>Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>Activate last used tool (Ctrl+Shift+L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+275"/>
         <source>Zoom to Selected (Ctrl+Right)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Zoom to selected Area (Ctrl+A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pan Work Area (Z, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+180"/>
         <source>Create New Print Layout (N, L)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Toggle Point Name Text (V, P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+209"/>
         <source>Images tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Align</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Zoom to point (Ctrl + Alt + P)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Alt+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2359"/>
         <source>Please provide additional measurements: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
         <source>&lt;b&gt;Tool::Point - Midpoint on Line&lt;/b&gt;: Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length and Angle&lt;/b&gt;: Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Line:&lt;/b&gt; Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Perpendicular:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Bisector:&lt;/b&gt; Select first point of angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Length to Line:&lt;/b&gt; Select point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Line:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Axis and Triangle:&lt;/b&gt; Select first point of axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect XY&lt;/b&gt; Select point for X value (vertical)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Perpendicular:&lt;/b&gt; Select base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Line and Axis:&lt;/b&gt; Select first point of line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Line:&lt;/b&gt;:Select first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - Intersect Lines:&lt;/b&gt; Select first point of first line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Curve - Interactive:&lt;/b&gt; Select start point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Spline - Interactive:&lt;/b&gt; Select start point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Curve - Fixed:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Spline - Fixed:&lt;/b&gt; Select first point of spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Curve:&lt;/b&gt; Select first point of curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Spline:&lt;/b&gt; Select spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curves:&lt;/b&gt; Select first curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Curve and Axis:&lt;/b&gt; Select curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Angles:&lt;/b&gt; Select point of center of arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>&lt;b&gt;Tool::Point - On Arc:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Axis:&lt;/b&gt; Select arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arcs:&lt;/b&gt; Select first an arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circles:&lt;/b&gt; Select first circle center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>&lt;b&gt;Tool::Point - Intersect Circle and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Point - Intersect Arc and Tangent:&lt;/b&gt; Select point on tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>&lt;b&gt;Tool::Arc - Radius and Length:&lt;/b&gt; Select point of the center of the arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&lt;b&gt;Tool::Arc - Elliptical:&lt;/b&gt; Select point of center of elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-4444"/>
-        <location line="+1976"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+286"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+16"/>
         <source>Open Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1060"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+197"/>
         <source>Intersect Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="-354"/>
-        <location line="+974"/>
         <source>Add Objects to Group (G)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+69"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-1718"/>
         <source>Add Group Objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Group is Locked. Unlock to add objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2513"/>
-        <location line="+121"/>
         <source>Can not save file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-120"/>
-        <location line="+121"/>
         <source>Pattern is read only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-59"/>
         <source>Failed to lock. File with this name is opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.ui" line="+1124"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2038"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2074"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1448"/>
         <source>Pen Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2659"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4754"/>
-        <location line="+39"/>
-        <location line="+63"/>
-        <location line="+5717"/>
-        <location line="+90"/>
         <source>File exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
-        <location line="+67"/>
-        <location line="+486"/>
-        <location line="+24"/>
         <source>Export exception.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3223"/>
         <source>pattern</source>
         <translation>样板</translation>
     </message>
     <message>
-        <location line="-1545"/>
         <source>Base name used for new points.
 Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
-        <location line="+232"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9401,86 +7287,66 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MainWindowsNoGUI</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindowsnogui.cpp" line="+1141"/>
         <source>Creating file &apos;%1&apos; failed! %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical error!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+174"/>
-        <location line="+32"/>
         <source>Print error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
-        <location line="+32"/>
         <source>Cannot proceed because there are no available printers in your system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+382"/>
         <source>unnamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>The layout is stale.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The layout was not updated since last pattern modification. Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1527"/>
         <source>Couldn&apos;t prepare data for creation layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+799"/>
         <source>Can&apos;t open printer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
         <source>For previewing multipage document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>For printing multipages document all sheet should have the same size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+366"/>
         <source>Pages will be cropped because they do not fit printer paper size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-36"/>
-        <location line="+414"/>
         <source>Cannot set printer margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1134"/>
-        <location line="+91"/>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+491"/>
         <source>Pattern</source>
         <translation>样板</translation>
     </message>
     <message>
-        <location line="-651"/>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9488,148 +7354,118 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="+155"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+148"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">新</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">保存</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Help</source>
         <translation type="unfinished">帮助</translation>
     </message>
     <message>
-        <location line="-10"/>
-        <location line="+11"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.ui" line="-196"/>
         <source>SeamlyMe Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_shortcuts_dialog.cpp" line="+1"/>
         <source>Find previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9637,123 +7473,102 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDatabaseDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.cpp" line="+382"/>
         <source>Collapse All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expand All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Check all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Uncheck all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/dialogmdatabase.h" line="+95"/>
         <source>Direct Height</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Direct Width</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indentation</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hand</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Foot</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Head</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Circumference and Arc</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bust</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Balance</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arm</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Leg</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Crotch and Rise</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men &amp; Tailoring</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Historical &amp; Specialty</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking measurements</source>
         <comment>Measurement section</comment>
         <translation type="unfinished"></translation>
@@ -9762,18 +7577,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MeasurementDoc</name>
     <message>
-        <location filename="../../src/libs/vformat/measurements.cpp" line="+563"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
-        <location line="+14"/>
         <source>Can&apos;t find measurement &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+248"/>
         <source>The measurement name is empty!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9781,37 +7588,30 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MouseCoordinates</name>
     <message>
-        <location filename="../../src/libs/vwidgets/mouse_coordinates.ui" line="+26"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source> XPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>xpos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>YPos:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>ypos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>units</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9819,12 +7619,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveDoubleLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movedoublelabel.cpp" line="+76"/>
         <source>move the first dart label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>move the second dart label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9832,7 +7630,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/move_groupitem.cpp" line="+48"/>
         <source>Move group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9840,7 +7637,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/movelabel.cpp" line="+71"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9848,7 +7644,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveOperationLabel</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/moveoperationlabel.cpp" line="+73"/>
         <source>move point label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9856,7 +7651,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespoint.cpp" line="+68"/>
         <source>move single point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9864,7 +7658,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movespline.cpp" line="+74"/>
         <source>move spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9872,7 +7665,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>MoveSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movesplinepath.cpp" line="+73"/>
         <source>move spline path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9880,52 +7672,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>NewMeasurementsDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.ui" line="+23"/>
         <source>New measurement file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Measurement type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/new_measurements_dialog.cpp" line="+204"/>
         <source>Individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Centimeters</source>
         <translation>公分</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Inches</source>
         <translation>英寸</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>Multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9933,87 +7715,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PageFormatCombobox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/page_format_combobox.cpp" line="+60"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Letter</source>
         <translation type="unfinished">信</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Legal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ANSI E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 24in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 30in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 36in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 42in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Roll 44in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10021,887 +7786,634 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="+32"/>
         <source>Pattern Piece Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+761"/>
         <source>Properties </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-208"/>
         <source>Paths </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-9"/>
         <source>Seam Allowance </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1600"/>
-        <location line="+6"/>
-        <location line="+174"/>
-        <location line="+33"/>
         <source>Labels </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Anchors </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-222"/>
         <source>Grainline </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Notches </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Poperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name can&apos;t be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Letter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Letter of pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quantity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Placement:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Fold position:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+59"/>
         <source>Undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Up/Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Orientation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3517"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3488"/>
-        <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
-        <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>1-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>2-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>4-Way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Tilt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>CW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CCW X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Annotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>A text field to add comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+54"/>
         <source>Forbid piece be mirrored in a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>hex Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>All objects in path should follow in clockwise direction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Move row to top of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row up one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Move row down one row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Molve row to botton of list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Status:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2430"/>
         <source>Ready!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Internal paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Built in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+1082"/>
-        <location line="+835"/>
         <source>Width:</source>
         <translation type="unfinished">宽度:</translation>
     </message>
     <message>
-        <location line="-1883"/>
-        <location line="+304"/>
-        <location line="+227"/>
-        <location line="+551"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1134"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2910"/>
-        <location line="+332"/>
-        <location line="+227"/>
-        <location line="+517"/>
-        <location line="+193"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Formula wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2875"/>
-        <location line="+323"/>
-        <location line="+227"/>
-        <location line="+520"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+452"/>
-        <location line="+190"/>
-        <location line="+190"/>
-        <location line="+458"/>
-        <location line="+190"/>
         <source>Calculation</source>
         <translation type="unfinished">打算</translation>
     </message>
     <message>
-        <location line="-2894"/>
         <source>Nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Node:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Before:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
-        <location line="+227"/>
         <source>Return to default width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-224"/>
-        <location line="+227"/>
         <source>Use Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>After:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+178"/>
-        <location line="+756"/>
-        <location line="+832"/>
-        <location line="+1603"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3140"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Start point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>End point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Include as:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <location line="+835"/>
         <source>Edit pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-832"/>
-        <location line="+835"/>
         <source>Edit template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-804"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+271"/>
-        <location line="+832"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-494"/>
-        <location line="+838"/>
-        <location line="+185"/>
-        <location line="+457"/>
         <source>Anchor points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1304"/>
         <source>Pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+847"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">长度:</translation>
     </message>
     <message>
-        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Type:</source>
         <translation type="unfinished">类型:</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Notch:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-1024"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V Internal </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+5"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+2"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Straightforward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Select to designate a corner point as a notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1"/>
         <source>Intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>  °</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Reset notch with to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
         <source>Reset notch angle to default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-367"/>
         <source>Select main path objects clockwise, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction,  or &lt;b&gt;CTRL&lt;/b&gt; to keep curve direction. Press &lt;b&gt;ENTER&lt;/b&gt; to finish piece creation </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Press OK to create pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+260"/>
-        <location line="+134"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-130"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>TNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>UNotch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VInternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>VExternal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Excluded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+105"/>
-        <location line="+43"/>
-        <location line="+35"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location line="-88"/>
-        <location line="+52"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+443"/>
         <source>Error. Can&apos;t save piece path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+259"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Infinite/undefined result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-163"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Length should be positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Error</source>
         <translation type="unfinished">错误</translation>
     </message>
     <message>
-        <location line="-164"/>
-        <location line="+82"/>
-        <location line="+85"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Edit length</source>
         <translation type="unfinished">修长度</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+57"/>
-        <location line="+60"/>
         <source>Edit angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+60"/>
         <source>Edit height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-54"/>
-        <location line="+60"/>
         <source>Edit width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Edit seam allowance width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Edit seam allowance width after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-512"/>
-        <location line="+572"/>
         <source>Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+309"/>
         <source>You need more points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>You must choose points in a clockwise direction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>First point cannot be same as last point!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You have double points!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Each point in the path must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+320"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>main path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>custom seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just front</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Just rear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Show notch on the seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3931"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2608"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Paths</source>
         <translation type="unfinished">路径</translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1058"/>
-        <location line="+85"/>
-        <location line="+436"/>
-        <location line="+33"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1597"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Flipping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Forbid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2158"/>
-        <location line="+860"/>
-        <location line="+698"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1492"/>
-        <location line="+860"/>
         <source>Top left:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-816"/>
-        <location line="+772"/>
         <source>Bottom right:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+598"/>
         <source>Top:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10909,218 +8421,166 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PatternPieceTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/pattern_piece_tool.cpp" line="+152"/>
-        <location line="+9"/>
         <source>Current seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+566"/>
         <source>move pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>rotate pattern piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>move pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>resize pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>rotate pattern info label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>move grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>resize grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>rotate grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+299"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lock Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+848"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-839"/>
         <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower to bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+850"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
         <source>Show Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Show Pattern Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Show Piece Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location line="+806"/>
         <source>Forbid Flipping changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Seam line visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
-        <location line="+18"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Show seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Seam allowance visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show grainline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Grainline visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show pattern label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Pattern label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Show piece label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece label visibility changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Piece name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rename Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Piece renamed to: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -11128,27 +8588,22 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PenToolBar</name>
     <message>
-        <location filename="../../src/libs/vwidgets/pen_toolbar.cpp" line="+67"/>
         <source>Current line color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Current line weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Reset current pen to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Save current pen preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11156,77 +8611,62 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PieceFillComboBox</name>
     <message>
-        <location filename="../../src/libs/vwidgets/fill_combobox.cpp" line="+88"/>
         <source>No Fill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Density 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Vertical Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Backward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forward Diagonal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diagonal Cross</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11234,139 +8674,94 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PiecesWidget</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+20"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+422"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+24"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+107"/>
-        <location line="+86"/>
         <source>Include all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-85"/>
-        <location line="+117"/>
         <source>Exclude all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+95"/>
         <source>Invert included pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-89"/>
-        <location line="+117"/>
         <source>Lock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-116"/>
-        <location line="+152"/>
         <source>Unlock all pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-151"/>
-        <location line="+126"/>
         <source>Invert locked pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-295"/>
         <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.ui" line="+45"/>
-        <location line="+3"/>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="+327"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+3"/>
         <source>Edit pattern piece properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/pieces_widget.cpp" line="-283"/>
         <source>Included</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece is locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern piece letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern piece name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
         <source>Toggle lock on pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Double click opens color selector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+8"/>
         <source>Double click opens pattern piece properties dialog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11374,62 +8769,50 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PointIntersectXYDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="+31"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>1st point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>2nd point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp" line="+251"/>
         <source>Select point for Y value (horizontal)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui" line="-292"/>
         <source>Unique name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Choose unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11437,316 +8820,250 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+1024"/>
         <source>Interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+225"/>
         <source>Language</source>
         <translation type="unfinished">语言</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation>GUI语言:</translation>
     </message>
     <message>
-        <location line="+105"/>
         <source>Default unit:</source>
         <translation type="unfinished">默认单位:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+312"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Centimeters</source>
         <translation type="unfinished">公分</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Inches</source>
         <translation type="unfinished">英寸</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-1002"/>
         <source>Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Count step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source> (0 - no limit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+215"/>
         <source>Pattern Editing Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Confirm Item Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Confirm Format Rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Operations Default Suffix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Mirror by axis suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Mirror by line suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Move suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Rotate suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>File Handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Create backup file when converting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Enable Autosave</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Export Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Include mode type in filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save last used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+177"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-252"/>
-        <location line="+12"/>
-        <location line="+13"/>
-        <location line="+13"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>_M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MOV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>_R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_ROT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>_MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_MBL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+211"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="-815"/>
         <source>Selection sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-456"/>
         <source>Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Company / Designer Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Company / Designer:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Contact:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>City:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>State:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Zipcode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Country:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Telephone:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Fax:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Email:</source>
         <translation type="unfinished">邮箱:</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Website:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="-132"/>
         <source>Email verification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Email format is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+149"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui" line="+847"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+207"/>
         <source>Point name text:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11754,582 +9071,414 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesGraphicsViewPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui" line="+82"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Text label appears under the icon (recommended for beginners)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Show tool toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>ToolBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Line</source>
         <translation type="unfinished">线</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Graphical output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Use anti-aliasing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Fonts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
-        <location line="+271"/>
-        <location line="+269"/>
         <source>Font:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-500"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-519"/>
-        <location line="+4"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>10.5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+172"/>
-        <location line="+97"/>
         <source>32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>44</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>48</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>54</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>60</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>66</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>72</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>80</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-533"/>
-        <location line="+122"/>
-        <location line="+147"/>
-        <location line="+269"/>
         <source>96</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-522"/>
-        <location line="+269"/>
-        <location line="+269"/>
         <source>The quick brown fox jumps over the lazy dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-511"/>
-        <location line="+718"/>
         <source>Point Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
         <source>GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+266"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Zoom Rubberband</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Positive:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Negative:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Default:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Hover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Drawing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Primary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Secondary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Tertiary:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Show Scrollbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Width:</source>
         <translation type="unfinished">宽度:</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Scrolling animation duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+57"/>
         <source> ms</source>
         <comment>milliseconds</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
         <source>Update interval:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Time in milliseconds between each animation update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+220"/>
         <source>Speed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-197"/>
-        <location line="+220"/>
-        <location line="+419"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-529"/>
-        <location line="+223"/>
-        <location line="+422"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
-        <location line="+392"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-369"/>
-        <location line="+252"/>
         <source>Use CTRL modifier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Behavior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Constraints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Angle Step:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source> deg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Zoom to selected with double click</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pan active while Space key is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Quality:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always use current pen</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.ui" line="+37"/>
         <source>Paths that Seamly2D uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespathpage.cpp" line="+195"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>My Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>My Patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Layouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>My Label Templates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12337,272 +9486,202 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>PreferencesPatternPage</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="+177"/>
         <source>Forbid flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+521"/>
-        <location line="+1350"/>
         <source>By default forbid flipping for all new created workpieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1898"/>
         <source>By default hide the main path if the seam allowance was enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+845"/>
         <source>Seam allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Default value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1354"/>
         <source>Date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+83"/>
         <source>Edit formats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-48"/>
         <source>Time:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2365"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+126"/>
-        <location line="+437"/>
-        <location line="+1350"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1817"/>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Show notch on both the seam allowance and seam line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Type:</source>
         <translation type="unfinished">类型:</translation>
     </message>
     <message>
-        <location line="+68"/>
-        <location line="+437"/>
-        <location line="+343"/>
-        <location line="+218"/>
-        <location line="+206"/>
-        <location line="+212"/>
-        <location line="+475"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-1828"/>
-        <location line="+282"/>
         <source>Length:</source>
         <translation type="unfinished">长度:</translation>
     </message>
     <message>
-        <location line="-184"/>
         <source>Width:</source>
         <translation type="unfinished">宽度:</translation>
     </message>
     <message>
-        <location line="+92"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Show grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>x 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
-        <location line="+151"/>
         <source>Paths</source>
         <translation type="unfinished">路径</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>LInetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-571"/>
-        <location line="+212"/>
-        <location line="+212"/>
-        <location line="+212"/>
         <source>Lineweight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-581"/>
         <source>Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+221"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+347"/>
         <source>Label data (date/time format)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>T Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>U Notch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>V External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Castle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2046"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1750"/>
         <source>Show pattern labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Show piece labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Width</source>
         <translation type="unfinished">宽度</translation>
     </message>
     <message>
-        <location line="+98"/>
         <source>Height</source>
         <translation type="unfinished">高度</translation>
     </message>
     <message>
-        <location line="+348"/>
         <source>Templates</source>
         <translation type="unfinished">草稿</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Pattern label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Piece label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui" line="-2344"/>
         <source>Show notch on Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1293"/>
         <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1438"/>
         <source>Show Cut Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12610,7 +9689,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../src/libs/vmisc/projectversion.cpp" line="+143"/>
         <source>Based on Qt %1 (%2, %3 bit)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12618,155 +9696,124 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="-2411"/>
         <source>Create new pattern piece to start working.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+736"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>inch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/vpropertymodel_p.h" line="+53"/>
         <source>Property</source>
         <extracomment>The text that appears in the first column header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Value</source>
         <extracomment>The text that appears in the second column header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="+3"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/adddetnode.cpp" line="+65"/>
         <source>add node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/mainwindow.cpp" line="+1599"/>
         <source>Changes applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+839"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+370"/>
-        <location line="+5"/>
         <source>Can&apos;t convert toUInt parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Can&apos;t convert toBool parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Got empty parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Can&apos;t convert toDouble parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Got wrong parameter id. Need only id &gt; 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vlayout/vtextmanager.cpp" line="+115"/>
         <source>Fabric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interfacing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Interlining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>on fold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+1329"/>
         <source>Union piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/movepiece.cpp" line="+76"/>
         <source>move piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/ifc/ifcdef.cpp" line="+250"/>
         <source>Solidline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dash Dot Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>No Pen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vmisc/def.cpp" line="-350"/>
         <source>%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12774,15 +9821,11 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParser</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparser.cpp" line="+195"/>
-        <location line="+21"/>
         <source>too few arguments for function sum.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+21"/>
         <source>too few arguments for function min.</source>
         <comment>parser error message</comment>
         <translation type="unfinished"></translation>
@@ -12791,217 +9834,181 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>QmuParserErrorMsg</name>
     <message>
-        <location filename="../../src/libs/qmuparser/qmuparsererror.cpp" line="+45"/>
         <source>Unexpected token &quot;$TOK$&quot; found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Internal error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid function-, variable- or constant name: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid binary operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid infix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid postfix operator identifier: &quot;$TOK$&quot;.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to callback function.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Expression is empty.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid pointer to variable.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected operator &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected end of expression at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected argument separator at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected parenthesis &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected function &quot;$TOK$&quot; at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected value &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unexpected variable &quot;$TOK$&quot; found at position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function arguments used without a function (position: $POS$)</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Missing parenthesis</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Too many parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Too few parameters for function &quot;$TOK$&quot; at expression position $POS$</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Divide by zero</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Domain error</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name conflict</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid value for operator priority (must be greater or equal to zero).</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>user defined binary operator &quot;$TOK$&quot; conflicts with a built in operator.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unexpected string token found at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unterminated string starting at position $POS$.</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String function called with a non string type of argument.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>String value used where a numerical argument is expected.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>No suitable overload for operator &quot;$TOK$&quot; at position $POS$.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot; and $POS$</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Function result is a string.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Parser error.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Decimal separator is identic to function argument separator.</source>
         <comment>Math parser error messages.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The &quot;$TOK$&quot; operator must be preceded by a closing bracket.</source>
         <comment>Math parser error messages. Left untouched &quot;$TOK$&quot;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>If-then-else operator is missing an else clause</source>
         <comment>Math parser error messages. Do not translate operator name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Misplaced colon at position $POS$</source>
         <comment>Math parser error messages. Left untouched $POS$</comment>
         <translation type="unfinished"></translation>
@@ -13010,7 +10017,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RemoveGroupItem</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/remove_groupitem.cpp" line="+44"/>
         <source>Delete group item</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13018,7 +10024,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>RenameDraftBlock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/rename_draftblock.cpp" line="+70"/>
         <source>rename pattern piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13026,12 +10031,10 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>ResizeHandlesItem</name>
     <message>
-        <location filename="../../src/libs/vwidgets/resize_handle.cpp" line="+630"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center - &lt;b&gt; Aspect ratio locked &lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Press &lt;b&gt;CTRL&lt;/b&gt; to scale around the center, &lt;b&gt;SHIFT&lt;/b&gt; to scale uniformly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13039,7 +10042,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePieceOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepieceoptions.cpp" line="+78"/>
         <source>save detail option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13047,7 +10049,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SavePiecePathOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savepiecepathoptions.cpp" line="+71"/>
         <source>save path options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13055,7 +10056,6 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SaveToolOptions</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/savetooloptions.cpp" line="+66"/>
         <source>save tool option</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13063,88 +10063,70 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesConfigurationPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.ui" line="+68"/>
         <source>Language</source>
         <translation type="unfinished">语言</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI语言:</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Pattern making system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>System:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Author:</source>
         <translation type="unfinished">作者:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Book:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
         <source>Measurements editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Reset warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Toolbar</source>
         <translation type="unfinished">工具栏</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>The text appears under the icon (recommended for beginners).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-157"/>
         <source>Default height and size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-376"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Do not show welcome screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp" line="+83"/>
-        <location line="+73"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13152,52 +10134,42 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMePreferencesPathPage</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="+69"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+167"/>
         <source>Open Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>My Individual Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Multisize Measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>My Templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.ui" line="-99"/>
         <source>Paths that SeamlyME uses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp" line="+9"/>
         <source>My Body Scans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13205,102 +10177,81 @@ Press enter to temporarily add it to the list.</source>
 <context>
     <name>SeamlyMeWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to SeamlyME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>3D Look users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>To utilize a 3D Look body scan the file needs to be converted to SeamlyME format. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You will recieve an email with the converted file, which you can then load in SeamlyME as usual.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Please choose your preferred units, decimal separator, and language. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-47"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI语言:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sets the language used for SeamlyMe.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/dialogs/me_welcome_dialog.cpp" line="+50"/>
-        <location line="+53"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">公分</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">英寸</translation>
     </message>
@@ -13308,92 +10259,73 @@ You can change this setting in the SeamlyMe preferences.</source>
 <context>
     <name>SeamlyWelcomeDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="+26"/>
         <source>Welcome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Welcome to Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Units:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the default units for a new measurement file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Decimal separator:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>GUI language:</source>
         <translation type="unfinished">GUI语言:</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Do not show again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.cpp" line="+50"/>
-        <location line="+72"/>
-        <location line="+13"/>
         <source>User locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Centimeters</source>
         <translation type="unfinished">公分</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Millimeters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inches</source>
         <translation type="unfinished">英寸</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/welcome_dialog.ui" line="-172"/>
         <source>Sets the language used for Seamly2D.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>Selects what decimal separator char to use. 
 When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Sound:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Sets the node selection click  sound.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13401,12 +10333,10 @@ When unchecked the period is used.</source>
 <context>
     <name>SetPieceColor</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/set_piece_color.cpp" line="+50"/>
         <source>Change piece color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece color changed: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13414,1071 +10344,854 @@ When unchecked the period is used.</source>
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.ui" line="+132"/>
         <source>Copy shortcuts to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export shortcuts as a PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send shortcuts to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-173"/>
         <source>Seamly2D Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/shortcuts_dialog.cpp" line="+72"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New</source>
         <translation type="unfinished">新</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save</source>
         <translation type="unfinished">保存</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+Comma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Draft Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Piece Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Layout Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom 1:1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Alt+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fit All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+=</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Z, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show Name Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Increase Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decrease Text Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use Tool Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve Control Points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Axis Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seam Allowance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Grainlines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>V, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Measurements</source>
         <translation type="unfinished">尺寸</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variables Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Variables Table  to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+137"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>X, Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>L, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Midpoint On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+O, Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+1"/>
         <source>Line</source>
         <translation type="unfinished">线</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Spline	</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+Shift+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>O, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Shift+I, Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>C, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elliptical Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Operations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Add Objects to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>M, A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>True Darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>T, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Draft Blocks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Import Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Alt + I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Pattern Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Anchor Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>A, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Internal Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>I, N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Include in Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forbid Flipping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Raise To Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lower To Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unite Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>N, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>E, L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+1"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Utilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Decimal Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Help</source>
         <translation type="unfinished">帮助</translation>
     </message>
     <message>
-        <location line="-270"/>
-        <location line="+271"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Shift+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+268"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-112"/>
         <source>Insert Nodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14486,12 +11199,10 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowDoublePointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showdoublepointname.cpp" line="+49"/>
         <source>toggle the first dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>toggle the second dart visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14499,42 +11210,34 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowInfoDialog</name>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.ui" line="+40"/>
         <source>Document Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
         <source>Copy info to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Export info as PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Send info to the Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/show_info_dialog.cpp" line="+79"/>
         <source>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Company:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Customer:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern Name:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Pattern No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Units:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Measurements:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Description: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notes:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>_info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14542,7 +11245,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowOperationPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showoperationpointname.cpp" line="+45"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14550,7 +11252,6 @@ When unchecked the period is used.</source>
 <context>
     <name>ShowPointName</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/label/showpointname.cpp" line="+42"/>
         <source>toggle point visibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14558,818 +11259,625 @@ When unchecked the period is used.</source>
 <context>
     <name>TMainWindow</name>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+37"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:18pt;&quot;&gt;Select New for creation measurement file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+121"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+280"/>
         <source>Calculated value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-275"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Base value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In sizes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>In heights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+3"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Base value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In sizes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>In heights:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Description:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-524"/>
         <source>Move measurement up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Move measurement down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Calculated value:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Full name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+412"/>
         <source>Information</source>
         <translation>信息</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Type:</source>
         <translation>类型:</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Measurement type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Show in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Base size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Base height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Base height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Given name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Family name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Birth date:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Email:</source>
         <translation>邮箱:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Notes:</source>
         <translation>备注:</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location line="-1170"/>
-        <location line="+1178"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+488"/>
         <source>Measurements</source>
         <translation>尺寸</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Gradation</source>
         <translation>退吗</translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Open individual ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+2067"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Save As ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>About SeamlyMe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>New</source>
         <translation>新</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Add known</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Add custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Database</source>
         <translation>资料库</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show information about all known measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1299"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1620"/>
         <source>untitled %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1219"/>
-        <location line="+1656"/>
         <source>This file already opened in another window.</source>
         <translation>这个文件已经在别的窗李打开的.</translation>
     </message>
     <message>
-        <location line="-2959"/>
-        <location line="+1318"/>
-        <location line="+1509"/>
         <source>File error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1997"/>
         <source>Could not save file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2103"/>
         <source>&amp;New Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1715"/>
         <source>Edit measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+430"/>
-        <location line="+982"/>
-        <location line="+24"/>
-        <location line="+13"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location line="-1019"/>
-        <location line="+982"/>
         <source>Empty field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+1"/>
         <source>Parser error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2524"/>
-        <location line="+60"/>
-        <location line="+157"/>
-        <location line="+401"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+1232"/>
         <source>Individual measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+217"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Measurements have been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+388"/>
         <source>Empty field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Open file</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+14"/>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1336"/>
         <source>Import from a pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-960"/>
-        <location line="+2693"/>
         <source>Pattern unit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1474"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Find Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+Shift+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Find Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2212"/>
         <source>Failed to lock. This file already opened in another window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-844"/>
-        <location line="+2826"/>
         <source>File contains invalid known measurement(s).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2849"/>
-        <location line="+2830"/>
         <source>File has unknown format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+38"/>
         <source>Full name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2873"/>
-        <location line="+2830"/>
         <source>File &apos;%1&apos; doesn&apos;t exist!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1166"/>
         <source>The name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-404"/>
-        <location line="+370"/>
-        <location line="+80"/>
-        <location line="+160"/>
         <source>Can&apos;t find measurement &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>The full name of known measurement forbidden to change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+354"/>
         <source>Function Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-316"/>
         <source>Move measurement top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Move measurement bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Delete measurement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1265"/>
         <source>unknown</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>male</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>female</source>
         <comment>gender</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+797"/>
         <source>Gender:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-196"/>
         <source>PM system:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+674"/>
         <source>Create from existing ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Create from existing file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2891"/>
         <source>Select file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-253"/>
         <source>Measurement diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=\&quot;center\&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+1326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:340pt;&quot;&gt;?&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Unknown measurement&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+399"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+253"/>
         <source>File was not saved yet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1244"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Measurement&apos;s name in a formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Measurement&apos;s name in a formula.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Measurement&apos;s human-readable name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+56"/>
         <source>Save...</source>
         <translation>保存...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Don&apos;t Save</source>
         <translation>不保存</translation>
     </message>
     <message>
-        <location line="+722"/>
-        <location line="+6"/>
-        <location line="+7"/>
         <source>Locking file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>The lock file could not be created, for lack of permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+1177"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-3146"/>
         <source>Show in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-591"/>
         <source>Customer&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Customer&apos;s family name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
         <source>Customer&apos;s email address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+485"/>
-        <location line="+1643"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1642"/>
-        <location line="+1648"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1859"/>
-        <location line="+26"/>
-        <location line="+15"/>
         <source>All files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+497"/>
         <source>The measurements document has no write permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Cannot set permissions for %1 to writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Could not save the file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1858"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2411"/>
-        <location line="+180"/>
-        <location line="+418"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+1172"/>
         <source>Multisize measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+684"/>
         <source>Invalid result. Value is infinite or NaN. Please, check your calculations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-461"/>
         <source>Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+361"/>
         <source>Open multisize ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+637"/>
         <source>Export from multisize measurements is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-146"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Ctrl+,</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-1930"/>
         <source>Failed to lock. This file already opened in another window. Expect collisions when running 2 copies of the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="+9"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1446"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1419"/>
         <source>Ctrl+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-368"/>
         <source>untitled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-1516"/>
         <source>Copy to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1448"/>
         <source>Open template ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ctrl+Alt+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="+802"/>
         <source>Pattern files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1640"/>
         <source>This file already opened in another window. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The lock file could not be created, for lack of permissions. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown error happened, for instance a full partition prevented writing out the lock file. Ignore if you want to continue (not recommended, can cause a data corruption).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.ui" line="-325"/>
         <source>Import body scan as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+422"/>
         <source>3D Measure Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>3D Look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamlyme/tmainwindow.cpp" line="-2717"/>
         <source>To utilize a 3DLook body scan the file needs to be converted to SeamlyME format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Attach your 3DLook file to an email and send to convert@seamly.io.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You will recieve an email with the converted file, which you can then
 load in SeamlyME as usual.
 
@@ -15377,7 +11885,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Convert 3DLook file:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15385,22 +11892,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceInLayout</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/togglepieceinlayout.cpp" line="+79"/>
         <source>Piece in Layout List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>Include piece in layout changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Include</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15408,22 +11911,18 @@ load in SeamlyME as usual.
 <context>
     <name>TogglePieceLock</name>
     <message>
-        <location filename="../../src/libs/vtools/undocommands/toggle_piecelock.cpp" line="+50"/>
         <source>Pattern piece lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
         <source>Piece lock changed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Unlocked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15431,47 +11930,38 @@ load in SeamlyME as usual.
 <context>
     <name>Tool</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+647"/>
         <source>First point</source>
         <translation type="unfinished">第一点</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Second point</source>
         <translation type="unfinished">第二点</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Highest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lowest point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Leftmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Rightmost point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Vertical axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Horizontal axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15479,47 +11969,38 @@ load in SeamlyME as usual.
 <context>
     <name>UnionDialog</name>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.ui" line="+17"/>
         <source>Union tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Do you really want to unite details?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Retain original pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/union_dialog.cpp" line="+177"/>
         <source>Select the first point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Pattern piece should have at least two points and three objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select a second point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Select a unique point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Select a piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select a point on edge</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15527,7 +12008,6 @@ load in SeamlyME as usual.
 <context>
     <name>UnionTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/union_tool.cpp" line="+200"/>
         <source>union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15535,17 +12015,14 @@ load in SeamlyME as usual.
 <context>
     <name>Utils::CheckableMessageBox</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/checkablemessagebox.cpp" line="+77"/>
         <source>Do not ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+371"/>
         <source>Do not &amp;ask again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Do not &amp;show again</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15553,57 +12030,46 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractConverter</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/abstract_converter.cpp" line="+132"/>
         <source>Couldn&apos;t get version information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Too many tags &lt;%1&gt; in file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Version &quot;%1&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Version &quot;0.0.0&quot; invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Invalid version. Minimum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Invalid version. Maximum supported version is %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error no unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Could not change version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Error creating a reserv copy: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Unexpected version &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-204"/>
         <source>Error Opening a temp file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15611,7 +12077,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vabstractcubicbezierpath.cpp" line="+194"/>
         <source>Can&apos;t cut this spline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15619,22 +12084,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractMainWindow</name>
     <message>
-        <location filename="../../src/libs/vwidgets/vabstractmainwindow.cpp" line="+78"/>
         <source>Confirm format rewriting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This file is using previous format version v%1. The current is v%2. Saving the file with this app version will update the format version for this file. This may prevent you from be able to open the file with older app versions. Do you really want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Comma-Separated Values</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export to CSV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15642,13 +12103,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractOperation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp" line="+754"/>
-        <location line="+14"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
@@ -15656,23 +12114,18 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPattern</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vabstractpattern.cpp" line="+862"/>
         <source>Can&apos;t find tool in table.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+487"/>
         <source>Error creating or updating group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+290"/>
         <source>New group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-209"/>
         <source>New group 2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15680,7 +12133,6 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractPieceData</name>
     <message>
-        <location filename="../../src/libs/vlayout/vabstractpiece_p.h" line="+70"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15688,12 +12140,10 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp" line="+203"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15701,283 +12151,226 @@ load in SeamlyME as usual.
 <context>
     <name>VAbstractTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/vabstracttool.cpp" line="+304"/>
         <source>Confirm deletion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-89"/>
         <source>Edit wrong formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Light Salmon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Goldenrod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Dark Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Medium Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Deep Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Corn Flower Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Gold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Forest Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lawn Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lime Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Green Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sandy Brown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Orange Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maroon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Hot Pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Blue Violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Violet Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Indigo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Plum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Medium Turquoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Powder Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Sky Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Navy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Magenta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+5"/>
         <source>Dark Slate Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gainsboro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Sea Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Light Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Light Steel Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Biege</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Silver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White Smoke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Grey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cadet Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dark Khaki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Tan</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15985,302 +12378,242 @@ load in SeamlyME as usual.
 <context>
     <name>VCommandLine</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vcmdexport.cpp" line="+96"/>
         <source>Path to custom measure file (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The measure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Format number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Template number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The page width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The measure unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Auto crop unused length (export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Layout units (as paper&apos;s one except px, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>The gap width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Grouping type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Cannot use pageformat and page explicit size/units together.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height, width, units must be used all 3 at once.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>Invalid rotation value. That must be one of predefined values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unknown page templated selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Unsupported paper units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Unsupported layout units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Export options can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-18"/>
         <source>Test option can be used with single input file only.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-439"/>
         <source>The base filename of exported layout files. Use it to enable console export mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The base filename of layout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The size value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The height value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Page width in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Page height in current units like 12.0 (cannot be used with &quot;%1&quot;, export mode).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+536"/>
         <source>Invalid gradation size value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Invalid gradation height value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-655"/>
         <source>Pattern making program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pattern file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+279"/>
         <source>Gap width must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Left margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Right margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Top margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Bottom margin must be used together with page units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-289"/>
         <source>The path to output destination folder. By default the directory at which the application was started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
         <source>Page height/width measure units (cannot be used with &quot;%1&quot;, export mode). Valid values: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Ignore margins printing (export mode). Disable value keys: &quot;%1&quot;, &quot;%2&quot;, &quot;%3&quot;, &quot;%4&quot;. Set all margins to 0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Page left margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page right margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page top margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Page bottom margin in current units like 3.0 (export mode). If not set will be used value from default printer. Or 0 if none printers was found. Value will be ignored if key &quot;%1&quot; is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation in degrees (one of predefined, export mode). Default value is 180. 0 is no-rotate. Valid values: %1. Each value show how many times details will be rotated. For example 180 mean two times (360/180=2) by 180 degree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Unite pages if possible (export mode). Maximum value limited by QImage that supports only a maximum of 32768x32768 px images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Save length of the sheet if set (export mode). The option tells the program to use as much as possible width of sheet. Quality of a layout can be worse when this option was used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>The layout gap width x2, measured in layout units (export mode). Set distance between details and a detail and a sheet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sets layout groupping cases (export mode): %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Run the program in a test mode. The program in this mode loads a single pattern file and silently quit without showing the main window. The key have priority before key &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Shift/Offset layout length measured in layout units (export mode). The option show how many points along edge will be used in creating a layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shift/Offset length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Shift/Offset length must be used together with shift units.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-217"/>
         <source>Number corresponding to output format (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>Number corresponding to page template (default = 0, export mode):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+134"/>
         <source>Disable high dpi scaling. Call this option if has problem with scaling (by default scaling enabled). Alternatively you can use the %1 environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-165"/>
         <source>Export dxf in binary form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export text as paths.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Export only details. Export details as they positioned in the details mode. Any layout related options will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set size value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Set height value a pattern file, that was opened with multisize measurements (export mode). Valid values: %1cm.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16288,43 +12621,34 @@ load in SeamlyME as usual.
 <context>
     <name>VCommonSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vcommonsettings.cpp" line="+415"/>
-        <location line="+21"/>
         <source>measurements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>individual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>multisize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>label templates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>backups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>bodyscans</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16332,55 +12656,42 @@ load in SeamlyME as usual.
 <context>
     <name>VContainer</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="+407"/>
-        <location line="+65"/>
         <source>Can&apos;t find object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
-        <location line="+40"/>
-        <location line="+153"/>
         <source>Can&apos;t cast object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>Can&apos;t find object. Type mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.cpp" line="+417"/>
         <source>Number of free id exhausted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+264"/>
         <source>Can&apos;t create a curve with type &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-424"/>
         <source>Can&apos;t find object: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find piece: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Can&apos;t find path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vcontainer.h" line="-116"/>
         <source>Can&apos;t find object Id: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>Can&apos;t cast object.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16388,12 +12699,10 @@ load in SeamlyME as usual.
 <context>
     <name>VCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vcubicbezierpath.cpp" line="+208"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16401,50 +12710,40 @@ load in SeamlyME as usual.
 <context>
     <name>VDomDocument</name>
     <message>
-        <location filename="../../src/libs/ifc/xml/vdomdocument.cpp" line="+108"/>
-        <location line="+60"/>
         <source>Can&apos;t open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Can&apos;t open schema file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Validation error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Parsing error file %3 in line %1 column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+156"/>
         <source>Couldn&apos;t get node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-255"/>
         <source>This id is not unique.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Could not load schema file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-328"/>
         <source>Fail to write Canonical XML.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+625"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16452,27 +12751,22 @@ load in SeamlyME as usual.
 <context>
     <name>VDrawTool</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vdrawtool.h" line="+211"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Add Group Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16480,7 +12774,6 @@ load in SeamlyME as usual.
 <context>
     <name>VException</name>
     <message>
-        <location filename="../../src/libs/ifc/exception/vexception.cpp" line="+101"/>
         <source>Exception: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16488,11 +12781,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormula</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vformula.cpp" line="+72"/>
-        <location line="+7"/>
-        <location line="+180"/>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
@@ -16500,7 +12788,6 @@ load in SeamlyME as usual.
 <context>
     <name>VFormulaProperty</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vformulaproperty.cpp" line="+67"/>
         <source>Formula:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16508,7 +12795,6 @@ load in SeamlyME as usual.
 <context>
     <name>VLayoutPiece</name>
     <message>
-        <location filename="../../src/libs/vlayout/vlayoutpiece.cpp" line="+436"/>
         <source>Piece %1 doesn&apos;t have shape.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16516,7 +12802,6 @@ load in SeamlyME as usual.
 <context>
     <name>VNodePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/nodeDetails/vnodepoint.cpp" line="+333"/>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16524,12 +12809,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VBoolProperty</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vboolproperty.cpp" line="+41"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16537,12 +12820,10 @@ load in SeamlyME as usual.
 <context>
     <name>VPE::VFileEditWidget</name>
     <message>
-        <location filename="../../src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.cpp" line="+114"/>
         <source>Directory</source>
         <translation>文件夹</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open File</source>
         <translation>打开文件</translation>
     </message>
@@ -16550,335 +12831,246 @@ load in SeamlyME as usual.
 <context>
     <name>VPattern</name>
     <message>
-        <location filename="../../src/app/seamly2d/xml/vpattern.cpp" line="+470"/>
-        <location line="+28"/>
-        <location line="+50"/>
-        <location line="+44"/>
         <source>Error parsing file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-115"/>
-        <location line="+82"/>
         <source>Error can&apos;t convert value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
-        <location line="+86"/>
         <source>Error empty parameter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
-        <location line="+90"/>
         <source>Error wrong id.</source>
         <translation>错误:编码错误.</translation>
     </message>
     <message>
-        <location line="-76"/>
-        <location line="+98"/>
         <source>Error parsing file (std::bad_alloc).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+699"/>
         <source>Error creating or updating single point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
-        <location line="+6"/>
         <source>Error creating or updating point of end line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+6"/>
         <source>Error creating or updating point along line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of shoulder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Error creating or updating point of bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
-        <location line="+6"/>
         <source>Error creating or updating point of contact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Error creating or updating modeling point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
         <source>Error creating or updating height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Error creating or updating triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+6"/>
         <source>Error creating or updating cut spline path point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+6"/>
         <source>Error creating or updating cut arc point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection line and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+7"/>
         <source>Error creating or updating point of intersection curve and axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-834"/>
         <source>Error creating or updating line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1106"/>
-        <location line="+60"/>
         <source>Error creating or updating simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+113"/>
-        <location line="+88"/>
         <source>Error creating or updating curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+109"/>
         <source>Error creating or updating modeling simple curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating modeling curve path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
-        <location line="+6"/>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Error creating or updating simple arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-49"/>
         <source>Error creating or updating modeling arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-826"/>
         <source>Error creating or updating point of intersection arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Error creating or updating point of intersection circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+74"/>
         <source>Error creating or updating point from circle and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Error creating or updating point from arc and tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Error creating or updating true darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1569"/>
-        <location line="+43"/>
-        <location line="+79"/>
         <source>Wrong tag name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+352"/>
         <source>Unknown point type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2092"/>
         <source>Unknown spline type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Unknown arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Unknown tools type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2936"/>
         <source>Error not unique id.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1703"/>
         <source>Error creating or updating point of intersection curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+228"/>
         <source>Error creating or updating simple interactive spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+201"/>
         <source>Error creating or updating interactive spline path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-156"/>
         <source>Error creating or updating cubic bezier curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
         <source>Error creating or updating cubic bezier path curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+350"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+424"/>
         <source>Unknown operation type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-318"/>
-        <location line="+6"/>
         <source>Error creating or updating operation of moving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1497"/>
         <source>Error creating or updating point of line intersection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1217"/>
-        <location line="+6"/>
         <source>Error creating or updating simple elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+505"/>
         <source>Unknown elliptical arc type &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-470"/>
         <source>Error creating or updating modeling elliptical arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+565"/>
         <source>Unnamed path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Error creating or updating a piece path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1740"/>
         <source>Error creating or updating anchor point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Error creating or updating Intersect XY tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1212"/>
         <source>Error creating or updating operation of mirror by line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Error creating or updating operation of mirror by axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2209"/>
         <source>Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>nobrush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Error creating or updating piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2448"/>
         <source>Error creating or updating union pieces</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16886,17 +13078,14 @@ load in SeamlyME as usual.
 <context>
     <name>VPoster</name>
     <message>
-        <location filename="../../src/libs/vlayout/vposter.cpp" line="+170"/>
         <source>Grid ( %1 , %2 )</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Sheet %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16904,12 +13093,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSettings</name>
     <message>
-        <location filename="../../src/libs/vmisc/vsettings.cpp" line="+136"/>
         <source>patterns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>layouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16917,14 +13104,10 @@ load in SeamlyME as usual.
 <context>
     <name>VSplinePath</name>
     <message>
-        <location filename="../../src/libs/vgeometry/vsplinepath.cpp" line="+255"/>
         <source>Not enough points to create the spline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+21"/>
-        <location line="+23"/>
         <source>This spline does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16932,17 +13115,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolAlongLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp" line="+210"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16950,27 +13130,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp" line="+457"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16978,37 +13153,30 @@ load in SeamlyME as usual.
 <context>
     <name>VToolArcWithLength</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp" line="+415"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>     Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17016,7 +13184,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolBasePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp" line="+404"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17024,12 +13191,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp" line="+171"/>
         <source>&lt;b&gt;&lt;big&gt;Can not create intersection point %1 from point %2&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;to curve %3 with an axis angle of %4°&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Intersection Point of Curve &amp; Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17037,32 +13202,26 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp" line="+290"/>
         <source>Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>end angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17070,18 +13229,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp" line="+296"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17089,18 +13244,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolCutSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp" line="+382"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+2"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17108,7 +13259,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolDoublePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp" line="+456"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17116,28 +13266,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolEllipticalArc</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp" line="+509"/>
         <source>Start angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>     Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>    Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>  End angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>      Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17145,17 +13289,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolHeight</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp" line="+347"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17163,12 +13304,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/vtoolline.cpp" line="+480"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17176,7 +13315,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersect</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp" line="+375"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17184,27 +13322,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp" line="+409"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-254"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;Line and Axis&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17212,17 +13345,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolLinePoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.cpp" line="+196"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17230,7 +13360,6 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp" line="+278"/>
         <source>Origin point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17238,12 +13367,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMirrorByLine</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp" line="+283"/>
         <source>First line point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Second line point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17251,27 +13378,22 @@ load in SeamlyME as usual.
 <context>
     <name>VToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp" line="+471"/>
         <source>Center point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17279,714 +13401,398 @@ load in SeamlyME as usual.
 <context>
     <name>VToolOptionsPropertyBrowser</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/vtooloptionspropertybrowser.cpp" line="+1763"/>
         <source>Base point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>True darts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+170"/>
         <source>Base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-167"/>
-        <location line="+22"/>
-        <location line="+44"/>
-        <location line="+22"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+147"/>
-        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">长度:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+507"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
         <source>Angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-547"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">第一点:</translation>
     </message>
     <message>
-        <location line="-485"/>
-        <location line="+65"/>
-        <location line="+103"/>
-        <location line="+19"/>
-        <location line="+3"/>
-        <location line="+16"/>
-        <location line="+42"/>
-        <location line="+99"/>
-        <location line="+25"/>
-        <location line="+45"/>
-        <location line="+55"/>
-        <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">第二点:</translation>
     </message>
     <message>
-        <location line="-466"/>
-        <location line="+22"/>
-        <location line="+273"/>
-        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">中点:</translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+190"/>
-        <location line="+49"/>
-        <location line="+4"/>
-        <location line="+303"/>
-        <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">半径:</translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+22"/>
-        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-568"/>
-        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Color:</source>
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-532"/>
-        <location line="+282"/>
-        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Point 2 label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second base point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>First dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+230"/>
         <source>Arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-215"/>
-        <location line="+15"/>
-        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-359"/>
-        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-410"/>
-        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>First arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+12"/>
-        <location line="+41"/>
-        <location line="+14"/>
         <source>Take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>First curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Second curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+16"/>
         <source>Tangent point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Circle radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+39"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+37"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+82"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
-        <location line="+22"/>
-        <location line="+68"/>
         <source>Axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-46"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+13"/>
         <source>Suffix:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Axis type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+47"/>
         <source>Rotation angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-176"/>
         <source>Fourth point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-433"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Linetype:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rotation point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Mirror by Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Mirror by Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+15"/>
-        <location line="+21"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+19"/>
-        <location line="+18"/>
-        <location line="+17"/>
-        <location line="+28"/>
-        <location line="+17"/>
-        <location line="+18"/>
-        <location line="+14"/>
-        <location line="+21"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+14"/>
-        <location line="+24"/>
-        <location line="+46"/>
-        <location line="+22"/>
-        <location line="+16"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+15"/>
-        <location line="+17"/>
-        <location line="+15"/>
-        <location line="+13"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Length and Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+22"/>
-        <location line="+24"/>
-        <location line="+37"/>
-        <location line="+15"/>
-        <location line="+15"/>
-        <location line="+68"/>
-        <location line="+31"/>
-        <location line="+47"/>
-        <location line="+37"/>
-        <location line="+32"/>
-        <location line="+24"/>
-        <location line="+114"/>
-        <location line="+22"/>
-        <location line="+20"/>
-        <location line="+15"/>
-        <location line="+45"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-606"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-610"/>
-        <location line="+21"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+22"/>
-        <location line="+81"/>
-        <location line="+18"/>
-        <location line="+45"/>
-        <location line="+35"/>
-        <location line="+103"/>
-        <location line="+47"/>
-        <location line="+21"/>
-        <location line="+17"/>
-        <location line="+16"/>
-        <location line="+37"/>
-        <location line="+22"/>
-        <location line="+84"/>
         <source>Lineweight:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Arc - Radius and Angles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Arc - Radius and Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - On Bisector</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Second dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Third dart point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - On Arc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - On Spline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Line and Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Line</source>
         <translation type="unfinished">线</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>First line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Second line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - On Perpendicular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Rotation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Point - Intersect Arc and Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>1st line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Point - Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Intersect Circles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>First circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>Center:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Second circle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Vertical take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Horizontal take:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Point - Intersect Circle and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Point - Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Point - Length to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Curve - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Spline - Interactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Spline - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Point - Intersect Axis and Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>1st axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>2nd axis point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Point - Intersect Line and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Point - Intersect Curve and Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>Origin point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Arc - Elliptical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-565"/>
-        <location line="+22"/>
-        <location line="+546"/>
-        <location line="+102"/>
-        <location line="+41"/>
-        <location line="+895"/>
         <source>Arc_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1256"/>
-        <location line="+46"/>
-        <location line="+866"/>
-        <location line="+67"/>
         <source>Spl_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-911"/>
-        <location line="+16"/>
         <source>SplPath_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+493"/>
         <source>Line_</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17994,12 +13800,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointFromArcAndTangent</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;big&gt;%2 and Tangent&lt;/big&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Intersect Arc and Tangent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18007,17 +13811,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfContact</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp" line="+412"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18025,12 +13826,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionArcs</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp" line="+149"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Arcs&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Arcs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18038,12 +13837,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolPointOfIntersectionCurves</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp" line="+154"/>
         <source>&lt;b&gt;&lt;big&gt;Can&apos;t find intersection point %1 of Curves&lt;/big&gt;&lt;/b&gt;&lt;br&gt;Using origin point as a place holder until pattern is corrected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Point Intersect Curves</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18051,12 +13848,10 @@ load in SeamlyME as usual.
 <context>
     <name>VToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp" line="+395"/>
         <source>  Origin point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Rotation angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18064,17 +13859,14 @@ load in SeamlyME as usual.
 <context>
     <name>VToolShoulderPoint</name>
     <message>
-        <location filename="../../src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp" line="+404"/>
         <source>Length</source>
         <translation type="unfinished">长度</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18082,1552 +13874,1295 @@ load in SeamlyME as usual.
 <context>
     <name>VTranslateVars</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatevars.cpp" line="+107"/>
         <source>Bunka</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bunka Fashion College</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fundamentals of Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Barnfield and Richard</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jo Barnfield and Andrew Richards</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Making Primer</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Friendship/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+236"/>
         <source>Elizabeth Friendship</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-235"/>
         <source>Creating Historical Clothes - Pattern Cutting from the 16th to the 19th Centuries</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Morris, K.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karen Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sewing Lingerie that Fits</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Castro</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lucia Mors de Castro</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking in Practic</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kim &amp; Uh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Injoo Kim and Mykyung Uh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Apparel Making in Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Waugh</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Norah Waugh</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corsets and Crinolines</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Grimble</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frances Grimble</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fashions of the Gilded Age</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Thornton&apos;s International System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+237"/>
         <source>ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-236"/>
-        <location line="+237"/>
         <source>The Great War: Styles and Patterns of the 1910s</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-234"/>
         <source>Hillhouse &amp; Mansfield</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Marion S. Hillhouse and Evelyn A. Mansfield</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Design: Draping and Flat Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Pivnick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Esther Kaplan Pivnick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Design Beautiful Clothes: Designing and Pattern Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Minister &amp; Son</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edward Minister &amp; Son, ed. R. L. Shep</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Complete Guide to Practical Cutting (1853)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Strickland</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Strickland</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A Tailoring Manual</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Loh &amp; Lewis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>May Loh and Diehl Lewis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternless Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Morris, F. R.</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>F. R. Morris</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ladies Garment Cutting and Making</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mason</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gertrude Mason&apos;s Patternmaking Book</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kimata</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K. Kimata</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>K.Kimata&apos;s Simplified Drafting Book for Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Master Designer</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Master Designer (Chicago, IL)</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Master Designer&apos;s System of Designing, Cutting and Grading</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kopp</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ernestine Kopp, Vittorina Rolfo, Beatrice Zelin, Lee Gross</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Draft Basic Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ekern</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Doris Ekern</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Slacks Cut-to-Fit for Your Figure</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Doyle</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah J. Doyle</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sarah&apos;s Key to Pattern Drafting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Shelton</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Karla J. Shelton</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Design and Sew Jeans</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lady Boutique</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lady Boutique magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Rohr</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>M. Rohr</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting and Grading: Women&apos;s nd Misses&apos; Garment Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Moore</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dorothy Moore&apos;s Pattern Drafting and Dressmaking</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Abling</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bina Abling</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Integrating Draping, Drafting and Drawing</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Fukomoto</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sue S. Fukomoto</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Scientific Pattern Drafting as taught at Style Center School of Costume Design, Dressmaking and Millinery</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Dressmaking International</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking International magazine (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Erwin</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mabel D. Erwin</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Practical Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gough</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>E. L. G. Gough</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Principles of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Allemong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Elizabeth M. Allemong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>European Cut</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>McCunn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Donald H. McCunn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>How to Make Your Own Sewing Patterns</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Zarapkar</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shri K. R. Zarapkar and Shri Arvind K. Zarapkar</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Zarapkar System of Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kunick</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Philip Kunick</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Sizing, Pattern Construction and Grading for Women&apos;s and Children&apos;s Garments</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Handford</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jack Handford</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Professional Patternmaking for Designers: Women&apos;s Wear, Men&apos;s Casual Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Davis</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>R. I. Davis</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Men&apos;s 17th &amp; 18th Century Costume, Cut &amp; Fashion</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>MacLochlainn</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jason MacLochlainn</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Victorian Tailor: An Introduction to Period Tailoring</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Joseph-Armstrong</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Helen Joseph-Armstrong</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Fashion Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Supreme System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Frederick T. Croonberg</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Blue Book of Men&apos;s Tailoring, Grand Edition of Supreme System for Producing Mens Garments (1907)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Sugino</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dressmaking</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Drafting Vols. I, II, III (Japan)</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Centre Point System</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Louis Devere</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The Handbook of Practical Cutting on the Centre Point System</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>Winifred Aldrich</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Metric Pattern Cutting for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Aldrich/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Metric Pattern Cutting for Women&apos;s Wear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Kershaw</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Gareth Kershaw</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Patternmaking for Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Gilewska</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Teresa Gilewska</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern-Drafting for Fashion: The Basics</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Lo</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dennic Chunman Lo</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bray</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Natalie Bray</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Dress Pattern Designing: The Basic Principles of Cut and Fit</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+32"/>
         <source>Lori A. Knowles</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>The Practical Guide to Patternmaking for Fashion Designers: Menswear</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Friendship/Men</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Pattern Cutting for Men&apos;s Costume</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Brown</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>P. Clement Brown</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Art in Dress</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Mitchell</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Jno. J. Mitchell</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&quot;Standard&quot; Work on Cutting (Men&apos;s Garments) 1886: The Art and Science of Garment Cutting</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>GOST 17917-86</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ministry of consumer industry of the USSR</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Standard figure boys</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Eddy</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Josephine F. Eddy and Elizabeth C. B. Wiley</source>
         <comment>Author name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pattern and Dress Design</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Knowles/Women</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Practical Guide to Patternmaking for Fashion Designers: Juniors, Misses, and Women</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>American Garment Cutter</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>None</source>
         <comment>System name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D team</source>
         <comment>Author name</comment>
         <translation>Seamly2D团队</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Seamly2D&apos;s internal standard</source>
         <comment>Book name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>cm</source>
         <comment>centimeter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mm</source>
         <comment>millimeter</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>in</source>
         <comment>inch</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Angle1SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Angle2SplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Seg_</source>
         <comment>Segment. Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>size</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>height</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>C1LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>C2LengthSplPath</source>
         <comment>Do not add symbol _ to the end of the name</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>CurrentSeamAllowance</source>
         <comment>Do not add space between words</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
         <source>date</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>time</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>patternNumber</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>author</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>customer</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFileName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mExt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pLetter</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pAnnotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pOrientation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pRotation</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pTilt</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pFoldPosition</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pName</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>pQuantity</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mFabric</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mLining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterfacing</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>mInterlining</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wCut</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wOnFold</source>
         <comment>placeholder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
         <source>degTorad</source>
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(angle θ in radians)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log10</source>
         <comment>Logarithm to the base 10
 Usage: log10(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>exp</source>
         <comment>E raised to the power of x
 Usage: exp(x) where e = 2.718</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(float x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-69"/>
         <source>M_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Variable_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Line_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RadiusArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Radius2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Arc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle1Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Angle2Spl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>C1LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>C2LengthSpl_</source>
         <comment>Leave the _ symbol in translation</comment>
         <translation type="unfinished"></translation>
@@ -19636,17 +15171,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCubicBezierPath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolcubicbezierpath.cpp" line="+308"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select more points for complete segment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select seven or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19654,7 +15186,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolCurveIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolcurveintersectaxis.cpp" line="+120"/>
         <source>&lt;b&gt;Intersection curve and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation </source>
         <translation type="unfinished"></translation>
     </message>
@@ -19662,7 +15193,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolEndLine</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoolendline.cpp" line="+105"/>
         <source>&lt;b&gt;Point Length and Angle&lt;/b&gt;: angle = %1°, length = %2%3; Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19670,7 +15200,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolLineIntersectAxis</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/vistoollineintersectaxis.cpp" line="+128"/>
         <source>&lt;b&gt;Intersection line and axis&lt;/b&gt;: angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19678,12 +15207,10 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolMove</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolmove.cpp" line="+212"/>
         <source>Length = %1%2, angle = %3°, &lt;b&gt;Shift&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish selecting a position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Length = %1%2, angle = %3°, rotation angle = %4° Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle,&lt;b&gt;CTRL&lt;/b&gt; - change rotation origin point, &lt;b&gt;Mouse click&lt;/b&gt; - finish creating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19691,7 +15218,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolRotation</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/line/operation/vistoolrotation.cpp" line="+145"/>
         <source>Rotating angle = %1°, Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle, &lt;b&gt;Mouse click&lt;/b&gt; - finish creation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19699,7 +15225,6 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSpline</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolspline.cpp" line="+193"/>
         <source>Hold &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19707,17 +15232,14 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>VisToolSplinePath</name>
     <message>
-        <location filename="../../src/libs/vtools/visualization/path/vistoolsplinepath.cpp" line="+135"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;b&gt;Curved path&lt;/b&gt;: select three or more points, Press &lt;b&gt;ENTER&lt;/b&gt; to finish tool creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Use &lt;b&gt;SHIFT&lt;/b&gt; to constrain angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19725,47 +15247,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>mNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamlyme/application_me.cpp" line="-408"/>
         <source>DEBUG:</source>
         <translation>BUG:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>WARNING:</source>
         <translation>警告:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>INFO:</source>
         <translation>信息:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Information</source>
         <translation type="unfinished">信息</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19773,47 +15286,38 @@ Usage: fmod(x; y)</comment>
 <context>
     <name>vNoisyHandler</name>
     <message>
-        <location filename="../../src/app/seamly2d/core/application_2d.cpp" line="-239"/>
         <source>DEBUG:</source>
         <translation>BUG:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>WARNING:</source>
         <translation>警告:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>CRITICAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>FATAL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>INFO:</source>
         <translation>信息:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Critical Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Fatal Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Information</source>
         <translation type="unfinished">信息</translation>
     </message>


### PR DESCRIPTION
This removes the location tags from the translation (ts) files to avoid resolving excessive conflicts when merging develop back into a local feature branch. 

This closes issue #1140 